### PR TITLE
Added preserveOverlays option to Viewer

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -519,6 +519,12 @@
   *     position.  If preserveViewport is set to true, then the viewport position
   *     is preserved when navigating between images in the sequence.
   *
+  * @property {Boolean} [preserveOverlays=false]
+  *     If the viewer has been configured with a sequence of tile sources, then
+  *     normally navigating to through each image resets the overlays.
+  *     If preserveOverlays is set to true, then the overlays
+  *     are preserved when navigating between images in the sequence.
+  *
   * @property {Boolean} [showReferenceStrip=false]
   *     If the viewer has been configured with a sequence of tile sources, then
   *     display a scrolling strip of image thumbnails for navigating through the images.
@@ -945,6 +951,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
             showSequenceControl:     true,  //SEQUENCE
             sequenceControlAnchor:   null,  //SEQUENCE
             preserveViewport:        false, //SEQUENCE
+            preserveOverlays:        false, //SEQUENCE
             navPrevNextWrap:         false, //SEQUENCE
             showNavigationControl:   true,  //ZOOM/HOME/FULL/ROTATION
             navigationControlAnchor: null,  //ZOOM/HOME/FULL/ROTATION

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1973,11 +1973,10 @@ function openTileSource( viewer, source ) {
     }
 
     if( _this.preserveOverlays ){
-        _this.source.overlays = _this.currentOverlays;
+        _this.overlays = _this.currentOverlays;
     }
-    else{
-        _this.source.overlays = _this.source.overlays || [];
-    }
+
+    _this.source.overlays = _this.source.overlays || [];
 
     _this.drawer = new $.Drawer({
         viewer:             _this,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -539,9 +539,13 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             this.navigator.close();
         }
 
-        this.clearOverlays();
+        if( ! this.preserveOverlays)
+        {
+            this.clearOverlays();
+            this.overlaysContainer.innerHTML = "";
+        }
+
         this.drawersContainer.innerHTML = "";
-        this.overlaysContainer.innerHTML = "";
 
         if ( this.drawer ) {
             this.drawer.destroy();
@@ -1968,7 +1972,12 @@ function openTileSource( viewer, source ) {
         _this.viewport.resetContentSize( _this.source.dimensions );
     }
 
-    _this.source.overlays = _this.source.overlays || [];
+    if( _this.preserveOverlays ){
+        _this.source.overlays = _this.currentOverlays;
+    }
+    else{
+        _this.source.overlays = _this.source.overlays || [];
+    }
 
     _this.drawer = new $.Drawer({
         viewer:             _this,


### PR DESCRIPTION
Added preserveOverlays option.

Similar to preserveViewport but for overlays.
If set to true it will stop the viewer from reseting the overlays, by default it is set to false.