### PR TITLE
Make OpenSeadragon W3C compliant.

### DIFF
--- a/src/button.js
+++ b/src/button.js
@@ -120,18 +120,23 @@ $.Button = function( options ) {
      * @member {Element} element
      * @memberof OpenSeadragon.Button#
      */
-    this.element        = options.element   || $.makeNeutralElement( "button" );
+    this.element        = options.element   || $.makeNeutralElement( "div" );
 
     //if the user has specified the element to bind the control to explicitly
     //then do not add the default control images
-    if( !options.element ){
+    if ( !options.element ) {
         this.imgRest      = $.makeTransparentImage( this.srcRest );
         this.imgGroup     = $.makeTransparentImage( this.srcGroup );
         this.imgHover     = $.makeTransparentImage( this.srcHover );
         this.imgDown      = $.makeTransparentImage( this.srcDown );
-        this.imgDiv       = $.makeNeutralElement( "div" );
 
-        this.imgDiv.style.position = "relative";
+        this.imgRest.alt  =
+        this.imgGroup.alt =
+        this.imgHover.alt =
+        this.imgDown.alt  =
+            this.tooltip;
+
+        this.element.style.position = "relative";
 
         this.imgGroup.style.position =
         this.imgHover.style.position =
@@ -159,11 +164,10 @@ $.Button = function( options ) {
                 "";
         }
 
-        this.imgDiv.appendChild( this.imgRest );
-        this.imgDiv.appendChild( this.imgGroup );
-        this.imgDiv.appendChild( this.imgHover );
-        this.imgDiv.appendChild( this.imgDown );
-        this.element.appendChild( this.imgDiv );
+        this.element.appendChild( this.imgRest );
+        this.element.appendChild( this.imgGroup );
+        this.element.appendChild( this.imgHover );
+        this.element.appendChild( this.imgDown );
     }
 
 

--- a/src/buttongroup.js
+++ b/src/buttongroup.js
@@ -66,7 +66,7 @@ $.ButtonGroup = function( options ) {
      * @member {Element} element
      * @memberof OpenSeadragon.ButtonGroup#
      */
-    this.element = options.element || $.makeNeutralElement( "fieldgroup" );
+    this.element = options.element || $.makeNeutralElement( "div" );
 
     // TODO What if there IS an options.group specified? 
     if( !options.group ){

--- a/src/control.js
+++ b/src/control.js
@@ -128,7 +128,7 @@ $.Control = function ( element, options, container ) {
         this.element.style.height = "100%";
         this.element.style.width = "100%";
     } else {
-        this.wrapper    = $.makeNeutralElement( "span" );
+        this.wrapper    = $.makeNeutralElement( "div" );
         this.wrapper.style.display = "inline-block";
         if ( this.anchor == $.ControlAnchor.NONE ) {
             // IE6 fix

--- a/src/controldock.js
+++ b/src/controldock.js
@@ -46,7 +46,7 @@
 
         $.extend( true, this, {
             id: 'controldock-'+$.now()+'-'+Math.floor(Math.random()*1000000),
-            container: $.makeNeutralElement('form'),
+            container: $.makeNeutralElement( 'div' ),
             controls: []
         }, options );
 

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -201,7 +201,7 @@ $.Navigator = function( options ){
 
     $.Viewer.apply( this, [ options ] );
 
-    this.element.getElementsByTagName('form')[0].appendChild( this.displayRegion );
+    this.element.getElementsByTagName( 'div' )[0].appendChild( this.displayRegion );
     unneededElement = this.element.getElementsByTagName('textarea')[0];
     if (unneededElement) {
         unneededElement.parentNode.removeChild(unneededElement);

--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -447,7 +447,7 @@ function loadPanels( strip, viewerSize, scroll ) {
                 element: miniViewer.displayRegion
             } );
 
-            element.getElementsByTagName( 'form' )[0].appendChild(
+            element.getElementsByTagName( 'div' )[0].appendChild(
                 miniViewer.displayRegion
             );
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -102,7 +102,7 @@ $.Viewer = function( options ) {
          */
         element:        null,
         /**
-         * A &lt;form&gt; element (provided by {@link OpenSeadragon.ControlDock}), the base element of this Viewer instance.<br><br>
+         * A &lt;div&gt; element (provided by {@link OpenSeadragon.ControlDock}), the base element of this Viewer instance.<br><br>
          * Child element of {@link OpenSeadragon.Viewer#element}.
          * @member {Element} container
          * @memberof OpenSeadragon.Viewer#


### PR DESCRIPTION
I just discovered this firefox plugin: http://users.skynet.be/mgueury/mozilla/

So here is what was needed to make OSD W3C compliant:
- add alt attributes to the img elements
- change button element to div because a button can not have a child element
- change fieldgroup to div because a fieldgroup can not have a child div
- change span to div for the same reason
- change form to div because you can't have a form in a form.
