### PR TITLE
Optimize tile loading by clearing the queue on a re-draw

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -144,7 +144,7 @@ $.ImageLoader.prototype = /** @lends OpenSeadragon.ImageLoader.prototype */{
      */
     clear: function() {
         for( var i = 0; i < this.jobQueue.length; i++ ) {
-            job = this.jobQueue[i];
+            var job = this.jobQueue[i];
             if ( typeof job.abort === "function" ) {
                 job.abort();
             }

--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -124,7 +124,8 @@ $.ImageLoader.prototype = /** @lends OpenSeadragon.ImageLoader.prototype */{
             jobOptions = {
                 src: options.src,
                 crossOriginPolicy: options.crossOriginPolicy,
-                callback: complete
+                callback: complete,
+                abort: options.abort
             },
             newJob = new ImageJob( jobOptions );
 
@@ -142,6 +143,13 @@ $.ImageLoader.prototype = /** @lends OpenSeadragon.ImageLoader.prototype */{
      * @method
      */
     clear: function() {
+        for( var i = 0; i < this.jobQueue.length; i++ ) {
+            job = this.jobQueue[i];
+            if ( typeof job.abort === "function" ) {
+                job.abort();
+            }
+        }
+
         this.jobQueue = [];
     }
 };

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -883,6 +883,9 @@ function loadTile( tiledImage, tile, time ) {
         crossOriginPolicy: tiledImage.crossOriginPolicy,
         callback: function( image ){
             onTileLoad( tiledImage, tile, time, image );
+        },
+        abort: function() {
+            tile.loading = false;
         }
     });
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -673,7 +673,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         THIS[ this.hash ].animating = false;
         this.world.removeAll();
         this.imageLoader.clear();
-        
+
         /**
          * Raised when the viewer is closed (see {@link OpenSeadragon.Viewer#close}).
          *
@@ -2926,6 +2926,7 @@ function resizeViewportAndRecenter( viewer, containerSize, oldBounds, oldCenter 
 }
 
 function drawWorld( viewer ) {
+    viewer.imageLoader.clear();
     viewer.drawer.clear();
     viewer.world.draw();
 


### PR DESCRIPTION
This is my first try to optimize the tile loading of OSD. Currently if you quickly scroll over a big document, all tiles are getting queued and the queue starts one job after another. If a `imageLoaderLimit` is set, it will start a maximum of X requests.

With this approach, all jobs that aren't started yet are getting out of the queue and re-queued by the viewer if they are still needed. I extended the imageLoader to call `.abort()` on all jobs before the queue gets cleared.

We tested this behaviour now for a day and could really notice a big difference. We tested it with 20Mbit, 1Mbit (it wasn't possible to read here without waiting 5 minutes) and 7Mbit connection and on all of them it was much better.

It will only work if the `imageLoaderLimit` is set, otherwise it will be ignored because the job starts immediatly. We have set it to 10 to test it.

What do you think about this approach?