### PR TITLE
Fixed blendTile()-related blurriness issue (for #95)

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -709,8 +709,7 @@ function updateTile( drawer, drawLevel, haveDrawn, x, y, level, levelOpacity, le
     );
 
     if ( tile.loaded ) {
-        
-        drawer.updateAgain = blendTile(
+        var needsUpdate = blendTile(
             drawer,
             tile, 
             x, y,
@@ -718,6 +717,10 @@ function updateTile( drawer, drawLevel, haveDrawn, x, y, level, levelOpacity, le
             levelOpacity, 
             currentTime 
         );
+
+        if ( needsUpdate ) {
+            drawer.updateAgain = true;
+        }
     } else if ( tile.loading ) {
         // the tile is already in the download queue 
         // thanks josh1093 for finally translating this typo


### PR DESCRIPTION
We were setting drawer.updateAgain to the result of each blendTile(),
which meant it was keeping only the last result. Instead we should have
been only setting it to true if blendTile returned true, but never
setting it to false. Fixed.
