### PR TITLE
fix #500 - requests keyboard focus when canvas is clicked

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -300,6 +300,8 @@ $.Viewer = function( options ) {
         style.left     = "0px";
         style.resize   = "none";
     }(  this.keyboardCommandArea.style ));
+    // Set read-only - hides keyboard on mobile devices, still allows input.
+    this.keyboardCommandArea.readOnly = true;
 
     this.container.insertBefore( this.canvas, this.container.firstChild );
     this.container.insertBefore( this.keyboardCommandArea, this.container.firstChild );

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2265,6 +2265,13 @@ function onBlur(){
 function onCanvasClick( event ) {
     var gestureSettings;
 
+    var haveKeyboardFocus = document.activeElement == this.keyboardCommandArea;
+
+    // If we don't have keyboard focus, request it.
+    if ( !haveKeyboardFocus ) {
+        this.keyboardCommandArea.focus();
+    }
+
     if ( !event.preventDefaultAction && this.viewport && event.quick ) {
         gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
         if ( gestureSettings.clickToZoom ) {


### PR DESCRIPTION
The canvas click listener will now check if keyboard-command-area has
focus, and if it does not, it will request it.

Addresses #500.