### PR TITLE
Fixed x/y typo in reference strip.

### DIFF
--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -224,7 +224,7 @@ $.ReferenceStrip = function ( options ) {
         this.panels.push( element );
 
     }
-    loadPanels( this, this.scroll == 'vertical' ? viewerSize.y : viewerSize.y, 0 );
+    loadPanels( this, this.scroll == 'vertical' ? viewerSize.y : viewerSize.x, 0 );
     this.setFocus( 0 );
 
 };


### PR DESCRIPTION
Typo caused horizontal strip to be rendered only relative to height, not to width as it should. On typical landscape sized screens this forced only ~half the reference strip to be (pre-)rendered at any time.