### PR TITLE
Removed 'position' property from MouseTracker keyDownHandler/keyUpHandle...

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ OPENSEADRAGON CHANGELOG
 * Requesting keyboard focus when viewer is clicked (#537)
 * Arrow key navigation fixed across platforms (#565)
 * Removed textarea element from viewer DOM. Viewer.canvas now handles keyboard navigation (#569)
+* Removed 'position' property from MouseTracker keyDownHandler/keyUpHandler/keyHandler functions (#573)
 
 1.2.0:
 

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1518,7 +1518,6 @@
             propagate = tracker.keyDownHandler(
                 {
                     eventSource:          tracker,
-                    position:             getMouseRelative( event, tracker.element ),
                     keyCode:              event.keyCode ? event.keyCode : event.charCode,
                     ctrl:                 event.ctrlKey,
                     shift:                event.shiftKey,
@@ -1548,7 +1547,6 @@
             propagate = tracker.keyUpHandler(
                 {
                     eventSource:          tracker,
-                    position:             getMouseRelative( event, tracker.element ),
                     keyCode:              event.keyCode ? event.keyCode : event.charCode,
                     ctrl:                 event.ctrlKey,
                     shift:                event.shiftKey,
@@ -1578,7 +1576,6 @@
             propagate = tracker.keyHandler(
                 {
                     eventSource:          tracker,
-                    position:             getMouseRelative( event, tracker.element ),
                     keyCode:              event.keyCode ? event.keyCode : event.charCode,
                     ctrl:                 event.ctrlKey,
                     shift:                event.shiftKey,


### PR DESCRIPTION
...r/keyHandler functions

Positional data is not available in the corresponding DOM event objects, causing an exception when the handlers were used.