### PR TITLE
Ignoring touchMove if we didn't get the touchStart

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -993,6 +993,10 @@
             touchB,
             pinchDelta;
 
+        if ( !THIS[ tracker.hash ].lastTouch ) {
+          return;
+        }
+
         if( event.touches.length === 1 &&
             event.targetTouches.length === 1 &&
             event.changedTouches.length === 1 &&


### PR DESCRIPTION
If the touchStart doesn't get through (if, for instance, the app blocks the event), we'll throw on every touchMove without this patch.
