### PR TITLE
Improve performance of Tile#drawHTML.

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -110,9 +110,6 @@ $.Tile.prototype = {
      * @param {Element} container
      */
     drawHTML: function( container ) {
-
-        var containerSize = $.getElementSize( container );
-
         if ( !this.loaded || !this.image ) {
             $.console.warn(
                 "Attempting to draw tile %s when it's not yet loaded.",
@@ -121,29 +118,9 @@ $.Tile.prototype = {
             return;
         }
 
-        /* EXISTING IMPLEMENTATION
-        if ( !this.element ) {
-            this.element              = $.makeNeutralElement("img");
-            this.element.src          = this.url;
-
-            this.style                     = this.element.style;
-            this.style.position            = "absolute";
-            this.style.msInterpolationMode = "nearest-neighbor";
-        }
-
-        if ( this.element.parentNode != container ) {
-            container.appendChild( this.element );
-        }
-
-        this.style.top     = position.y + "px";
-        this.style.left    = position.x + "px";
-        this.style.height  = size.y + "px";
-        this.style.width   = size.x + "px";
-        */
-
         //EXPERIMENTAL - trying to figure out how to scale the container
         //               content during animation of the container size.
-        
+
         if ( !this.element ) {
             this.element              = $.makeNeutralElement("img");
             this.element.src          = this.url;
@@ -156,14 +133,12 @@ $.Tile.prototype = {
             container.appendChild( this.element );
         }
 
-        this.style.top     = 100 * ( this.position.y / containerSize.y ) + "%";
-        this.style.left    = 100 * ( this.position.x / containerSize.x ) + "%";
-        this.style.height  = 100 * ( this.size.y / containerSize.y ) + "%";
-        this.style.width   = 100 * ( this.size.x / containerSize.x ) + "%";
-        
+        this.style.top     = this.position.y + "px";
+        this.style.left    = this.position.x + "px";
+        this.style.height  = this.size.y + "px";
+        this.style.width   = this.size.x + "px";
+
         $.setElementOpacity( this.element, this.opacity );
-
-
     },
 
     /**


### PR DESCRIPTION
By specifying the tile size in absolute pixel values instead of percentages, we can save the call to $.getElementSize. When forcing OpenSeadragon to use the HTML path instead of canvas, this simple optimization reduce the total runtime by about 10% (tested in FF22).

Note that this essentially reverts parts of 6efc348b8aa63b6812e70bbd6338362fe6108c5c. I'm not sure why this change was added in that commit, but in my tests in FF22, Chrome 29 and IE10, I couldn't see any visual difference (and there shouldn't be any, as both ways of setting the position/size should be equivalent).
