### PR TITLE
Fixes IE 10 panning issues on tablets.

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1896,6 +1896,7 @@
                 event.currentTarget.msReleasePointerCapture( event.pointerId );
             }
         }
+        updatePointersExit(tracker, event, [gPoint]);
     }
 
 


### PR DESCRIPTION
Panning on IE 10 on our Windows 8 tablet was faulty. Specifically the image would move only once the touch input ended, i.e. I lifted my fingers off the screen. I have spent quite some time figuring out the problem, hopefully I got the fix right!

The problem seems to have been caused by pointers never being removed. Each time panning started a new pointer was created causing issues. This patch modifies the code to ensure that pointers are deleted when touch input ends.

It's also possible that this PR fixes issue #152.
