### PR TITLE
Fix handling of touchmove events on Android

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -943,7 +943,7 @@
         if( event.touches.length === 1 &&
             event.targetTouches.length === 1 && 
             event.changedTouches.length === 1 && 
-            THIS[ tracker.hash ].lastTouch === event.touches[ 0 ]){
+            THIS[ tracker.hash ].lastTouch.identifier === event.touches[ 0 ].identifier){
 
             onMouseMove( tracker, event.touches[ 0 ] );
 


### PR DESCRIPTION
Dragging the canvas did not work on Android devices as the === check for
lastTouch and the current event was always evaluating to false.
Presumably Safari on iOS re-uses the same Touch object for touchmove
events with the same finger, whereas Chrome/Firefox on Android creates
new Touch objects for each event (so the === evaluates false). The code
now compares Touch.identifier to ensure the new touch event is from the
same finger as the initiating touchstart.
