### PR TITLE
Better fix for issue #109, viewport broken on hide. 

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -704,8 +704,9 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
             element = $.getElement( element );
 
             return new $.Point(
-                element.clientWidth, 
-                element.clientHeight
+              // By refusing to return 0 for either width or height, later operations do not resolve to NaN.
+                (element.clientWidth === 0 ? 1 : element.clientWidth),
+                (element.clientHeight === 0 ? 1 : element.clientHeight)
             );
         },
 


### PR DESCRIPTION
By refusing to return 0 for either width or height, later operations
do not resolve to NaN. This results in the viewport being functional after it has been hidden, and allows it to retain its pre-hidden state. 
