### PR TITLE
DziTileSource: avoid changing relative paths

### DIFF
--- a/src/dzitilesource.js
+++ b/src/dzitilesource.js
@@ -108,19 +108,8 @@ $.extend( $.DziTileSource.prototype, $.TileSource.prototype, {
             options = configureFromObject( this, data );
         }
 
-        if( url && !options.tilesUrl ){
-            if( 'http' !== url.substring( 0, 4 ) ){
-                host = location.protocol + '//' + location.host;
-            }
-            dziPath = url.split('/');
-            dziName = dziPath.pop();
-            dziName = dziName.substring(0, dziName.lastIndexOf('.'));
-            dziPath = '/' + dziPath.join('/') + '/' + dziName + '_files/';
-            tilesUrl = dziPath;
-            if( host ){
-                tilesUrl = host + tilesUrl;
-            }
-            options.tilesUrl = tilesUrl;
+        if (url && !options.tilesUrl) {
+            options.tilesUrl = url.replace(/([^\/]+)\.dzi$/, '$1_files/');
         }
 
         return options;


### PR DESCRIPTION
For cases where DZI files aren't explicitly configured with a tilesUrl,
the logic for generating a URL from the DZI source URL would inject an
extra leading `/` which would either cause an unnecessary redirect or
break depending on whether the webserver in use attempts to normalize
`//` to `/`.

This change also removes some URL processing logic which duplicates the browser's default behaviour
