### PR TITLE
add crossOriginPolicy drawer configuration to enable or disable CORS image requests

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -100,7 +100,8 @@ $.Drawer = function( options ) {
         alwaysBlend:        $.DEFAULT_SETTINGS.alwaysBlend,
         minPixelRatio:      $.DEFAULT_SETTINGS.minPixelRatio,
         debugMode:          $.DEFAULT_SETTINGS.debugMode,
-        timeout:            $.DEFAULT_SETTINGS.timeout
+        timeout:            $.DEFAULT_SETTINGS.timeout,
+        crossOriginPolicy:  $.DEFAULT_SETTINGS.crossOriginPolicy
 
     }, options );
 
@@ -303,7 +304,10 @@ $.Drawer.prototype = /** @lends OpenSeadragon.Drawer.prototype */{
             this.downloading++;
 
             image = new Image();
-            image.crossOrigin = 'Anonymous';
+
+            if (_this.crossOriginPolicy !== false) {
+              image.crossOrigin = _this.crossOriginPolicy;
+            }
 
             complete = function( imagesrc, resultingImage ){
                 _this.downloading--;

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -403,6 +403,10 @@
   *
   * @property {Number} [collectionTileSize=800]
   *
+  * @property {String} [crossOriginPolicy='Anonymous']
+  *      Valid values are 'Anonymous', 'use-credentials', and false. If false, canvas requests will
+  *      not use CORS, and the canvas will be tainted.
+  *
   */
 
 /**
@@ -717,6 +721,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
             tileSources:            null,
             tileHost:               null,
             initialPage:            0,
+            crossOriginPolicy:      'Anonymous',
             
             //PAN AND ZOOM SETTINGS AND CONSTRAINTS
             panHorizontal:          true,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1662,7 +1662,8 @@ function openTileSource( viewer, source ) {
         minPixelRatio:      _this.collectionMode ? 0 : _this.minPixelRatio,
         timeout:            _this.timeout,
         debugMode:          _this.debugMode,
-        debugGridColor:     _this.debugGridColor
+        debugGridColor:     _this.debugGridColor,
+        crossOriginPolicy:  _this.crossOriginPolicy
     });
 
     // Now that we have a drawer, see if it supports rotate. If not we need to remove the rotate buttons


### PR DESCRIPTION
After #308, tile sources that do not support CORS are failing with:

``` console
Cross-origin image load denied by Cross-Origin Resource Sharing policy.
Tile $.Tile failed to load: [URL]
```

This patch adds a configuration setting for the `crossOrigin` request, allowing the new behavior to be disabled (or, to add use-credentials).
