### PR TITLE
Fixed Firefox 35 not able to open local files (#588)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -51,6 +51,7 @@ OPENSEADRAGON CHANGELOG
 * Added support for HDPI (retina) displays (#583)
 * Corrected IIIF tile source to use canonical syntax (#586)
 * Fixed x/y typo that caused horizontal reference strip to be rendered only relative to height (#595)
+* Fixed Firefox 35 not able to open local files (#588)
 
 1.2.1:
 

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1984,9 +1984,12 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
                 if ( request.readyState == 4 ) {
                     request.onreadystatechange = function(){};
 
-                    var successStatus =
-                        protocol === "http:" || protocol === "https:" ? 200 : 0;
-                    if ( request.status === successStatus ) {
+                    // With protocols other than http/https, the status is 200
+                    // on Firefox and 0 on other browsers
+                    if ( request.status === 200 ||
+                        ( request.status === 0 &&
+                          protocol !== "http:" &&
+                          protocol !== "https:" )) {
                         onSuccess( request );
                     } else {
                         $.console.log( "AJAX request returned %d: %s", request.status, url );


### PR DESCRIPTION
Tested on Firefox, Chromium (with --disable-web-security option) and IE11. 