### PR TITLE
Enabled basic cross-domain tile loading without tainting canvas

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -419,6 +419,7 @@ $.Drawer.prototype = /** @lends OpenSeadragon.Drawer.prototype */{
             this.downloading++;
 
             image = new Image();
+            image.crossOrigin = 'Anonymous';
 
             complete = function( imagesrc, resultingImage ){
                 _this.downloading--;


### PR DESCRIPTION
Although OpenSeadragon could already load tiles from other domains and draw them to the canvas, the canvas immediately became "tainted" even when the tile source enabled a wide-open CORS configuration because the `crossOrigin` attribute needs to be set before attempting to load the image. When a canvas is tainted, the canvas's raw image data cannot be read. By setting this attribute, however, applications can use OpenSeadragon to load image tiles from external (CORS-enabled) repositories and process them, for example, as part of an image analysis workflow.

See [MDN](https://developer.mozilla.org/en-US/docs/HTML/CORS_Enabled_Image) and the [HTML Specification](http://whatwg.org/html#attr-img-crossorigin) for more information.

Note that more sophisticated access control is possible than what I have added here, but that what I have added here already solves problems for those of us in the scientific community who curate publicly available image repositories.
