### PR TITLE
Update qunit version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "grunt-contrib-concat": "~0.1.2",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-uglify": "~0.1.1",
-    "grunt-contrib-qunit": "~0.1.1",
+    "grunt-contrib-qunit": "~0.2.0",
     "grunt-contrib-connect": "~0.1.2",
     "grunt-contrib-watch": "~0.2.0",
     "grunt-contrib-clean": "~0.4.0",


### PR DESCRIPTION
qunit 0.1.1 fails on node v0.10.1 with the new streaming API
