### PR TITLE
Fix for issue #109 - Viewport blank after jQuery hide.

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -577,6 +577,7 @@ $.Viewport.prototype = {
      */
     resize: function( newContainerSize, maintain ) {
         //Set current size to 1 if 0 (hidden div)
+        var currentsize = this.containerSize.x === 0 ? 1 : this.containerSize.x;
 
         var oldBounds = this.getBounds(),
             newBounds = oldBounds,


### PR DESCRIPTION
Hiding the container div was breaking the viewport. This patch fixes
that by defaulting to the home view when hidden. (Better fix would
maintain last position)

Issue: https://github.com/openseadragon/openseadragon/issues/109
