### PR TITLE
Add support for non-square tiles (#670)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@ OPENSEADRAGON CHANGELOG
 * Better error reporting for tile load failures (#679)
 * Added collectionColumns as a configuration parameter (#680)
 * Added support for non-square tiles (#673)
-    * TileSource.Options objects can now optionally provide tileWidth/tileWidth instead of tileSize for non-square tile support.
+    * TileSource.Options objects can now optionally provide tileWidth/tileHeight instead of tileSize for non-square tile support.
     * IIIFTileSources will now respect non-square tiles if available.
     * DEPRECATION: TileSource.getTileSize is deprecated use TileSource.getTileWidth and TileSource.getTileHeight instead.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,11 @@ OPENSEADRAGON CHANGELOG
 * Fixed flickering tiles with useCanvas=false when no cache is used (#661)
 * Added additional coordinates conversion methods to TiledImage (#662)
 * 'display: none' no longer gets reset on overlays during draw (#668)
+* Added support for non-square tiles (#673)
+    * TileSource.Options objects can now optionally provide tileWidth/tileWidth instead of tileSize for non-square tile support.
+    * IIIFTileSources will now respect non-square tiles if available.
+    * DEPRECATION: TileSource.getTileSize is deprecated use TileSource.getTileWidth and TileSource.getTileHeight instead.
+
 
 2.0.0:
 

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -185,15 +185,11 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
      * @function
      * @param {Number} level
     */
-
     getTileSize: function( level ){
         var scaleFactor = Math.pow(2, this.maxLevel - level);
         // cache it in case any external code is going to read it directly
         if (this.tileSizePerScaleFactor && this.tileSizePerScaleFactor[scaleFactor]) {
-            this.tileSize = new $.Point(
-                this.tileSizePerScaleFactor[scaleFactor],
-                this.tileSizePerScaleFactor[scaleFactor]
-            );
+            this.tileSize = this.tileSizePerScaleFactor[scaleFactor];
         }
         return this.tileSize;
     },
@@ -233,8 +229,8 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
 
         tileSize = this.getTileSize(level);
 
-        iiifTileSizeWidth = Math.ceil( tileSize.x / scale );
-        iiifTileSizeHeight = Math.ceil( tileSize.y / scale );
+        iiifTileSizeWidth = Math.ceil( tileSize / scale );
+        iiifTileSizeHeight = Math.ceil( tileSize / scale );
 
         if ( this['@context'].indexOf('/1.0/context.json') > -1 ||
              this['@context'].indexOf('/1.1/context.json') > -1 ||
@@ -244,7 +240,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifQuality = "default.jpg";
         }
 
-        if ( levelWidth < tileSize.x && levelHeight < tileSize.y ){
+        if ( levelWidth < tileSize && levelHeight < tileSize ){
             iiifSize = levelWidth + ",";
             iiifRegion = 'full';
         } else {

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -55,14 +55,19 @@ $.IIIFTileSource = function( options ){
     options.tileSizePerScaleFactor = {};
 
     // N.B. 2.0 renamed scale_factors to scaleFactors
-    if ( this.tile_width ) {
+    if ( this.tile_width && this.tile_height ) {
+        options.tileWidth = this.tile_width;
+        options.tileHeight = this.tile_height;
+    } else if ( this.tile_width ) {
         options.tileSize = this.tile_width;
     } else if ( this.tile_height ) {
         options.tileSize = this.tile_height;
     } else if ( this.tiles ) {
         // Version 2.0 forwards
         if ( this.tiles.length == 1 ) {
-            options.tileSize = this.tiles[0].width;
+            options.tileWidth  = this.tiles[0].width;
+            // Use height if provided, otherwise assume square tiles and use width.
+            options.tileHeight = this.tiles[0].height || this.tiles[0].width;
             this.scale_factors = this.tiles[0].scaleFactors;
         } else {
             // Multiple tile sizes at different levels
@@ -71,13 +76,15 @@ $.IIIFTileSource = function( options ){
                 for (var sf = 0; sf < this.tiles[t].scaleFactors.length; sf++) {
                     var scaleFactor = this.tiles[t].scaleFactors[sf];
                     this.scale_factors.push(scaleFactor);
-                    options.tileSizePerScaleFactor[scaleFactor] = this.tiles[t].width;
+                    options.tileSizePerScaleFactor[scaleFactor] = {
+                        width: this.tiles[t].width,
+                        height: this.tiles[t].height || this.tiles[t].width
+                    };
                 }
             }
         }
     } else {
         // use the largest of tileOptions that is smaller than the short dimension
-
         var shortDim = Math.min( this.height, this.width ),
             tileOptions = [256,512,1024],
             smallerTiles = [];
@@ -94,8 +101,6 @@ $.IIIFTileSource = function( options ){
             // If we're smaller than 256, just use the short side.
             options.tileSize = shortDim;
         }
-        this.tile_width = options.tileSize;  // So that 'full' gets used for
-        this.tile_height = options.tileSize; // the region below
     }
 
     if ( !options.maxLevel ) {
@@ -190,7 +195,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         var scaleFactor = Math.pow(2, this.maxLevel - level);
 
         if (this.tileSizePerScaleFactor && this.tileSizePerScaleFactor[scaleFactor]) {
-            return this.tileSizePerScaleFactor[scaleFactor];
+            return this.tileSizePerScaleFactor[scaleFactor].width;
         }
         return this._tileWidth;
     },
@@ -204,7 +209,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         var scaleFactor = Math.pow(2, this.maxLevel - level);
 
         if (this.tileSizePerScaleFactor && this.tileSizePerScaleFactor[scaleFactor]) {
-            return this.tileSizePerScaleFactor[scaleFactor];
+            return this.tileSizePerScaleFactor[scaleFactor].height;
         }
         return this._tileHeight;
     },

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -244,7 +244,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifQuality,
             uri;
 
-        tileWidth = this.getTileSize(level);
+        tileWidth = this.getTileWidth(level);
         tileHeight = this.getTileHeight(level);
         iiifTileSizeWidth = Math.ceil( tileWidth / scale );
         iiifTileSizeHeight = Math.ceil( tileHeight / scale );

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -190,9 +190,12 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         var scaleFactor = Math.pow(2, this.maxLevel - level);
         // cache it in case any external code is going to read it directly
         if (this.tileSizePerScaleFactor && this.tileSizePerScaleFactor[scaleFactor]) {
-            this.tileSize = this.tileSizePerScaleFactor[scaleFactor];
+            this.tileSize = new $.Point(
+                this.tileSizePerScaleFactor[scaleFactor],
+                this.tileSizePerScaleFactor[scaleFactor]
+            );
         }
-        return new $.Point(this.tileSize, this.tileSize);
+        return this.tileSize;
     },
 
     /**

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -117,6 +117,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
      * @param {Object|Array} data
      * @param {String} optional - url
      */
+     
     supports: function( data, url ) {
         // Version 2.0 and forwards
         if (data.protocol && data.protocol == 'http://iiif.io/api/image') {
@@ -228,9 +229,8 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             uri;
 
         tileSize = this.getTileSize(level);
-
         iiifTileSizeWidth = Math.ceil( tileSize / scale );
-        iiifTileSizeHeight = Math.ceil( tileSize / scale );
+        iiifTileSizeHeight = iiifTileSizeWidth;
 
         if ( this['@context'].indexOf('/1.0/context.json') > -1 ||
              this['@context'].indexOf('/1.1/context.json') > -1 ||

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -182,18 +182,33 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
     },
 
     /**
-     * Return the tileSize for the given level.
+     * Return the tileWidth for the given level.
      * @function
      * @param {Number} level
-    */
-    getTileSize: function( level ){
+     */
+    getTileWidth: function( level ) {
         var scaleFactor = Math.pow(2, this.maxLevel - level);
-        // cache it in case any external code is going to read it directly
+
         if (this.tileSizePerScaleFactor && this.tileSizePerScaleFactor[scaleFactor]) {
-            this.tileSize = this.tileSizePerScaleFactor[scaleFactor];
+            return this.tileSizePerScaleFactor[scaleFactor];
         }
-        return this.tileSize;
+        return this._tileWidth;
     },
+
+    /**
+     * Return the tileHeight for the given level.
+     * @function
+     * @param {Number} level
+     */
+    getTileHeight: function( level ) {
+        var scaleFactor = Math.pow(2, this.maxLevel - level);
+
+        if (this.tileSizePerScaleFactor && this.tileSizePerScaleFactor[scaleFactor]) {
+            return this.tileSizePerScaleFactor[scaleFactor];
+        }
+        return this._tileHeight;
+    },
+
 
     /**
      * Responsible for retreiving the url which will return an image for the
@@ -216,7 +231,8 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             levelHeight = Math.ceil( this.height * scale ),
 
             //## iiif region
-            tileSize,
+            tileWidth,
+            tileHeight,
             iiifTileSizeWidth,
             iiifTileSizeHeight,
             iiifRegion,
@@ -228,9 +244,10 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifQuality,
             uri;
 
-        tileSize = this.getTileSize(level);
-        iiifTileSizeWidth = Math.ceil( tileSize / scale );
-        iiifTileSizeHeight = iiifTileSizeWidth;
+        tileWidth = this.getTileSize(level);
+        tileHeight = this.getTileHeight(level);
+        iiifTileSizeWidth = Math.ceil( tileWidth / scale );
+        iiifTileSizeHeight = Math.ceil( tileHeight / scale );
 
         if ( this['@context'].indexOf('/1.0/context.json') > -1 ||
              this['@context'].indexOf('/1.1/context.json') > -1 ||
@@ -240,7 +257,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifQuality = "default.jpg";
         }
 
-        if ( levelWidth < tileSize && levelHeight < tileSize ){
+        if ( levelWidth < tileWidth && levelHeight < tileHeight ){
             iiifSize = levelWidth + ",";
             iiifRegion = 'full';
         } else {

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -192,7 +192,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         if (this.tileSizePerScaleFactor && this.tileSizePerScaleFactor[scaleFactor]) {
             this.tileSize = this.tileSizePerScaleFactor[scaleFactor];
         }
-        return this.tileSize;
+        return new $.Point(this.tileSize, this.tileSize);
     },
 
     /**
@@ -229,8 +229,9 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             uri;
 
         tileSize = this.getTileSize(level);
-        iiifTileSizeWidth = Math.ceil( tileSize / scale );
-        iiifTileSizeHeight = iiifTileSizeWidth;
+
+        iiifTileSizeWidth = Math.ceil( tileSize.x / scale );
+        iiifTileSizeHeight = Math.ceil( tileSize.y / scale );
 
         if ( this['@context'].indexOf('/1.0/context.json') > -1 ||
              this['@context'].indexOf('/1.1/context.json') > -1 ||
@@ -240,7 +241,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifQuality = "default.jpg";
         }
 
-        if ( levelWidth < tileSize && levelHeight < tileSize ){
+        if ( levelWidth < tileSize.x && levelHeight < tileSize.y ){
             iiifSize = levelWidth + ",";
             iiifRegion = 'full';
         } else {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1036,7 +1036,7 @@ function onTileLoad( tiledImage, tile, time, image ) {
 
     var finish = function() {
         var cutoff = Math.ceil( Math.log(
-            tiledImage.source.getTileSize(tile.level).x ) / Math.log( 2 ) );
+            tiledImage.source.getTileWidth(tile.level) ) / Math.log( 2 ) );
         setTileLoaded(tiledImage, tile, image, cutoff);
     };
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1036,7 +1036,7 @@ function onTileLoad( tiledImage, tile, time, image ) {
 
     var finish = function() {
         var cutoff = Math.ceil( Math.log(
-            tiledImage.source.getTileSize(tile.level) ) / Math.log( 2 ) );
+            tiledImage.source.getTileSize(tile.level).x ) / Math.log( 2 ) );
         setTileLoaded(tiledImage, tile, image, cutoff);
     };
 

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -146,7 +146,7 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
      * The size of the image tiles used to compose the image.
      * Please note that tileSize may be deprecated in a future release.
      * Instead the getTileSize(level) function should be used.
-     * @member {Number} tileSize
+     * @member {OpenSeadragon.Point} tileSize
      * @memberof OpenSeadragon.TileSource#
      */
     /**
@@ -179,7 +179,7 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
         //async mechanism set some safe defaults first
         this.aspectRatio = 1;
         this.dimensions  = new $.Point( 10, 10 );
-        this.tileSize    = 0;
+        this.tileSize    = new $.Point( 0, 0 );
         this.tileOverlap = 0;
         this.minLevel    = 0;
         this.maxLevel    = 0;
@@ -196,10 +196,16 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
         this.aspectRatio = ( options.width && options.height ) ?
             (  options.width / options.height ) : 1;
         this.dimensions  = new $.Point( options.width, options.height );
-        this.tileSize = new $.Point(
-            ( options.tileSize ? options.tileSize : options.tileWidth ),
-            ( options.tileSize ? options.tileSize : options.tileHeight )
-        );
+        
+        if( options.tileSize ){
+            this.tileSize = new $.Point(options.tileSize, options.tileSize);
+        } else {
+            this.tileSize = new $.Point(
+                (options.tileWidth ? options.tileWidth : 0),
+                (options.tileHeight ? options.tileHeight : 0)
+            );
+        }
+
         this.tileOverlap = options.tileOverlap ? options.tileOverlap : 0;
         this.minLevel    = options.minLevel ? options.minLevel : 0;
         this.maxLevel    = ( undefined !== options.maxLevel && null !== options.maxLevel ) ?

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -191,11 +191,26 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
             (  options.width / options.height ) : 1;
         this.dimensions  = new $.Point( options.width, options.height );
         
-        if ( options.tileSize ){
-            this._tileWidth = this._tileHeight = options.tileSize;
+        if ( this.tileSize ){
+            this._tileWidth = this._tileHeight = this.tileSize;
+            delete this.tileSize;
         } else {
-            this._tileWidth = options.tileWidth ? options.tileWidth : 0;
-            this._tileHeight = options.tileHeight ? options.tileHeight: 0;
+            if( this.tileWidth ){
+                // We were passed tileWidth in options, but we want to rename it
+                // with a leading underscore to make clear that it is not safe to directly modify it
+                this._tileWidth = this.tileWidth;
+                delete this.tileWidth;
+            } else {
+                this._tileWidth = 0;
+            }
+
+            if( this.tileHeight ){
+                // See note above about renaming this.tileWidth
+                this._tileHeight = this.tileHeight;
+                delete this.tileHeight;
+            } else {
+                this._tileHeight = 0;
+            }
         }
         
         this.tileOverlap = options.tileOverlap ? options.tileOverlap : 0;
@@ -230,7 +245,7 @@ $.TileSource.prototype = /** @lends OpenSeadragon.TileSource.prototype */{
      * Return the tileWidth for a given level.
      * Subclasses should override this if tileWidth can be different at different levels
      *   such as in IIIFTileSource.  Code should use this function rather than reading
-     *   from .tileWidth directly.
+     *   from ._tileWidth directly.
      * @function
      * @param {Number} level
      */
@@ -245,7 +260,7 @@ $.TileSource.prototype = /** @lends OpenSeadragon.TileSource.prototype */{
      * Return the tileHeight for a given level.
      * Subclasses should override this if tileHeight can be different at different levels
      *   such as in IIIFTileSource.  Code should use this function rather than reading
-     *   from .tileHeight directly.
+     *   from ._tileHeight directly.
      * @function
      * @param {Number} level
      */

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -143,13 +143,6 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
      * @memberof OpenSeadragon.TileSource#
      */
     /**
-     * The size of the image tiles used to compose the image.
-     * Please note that tileSize may be deprecated in a future release.
-     * Instead the getTileSize(level) function should be used.
-     * @member {Number} tileSize
-     * @memberof OpenSeadragon.TileSource#
-     */
-    /**
      * The overlap in pixels each tile shares with its adjacent neighbors.
      * @member {Number} tileOverlap
      * @memberof OpenSeadragon.TileSource#
@@ -179,7 +172,8 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
         //async mechanism set some safe defaults first
         this.aspectRatio = 1;
         this.dimensions  = new $.Point( 10, 10 );
-        this.tileSize    = 0;
+        this._tileWidth  = 0;
+        this._tileHeight = 0;
         this.tileOverlap = 0;
         this.minLevel    = 0;
         this.maxLevel    = 0;
@@ -197,9 +191,12 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
             (  options.width / options.height ) : 1;
         this.dimensions  = new $.Point( options.width, options.height );
         
-        this.tileSize = options.tileSize ? options.tileSize : 0;
-        this.tileWidth = options.tileWidth;
-        this.tileHeight = options.tileHeight;
+        if ( options.tileSize ){
+            this._tileWidth = this._tileHeight = options.tileSize;
+        } else {
+            this._tileWidth = options.tileWidth ? options.tileWidth : 0;
+            this._tileHeight = options.tileHeight ? options.tileHeight: 0;
+        }
         
         this.tileOverlap = options.tileOverlap ? options.tileOverlap : 0;
         this.minLevel    = options.minLevel ? options.minLevel : 0;
@@ -221,21 +218,12 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
 
 $.TileSource.prototype = /** @lends OpenSeadragon.TileSource.prototype */{
 
-    /**
-     * Return the tileSize for a given level.
-     * Subclasses should override this if tileSizes can be different at different levels
-     *   such as in IIIFTileSource.  Code should use this function rather than reading
-     *   from .tileSize directly.  tileSize may be deprecated in a future release.
-     * @deprecated
-     * @function
-     * @param {Number} level
-     */
     getTileSize: function( level ) {
         $.console.error(
             "[TileSource.getTileSize] is deprecated." +
             "Use TileSource.getTileWidth() and TileSource.getTileHeight() instead"
         );
-        return this.tileSize;
+        return this._tileWidth;
     },
     
     /**
@@ -247,11 +235,10 @@ $.TileSource.prototype = /** @lends OpenSeadragon.TileSource.prototype */{
      * @param {Number} level
      */
     getTileWidth: function( level ) {
-        // If tileWidth was not set, fallback by setting it to tileSize
-        if( this.tileWidth === undefined){
-            this.tileWidth = this.tileSize;
+        if (!this._tileWidth) {
+            return this.getTileSize(level);
         }
-        return this.tileWidth;
+        return this._tileWidth;
     },
 
     /**
@@ -263,11 +250,10 @@ $.TileSource.prototype = /** @lends OpenSeadragon.TileSource.prototype */{
      * @param {Number} level
      */
     getTileHeight: function( level ) {
-        // If tileHeight was not set, fallback by setting it to tileSize
-        if( this.tileHeight === undefined ){
-            this.tileHeight = this.tileSize;
+        if (!this._tileHeight) {
+            return this.getTileSize(level);
         }
-        return this.tileHeight;
+        return this._tileHeight;
     },
 
     /**

--- a/test/modules/tilesource.js
+++ b/test/modules/tilesource.js
@@ -1,0 +1,51 @@
+/* global module, ok, equal, start, test, testLog, Util */
+(function() {
+    
+    module('TileSource', {
+        setup: function() {
+            testLog.reset();
+        }
+    });
+    
+    
+    test("should set sane tile size defaults", function() {
+        var source = new OpenSeadragon.TileSource();
+        
+        equal(source.getTileWidth(), 0, "getTileWidth() should return 0 if not provided a size");
+        equal(source.getTileHeight(), 0, "getTileHeight() should return 0 if not provided a size");
+    });
+    
+    test("providing tileSize", function(){
+        var tileSize = 256,
+            source = new OpenSeadragon.TileSource({
+                tileSize: tileSize
+            });
+        
+        equal(source.tileSize, undefined, "tileSize should not be set on the tileSource");
+        equal(source.getTileWidth(), tileSize, "getTileWidth() should equal tileSize");
+        equal(source.getTileHeight(), tileSize, "getTileHeight() should equal tileSize");
+    });
+    
+    
+    test("providing tileWidth and tileHeight", function(){
+        var tileWidth = 256,
+            tileHeight = 512,
+            source = new OpenSeadragon.TileSource({
+                tileWidth: tileWidth,
+                tileHeight: tileHeight
+            });
+        
+        equal(source._tileWidth, tileWidth, "tileWidth option should set _tileWidth");
+        equal(source._tileHeight, tileHeight, "tileHeight option should set _tileHeight");
+        equal(source.tileWidth, undefined, "tileWidth should be renamed _tileWidth");
+        equal(source.tileHeight, undefined, "tileHeight should be renamed _tileHeight");
+        equal(source.getTileWidth(), tileWidth, "getTileWidth() should equal tileWidth");
+        equal(source.getTileHeight(), tileHeight, "getTileHeight() should equal tileHeight");
+    });
+    
+    test('getTileSize() deprecation', function() {
+        var source = new OpenSeadragon.TileSource();
+        Util.testDeprecation(source, 'getTileSize');
+    });
+
+}());

--- a/test/test.html
+++ b/test/test.html
@@ -36,6 +36,7 @@
     <script src="/test/modules/tiledimage.js"></script>
     <script src="/test/modules/tilecache.js"></script>
     <script src="/test/modules/referencestrip.js"></script>
+    <script src="/test/modules/tilesource.js"></script>
     <script src="/test/modules/tilesourcecollection.js"></script>
     <script src="/test/modules/spring.js"></script>
     <!-- The navigator tests are the slowest (for now; hopefully they can be sped up)


### PR DESCRIPTION
- This resolves #670 
- Custom tile sources options may now include tileSize for square tiles, or tileWidth and tileHeight for non-square tiles. 
- Add TileSource.getTileWidth() and TileSource.getTileHeight(). 
- Deprecate TileSource.getTileSize()

Example OSD viewer instance using non-square tiles via new tileWidth and tileHeight options. 
![OSD-non-square-tiles](https://cloud.githubusercontent.com/assets/597044/8386821/644bc430-1c21-11e5-84ee-9134ccd5b609.PNG)
