### PR TITLE
Support query parameters in DZI tileSource URL

### DIFF
--- a/src/dzitilesource.js
+++ b/src/dzitilesource.js
@@ -137,7 +137,8 @@ $.extend( $.DziTileSource.prototype, $.TileSource.prototype, /** @lends OpenSead
         }
 
         if (url && !options.tilesUrl) {
-            options.tilesUrl = url.replace(/([^\/]+)\.(dzi|xml|js)$/, '$1_files/');
+            options.tilesUrl = url.replace(/([^\/]+)\.(dzi|xml|js)(\?.*|$)/, '$1_files/');
+            options.queryParams = url.match(/\?.*/);
         }
 
         return options;
@@ -151,7 +152,7 @@ $.extend( $.DziTileSource.prototype, $.TileSource.prototype, /** @lends OpenSead
      * @param {Number} y
      */
     getTileUrl: function( level, x, y ) {
-        return [ this.tilesUrl, level, '/', x, '_', y, '.', this.fileFormat ].join( '' );
+        return [ this.tilesUrl, level, '/', x, '_', y, '.', this.fileFormat, this.queryParams ].join( '' );
     },
 
 

--- a/test/formats.js
+++ b/test/formats.js
@@ -66,6 +66,11 @@
     });
 
     // ----------
+    asyncTest('DZI XML with query parameter', function() {
+        testOpen('testpattern.xml?param=value');
+    });
+
+     // ----------
     asyncTest('IIIF 1.0 JSON', function() {
         testOpen('iiif1_0.json');
     });


### PR DESCRIPTION
We have a need to pass a sessionId query parameter to be able to fetch images that may require a session in order to access those images.  Before this change, if the tileSource was set to:
"/path/to/image.xml?param=value"

Subsequent tile URLs would look like "/path/to/image_files/?param=value0/0_0.jpg" which is obviously invalid.  This change extracts any query parameters and appends them (if there are any) onto the tile URLs.
