### PR TITLE
Paranoid requestAnimationFrame for antique Firefox

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1662,7 +1662,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
 
 
         // polyfill, when necessary
-        if ( w.requestAnimationFrame ) {
+        if ( w.requestAnimationFrame && w.cancelAnimationFrame ) {
             //we cant assign window.requestAnimationFrame directly to $.requestAnimationFrame
             //without getting Illegal Invocation errors in webkit so call in a
             //wrapper


### PR DESCRIPTION
Very old versions of Firefox - e.g. Firefox 7 - have window.requestAnimationFrame but not cancelAnimationFrame. This is a very old release so the easiest fix is simply to check for both of the functions which we intend to call and fall back on traditional behaviour if both aren't present.
