### PR TITLE
Simplify OpenSeadragon.makeAjaxRequest

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1341,7 +1341,6 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
                 $.console.log("%s while making AJAX request: %s", e.name, e.message);
 
                 request.onreadystatechange = function(){};
-                request = null;
 
                 if ($.isFunction(onError)) {
                     onError( request, e );


### PR DESCRIPTION
- Since async is always true – and browsers are starting to deprecate
  synchronous XHR – we were able to prune considerable amount of code
- Add an error callback to match the existing success callback
- All AJAX errors will log to the console
- The onError callback will only be called if defined
