### PR TITLE
Removed Viewer focusHandler, added tabIndex option

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ OPENSEADRAGON CHANGELOG
 * Removed 'position' property from MouseTracker keyDownHandler/keyUpHandler/keyHandler functions (#573)
 * Fixed pointer event model detection for IE 10 and IE 11 (#571)
 * Added setMouseNavEnabled() support to Navigator (#572)
+* Removed Viewer focusHandler/onCanvasFocus (#577)
 
 1.2.0:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ OPENSEADRAGON CHANGELOG
 * Fixed pointer event model detection for IE 10 and IE 11 (#571)
 * Added setMouseNavEnabled() support to Navigator (#572)
 * Removed Viewer focusHandler/onCanvasFocus (#577)
+* Added tabIndex option to viewer (#577)
 
 1.2.0:
 

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -98,6 +98,7 @@ $.Navigator = function( options ){
         sizeRatio:     $.DEFAULT_SETTINGS.navigatorSizeRatio
     }, options, {
         element:                this.element,
+        tabIndex:               -1, // No keyboard navigation, omit from tab order
         //These need to be overridden to prevent recursion since
         //the navigator is a viewer and a viewer has a navigator
         showNavigator:          false,

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -126,6 +126,10 @@
   *     The element to append the viewer's container element to. If not provided, the 'id' property must be provided.
   *     If both the element and id properties are specified, the viewer is appended to the element provided in the element property.
   *
+  * @property {Number} [tabIndex=0]
+  *     Tabbing order index to assign to the viewer element. Positive values are selected in increasing order. When tabIndex is 0 
+  *     source order is used. A negative value omits the viewer from the tabbing order.
+  *
   * @property {Array|String|Function|Object[]|Array[]|String[]|Function[]} [tileSources=null]
   *     As an Array, the tileSource can hold either Objects or mixed
   *     types of Arrays of Objects, Strings, or Functions. When a value is a String,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -301,7 +301,6 @@ $.Viewer = function( options ) {
         clickDistThreshold:       this.clickDistThreshold,
         dblClickTimeThreshold:    this.dblClickTimeThreshold,
         dblClickDistThreshold:    this.dblClickDistThreshold,
-        focusHandler:             $.delegate( this, onCanvasFocus ),
         keyDownHandler:           $.delegate( this, onCanvasKeyDown ),
         keyHandler:               $.delegate( this, onCanvasKeyPress ),
         clickHandler:             $.delegate( this, onCanvasClick ),
@@ -2186,13 +2185,6 @@ function onFocus(){
 function onBlur(){
     beginControlsAutoHide( this );
 
-}
-
-function onCanvasFocus( event ) {
-    if ( !event.preventDefaultAction ) {
-        var point    = $.getElementPosition( this.element );
-        window.scrollTo( 0, point.y );
-    }
 }
 
 function onCanvasKeyDown( event ) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -268,7 +268,7 @@ $.Viewer = function( options ) {
         style.left     = "0px";
     }(this.canvas.style));
     $.setElementTouchActionNone( this.canvas );
-    this.canvas.tabIndex = 0;
+    this.canvas.tabIndex = options.tabIndex || 0;
 
     //the container is created through applying the ControlDock constructor above
     this.container.className = "openseadragon-container";


### PR DESCRIPTION
Presumably, the focusHandler was meant to manually scroll the viewer into view when it receives focus. This is already handled by browsers when tabbing to the viewer, so doing it explicitly isn't necessary, and it creates a negative user experience when clicking on a viewer to give it focus (as of #569).

Added a tabIndex to the Viewer creation options to facilitate viewers in pages using tabIndex on other elements.