### PR TITLE
Quick patch to fix mid-update image loaded callbacks

### DIFF
--- a/src/imageLoader.js
+++ b/src/imageLoader.js
@@ -142,7 +142,14 @@ $.ImageLoader.prototype = {
         else {
            this.jobQueue.push( newJob );
         }
+    },
 
+    /**
+     * Clear any unstarted image loading jobs from the queue.
+     * @method
+     */
+    clear: function() {
+        this.jobQueue = [];
     }
 };
 


### PR DESCRIPTION
Believe this should fix #406.

The "Tile load callback in middle of drawing routine" error has been removed. Instead, the tile is always loaded, and if the drawer is in the middle of an update, the update of the image cache will be delayed. 

Please check that things don't go horribly wrong for IE8. You won't see the error message appear, but IE8 might implode or something.

Oh, and I added an important method to the Image Loader while updating things. Don't think there's a huge need for it now (and there's no need for it when the loader limit is set to 0), but there will be with future changes.
