### PR TITLE
IE 10 not reading DZI file correctly

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -211,14 +211,13 @@
             // TODO replace the size rotation with CSS3 transforms
             // TODO add an option to overlays to not rotate with the image
             // Currently only rotates position and size
-            if( degrees !== 0 ) {
-               overlayCenter = new $.Point( size.x / 2, size.y / 2 );
-               var overlayCenterAfterRotate = (degrees === 0 || degrees === 180) ? overlayCenter : new $.Point( size.y / 2, size.x / 2 );
-               
+            if( degrees !== 0 && this.scales ) {
+                overlayCenter = new $.Point( size.x / 2, size.y / 2 );
+
                 position = position.plus( overlayCenter ).rotate(
                     degrees,
                     drawerCenter
-                ).minus( overlayCenterAfterRotate );
+                ).minus( overlayCenter );
 
                 size = size.rotate( degrees, new $.Point( 0, 0 ) );
                 size = new $.Point( Math.abs( size.x ), Math.abs( size.y ) );


### PR DESCRIPTION
IE 10 is treating the data coming back from the JSONP request as a
string and not as XML. I have confirmed this issue is happening on
numerous IE10 machines but have not seen it on any other browser.

The change simply checks the type of the data variable and if it is a
string it parses the string as XML and updates the data object.
