### PR TITLE
Removed the 'onPageChange' callback (#285)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ OPENSEADRAGON CHANGELOG
     * The `fullpage` property of the 'full-page' event is now `fullPage`.
     * There is now a 'full-screen' event with a `fullScreen` property (true if it has gone to full screen).
     * There are now 'pre-full-page' and 'pre-full-screen' events that include a `preventDefaultAction` property you can set in your handler to cancel. They also have `fullPage` and `fullScreen` properties respectively, to indicate if they are going into or out of the mode.
+* BREAKING CHANGE: Removed the 'onPageChange' callback from the viewer options. Viewer.goToPage() now raises the 'page' event only (#285)
 * MouseTracker now passes the original event objects to its handler methods (#23)
 * MouseTracker now supports an optional 'moveHandler' method for tracking mousemove events (#215)
 * Added stopHandler to MouseTracker. (#262)

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -567,9 +567,6 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
             collectionMode:         false,
             collectionTileSize:     800,
 
-            //EVENT RELATED CALLBACKS
-            onPageChange:           null,
-
             //PERFORMANCE SETTINGS
             imageLoaderLimit:       0,
             maxImageCacheCount:     200,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1136,28 +1136,30 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * @return {OpenSeadragon.Viewer} Chainable.
      */
     goToPage: function( page ){
-        //page is a 1 based index so normalize now
-        //page = page;
-        this.raiseEvent( 'page', { page: page } );
-
-        if( this.tileSources.length > page ){
+        if( page >= 0 && page < this.tileSources.length ){
+            /**
+             * Raised when the page is changed on a viewer configured with multiple image sources.
+             *
+             * @event page
+             * @memberof OpenSeadragon.Viewer
+             * @type {Object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {Number} page - The page index.
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent( 'page', { page: page } );
 
             THIS[ this.hash ].sequence = page;
 
             this._updateSequenceButtons( page );
 
             this.open( this.tileSources[ page ] );
+
+            if( this.referenceStrip ){
+                this.referenceStrip.setFocus( page );
+            }
         }
 
-        if( $.isFunction( this.onPageChange ) ){
-            this.onPageChange({
-                page: page,
-                viewer: this
-            });
-        }
-        if( this.referenceStrip ){
-            this.referenceStrip.setFocus( page );
-        }
         return this;
     },
 


### PR DESCRIPTION
Fix for #285
Removed the 'onPageChange' callback from the viewer options.
Viewer.goToPage() now raises the 'page' event only.
