### PR TITLE
Fix for calculating overlay width / height

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -713,8 +713,8 @@ $.Viewport.prototype = {
         return new $.Rect(
             coordA.x,
             coordA.y,
-            coordA.x + coordB.x,
-            coordA.y + coordB.y
+            coordB.x,
+            coordB.y
         );
     }
 };


### PR DESCRIPTION
When calculating the new width and height of an overlay, do not add the source coordinates to it.
