### PR TITLE
preserveOverlays now handles both this.overlays and addOverlay()

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -523,13 +523,11 @@
   *     position.  If preserveViewport is set to true, then the viewport position
   *     is preserved when navigating between images in the sequence.
   *
-  * @property {Boolean} [preserveOverlays=false]
+  * @property {Boolean} [preserveOverlays=true]
   *     If the viewer has been configured with a sequence of tile sources, then
   *     normally navigating through each image resets the overlays.
   *     If preserveOverlays is set to true, then the overlays
   *     are preserved when navigating between images in the sequence.
-  *     Note: setting preserveOverlays overrides any overlays specified in the
-  *     "overlays" property.
   *
   * @property {Boolean} [showReferenceStrip=false]
   *     If the viewer has been configured with a sequence of tile sources, then
@@ -957,7 +955,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
             showSequenceControl:     true,  //SEQUENCE
             sequenceControlAnchor:   null,  //SEQUENCE
             preserveViewport:        false, //SEQUENCE
-            preserveOverlays:        false, //SEQUENCE
+            preserveOverlays:        true, //SEQUENCE
             navPrevNextWrap:         false, //SEQUENCE
             showNavigationControl:   true,  //ZOOM/HOME/FULL/ROTATION
             navigationControlAnchor: null,  //ZOOM/HOME/FULL/ROTATION

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -474,6 +474,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             this.drawer.destroy();
         }
 
+        this.overlays   = [];
         this.source     = null;
         this.drawer     = null;
         this.drawers    = [];
@@ -1892,7 +1893,9 @@ function openTileSource( viewer, source ) {
     }
 
     if( _this.preserveOverlays ){
-        _this.overlays = _this.currentOverlays;
+        if( _this.currentOverlays.length > 0 ){
+            _this.overlays = _this.currentOverlays;
+        }
     }
 
     _this.source.overlays = _this.source.overlays || [];


### PR DESCRIPTION
Hello, 

Following [561](https://github.com/openseadragon/openseadragon/pull/561) pull request discussion.
Please review and let me know if any modification are needed.