### PR TITLE
Safe cleanup in makeAjaxRequest error handler

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1335,6 +1335,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
             if ( options.async ) {
                 /** @ignore */
                 request.onreadystatechange = function() {
+                    // 4 = DONE (https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Properties)
                     if ( request.readyState == 4) {
                         request.onreadystatechange = function(){};
                         options.success( request );
@@ -1352,7 +1353,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
                     e.message
                 );
 
-                request.onreadystatechange = null;
+                request.onreadystatechange = function(){};
                 request = null;
 
                 if ( options.error && $.isFunction( options.error ) ) {


### PR DESCRIPTION
Previously `request.onreadystatechange` was assigned an empty function on
success but null on failures, which breaks in IE (see http://jsbin.com/ezozax/6/).

This patch simply mimics the success behaviour in the cleanup function

Closes #143
