### PR TITLE
Fix for non-canvas tile rendering at large size

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -54,7 +54,7 @@
  *      this tile failed to load?
  * @property {String} url The URL of this tile's image.
  * @property {Boolean} loaded Is this tile loaded?
- * @property {Boolean} loading Is this tile loading
+ * @property {Boolean} loading Is this tile loading?
  * @property {Element} element The HTML div element for this tile
  * @property {Element} imgElement The HTML img element for this tile
  * @property {Image} image The Image object for this tile


### PR DESCRIPTION
In USE_CANVAS==false mode, wrapped tile img elements in div elements to
allow them to be rendered larger than their containing element without
being stretched (in certain container styles, the tile img would be constrained).
