### PR TITLE
Only disable the previous button if the navPrevNextWrap option is not set

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -346,10 +346,6 @@ $.Viewer = function( options ) {
         beginControlsAutoHide( _this );
     } );    // initial fade out
 
-    if(this.navPrevNextWrap){
-        this.previousButton.enable();
-    }
-
 };
 
 $.extend( $.Viewer.prototype, $.EventHandler.prototype, $.ControlDock.prototype, {
@@ -855,7 +851,9 @@ $.extend( $.Viewer.prototype, $.EventHandler.prototype, $.ControlDock.prototype,
                 onBlur:     onBlurHandler
             });
 
-            this.previousButton.disable();
+            if( !this.navPrevNextWrap ){
+                this.previousButton.disable();
+            }
 
             if( useGroup ){
                 this.paging = new $.ButtonGroup({


### PR DESCRIPTION
This is a fix to the previously added navPrevNextWrap option. This fixes an error only seen when the option was set but only one tile source was loaded.
