### PR TITLE
Correct IIIF tile source to use canonical syntax

### DIFF
--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -216,6 +216,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             levelHeight = Math.ceil( this.height * scale ),
 
             //## iiif region
+            tileSize,
             iiifTileSizeWidth,
             iiifTileSizeHeight,
             iiifRegion,
@@ -227,7 +228,8 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifQuality,
             uri;
 
-        iiifTileSizeWidth = Math.ceil( this.getTileSize(level) / scale );
+        tileSize = this.getTileSize(level);
+        iiifTileSizeWidth = Math.ceil( tileSize / scale );
         iiifTileSizeHeight = iiifTileSizeWidth;
 
         if ( this['@context'].indexOf('/1.0/context.json') > -1 ||
@@ -238,7 +240,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifQuality = "default.jpg";
         }
 
-        if ( levelWidth < this.tile_width && levelHeight < this.tile_height ){
+        if ( levelWidth < tileSize && levelHeight < tileSize ){
             iiifSize = levelWidth + ",";
             iiifRegion = 'full';
         } else {
@@ -255,6 +257,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
     }
 
   });
+
 
     function configureFromXml10(xmlDoc) {
         //parse the xml


### PR DESCRIPTION
The IIIF canonical syntax is defined here: http://iiif.io/api/image/2.0/#canonical-uri-syntax. It was added in the 2.0 release of the spec in order to facilitate the creation of static image collections using a common syntax that clients would expect and servers could expose using only a file system.

OpenSeadragon does not presently use `full` when requesting the whole image (at lower levels) from IIIF 2.0-compliant servers. Instead it uses `0,0,<full_width>,<full_height>`. Functionally these are the same, but it breaks static collections and optimized servers.

Specifically, `this.tile_width` and `this.tile_height` ([here](https://github.com/jpstroop/openseadragon/compare/openseadragon:master...iiif_use_full#diff-8687fada024051e6abce230abcacc2aaL241)) were not defined for IIIF 2.0 requests, and so the `else` block was always executed.

/cc @azaroth42 