### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
[Editorconfig](http://www.editorconfig.org) is a very common configuration method for nearly every IDE and because of that perfect for open source projects.

What you think about removing the openseadragon.sublime-project file?