### PR TITLE
Check that zoom reference point is valid before using it

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -536,7 +536,7 @@ $.Viewport.prototype = {
      * @return {OpenSeadragon.Viewport} Chainable.
      */
     zoomBy: function( factor, refPoint, immediately ) {
-        if (refPoint instanceof $.Point && !isNaN(refPoint.x) && !isNaN(refPoint.y)) {
+        if( refPoint instanceof $.Point && !isNaN( refPoint.x ) && !isNaN( refPoint.y ) ) {
             refPoint = refPoint.rotate(
                 -this.degrees,
                 new $.Point( this.centerSpringX.target.value, this.centerSpringY.target.value )


### PR DESCRIPTION
We had a case where the final division in calculating the reference point turned into an effective divide-by-zero (floating point precision error, mumble mumble), resulting in an invalid reference point and images blanking out due to the invalid reference point. This commit simply checks that the reference point isn't NaN before using it.
