### PR TITLE
Don't load the tile source again when creating a navigator.

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1147,7 +1147,10 @@ function openTileSource( viewer, source ) {
             sizeRatio:   _this.navigatorSizeRatio,
             height:      _this.navigatorHeight,
             width:       _this.navigatorWidth,
-            tileSources: _this.tileSources,
+            // By passing the fully parsed source here, the navigator doesn't
+            // have to load it again. Additionally, we don't have to call
+            // navigator.open, as it's implicitly called in the ctor.
+            tileSources: source,
             tileHost:    _this.tileHost,
             prefixUrl:   _this.prefixUrl,
             overlays:    _this.overlays,
@@ -1211,10 +1214,6 @@ function openTileSource( viewer, source ) {
         }
     }
     VIEWERS[ _this.hash ] = _this;
-
-    if( _this.navigator ){
-        _this.navigator.open( source );
-    }
 
     _this.raiseEvent( 'open', { source: source, viewer: _this } );
 


### PR DESCRIPTION
Previously, when showNavigator was set to true when creating the viewer, the navigator would unnecessarily load and parse the tile source, even though a fully parsed object already exists.

PS: The README states the changelog should be updated in the corresponding pull request, but from the discussion in #90, it looks like you want to do this yourself to prevent merge conflicts. If that's correct, I guess the README should be updated.
