### PR TITLE
Support dzi xml with namespaces

### DIFF
--- a/src/dzitilesource.js
+++ b/src/dzitilesource.js
@@ -107,7 +107,7 @@ $.extend( $.DziTileSource.prototype, $.TileSource.prototype, /** @lends OpenSead
         var ns;
         if ( data.Image ) {
             ns = data.Image.xmlns;
-        } else if ( data.documentElement && "Image" == data.documentElement.tagName ) {
+        } else if ( data.documentElement && "Image" == data.documentElement.localName ) {
             ns = data.documentElement.namespaceURI;
         }
 
@@ -221,7 +221,7 @@ function configureFromXML( tileSource, xmlDoc ){
     }
 
     var root           = xmlDoc.documentElement,
-        rootName       = root.tagName,
+        rootName       = root.localName,
         configuration  = null,
         displayRects   = [],
         dispRectNodes,


### PR DESCRIPTION
The DZI I'm working with has namespaces in the xml, and openseadragon doesn't recognize it as valid DZI.  These two changes were all I needed to get openseadragon to recognize and work properly with my DZI file.  It's possible there are other places where it's not still namespace aware, but I think the other methods used (getElementsByTagName, getAttribute) aren't affected by the presence of the namespace prefixes on the elements, and as far as I could tell everything was working.

Here's a sample of my dzi xml with namespaces:

``` xml
<dz:Image xmlns:dz="http://schemas.microsoft.com/deepzoom/2008" TileSize="256" Format="jpg" Overlap="1">
<dz:Size Width="1458" Height="2246"/>
</dz:Image>
```
