### PR TITLE
(hopefully) Final fix for issue #109, Viewport Broken on Hide.

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1109,17 +1109,19 @@ $.extend( $.Viewer.prototype, $.EventHandler.prototype, $.ControlDock.prototype,
 
 
 /**
- * [_getSafeElemSize returns getElementSize(), but refuses to return NaN]
- * @return {[NaN]}
+ * _getSafeElemSize returns getElementSize(), but refuses to return 0 for X or y,
+ * which was causing some calling operations in updateOnve and openTileSource to
+ * return NaN.
+ * @returns {point}
  * @private
  */
 function _getSafeElemSize (oElement) {
-        oElement = $.getElement( oElement );
+    oElement = $.getElement( oElement );
 
-        return new $.Point(
-                (oElement.clientWidth === 0 ? 1 : oElement.clientWidth),
-                (oElement.clientHeight === 0 ? 1 : oElement.clientHeight)
-                );
+    return new $.Point(
+        (oElement.clientWidth === 0 ? 1 : oElement.clientWidth),
+        (oElement.clientHeight === 0 ? 1 : oElement.clientHeight)
+    );
 }
 
 /**


### PR DESCRIPTION
This fix implements a private method, used by updateOnce and openTileSource in viewer.js, named _getSafeElemSize(), which refuses to return 0 for either x or y. I was unsure as to where to place the method, and so placed it after all of the public functions.

This is functioning properly at www.biblicallinguistics.com/text
