### PR TITLE
Partial fix for referenceStripElement (#333).

### DIFF
--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -76,8 +76,11 @@ $.ReferenceStrip = function ( options ) {
         options.id              = 'referencestrip-' + $.now();
         this.element            = $.makeNeutralElement( "div" );
         this.element.id         = options.id;
-        this.element.className  = 'referencestrip';
+    } else {
+        this.element            = document.getElementById( options.id );
     }
+
+    this.element.className  = 'referencestrip';
 
     options = $.extend( true, {
         sizeRatio:  $.DEFAULT_SETTINGS.referenceStripSizeRatio,


### PR DESCRIPTION
This makes the behavior the same as the navigator (passing an id to
`referenceStripElement` to the main constructor). However, the reference strip
is still anchored to the bottom of the viewer, so it doesn't actually change
the appearance at all.

This doesn't fix the problem, really, but I wanted to submit the PR because I think that fully fixing it will require some relatively extensive refactoring of the ReferenceStrip class (I'm not familiar enough with the codebase to do it myself, I don't think). I do think I see the problem though, so here are some thoughts on what might be necessary.

The problem comes later (the block starting at [line 129](https://github.com/openseadragon/openseadragon/blob/master/src/referencestrip.js#L129)), when the controls are added. There, the control is added to the _viewer_, which anchors the reference strip inside the viewer. This means that although the ref strip is nominally "inside" the element we passed in, it looks like it's still in the viewer div.

I think what needs to happen is something similar to what happens in the navigator class. There ([line 68](https://github.com/openseadragon/openseadragon/blob/master/src/navigator.js#L68)), the anchor options are set in the initial if/else block (depending on whether or not the user provides the element or not). It might be a relatively simple fix to move the anchor logic there in the reference strip class, but it may also necessitate changes in the API. Offhand, it's tough for me to know exactly a vertical reference strip should be implemented if using an external element, for example. There might need to be some additional options in the root element (or a clarification of the ones already there).

Let me know what you think...I'm happy to help if I can, but JavaScript isn't my first (or second, or third) language, so it's tough for me sometimes to grasp the larger picture.
