### PR TITLE
Added XDomainRequest as fallback method for ajax, if XMLHttpRequest f…

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2056,7 +2056,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
                                     statusText: 'OK'
                                 });
                             }
-                        }
+                        };
                         xdr.onerror = function (e) {
                             if ( $.isFunction ( onError ) ) {
                                 onError({ // Faking an xhr object
@@ -2065,7 +2065,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
                                     statusText: 'An error happened. Due to an XDomainRequest deficiency we can not extract any information about this error. Upgrade your browser.'
                                 });
                             }
-                        }
+                        };
                         try {
                             xdr.open('GET', url);
                             xdr.send();

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2045,8 +2045,40 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
 
                 request.onreadystatechange = function(){};
 
-                if ( $.isFunction( onError ) ) {
-                    onError( request, e );
+                if (window.XDomainRequest) { // IE9 or IE8 might as well try to use XDomainRequest
+                    var xdr = new XDomainRequest();
+                    if (xdr) {
+                        xdr.onload = function (e) {
+                            if ( $.isFunction( onSuccess ) ) {
+                                onSuccess({ // Faking an xhr object
+                                    responseText: xdr.responseText,
+                                    status: 200, // XDomainRequest doesn't support status codes, so we just fake one! :/
+                                    statusText: 'OK'
+                                });
+                            }
+                        }
+                        xdr.onerror = function (e) {
+                            if ( $.isFunction ( onError ) ) {
+                                onError({ // Faking an xhr object
+                                    responseText: xdr.responseText,
+                                    status: 444, // 444 No Response
+                                    statusText: 'An error happened. Due to an XDomainRequest deficiency we can not extract any information about this error. Upgrade your browser.'
+                                });
+                            }
+                        }
+                        try {
+                            xdr.open('GET', url);
+                            xdr.send();
+                        } catch (e) {
+                            if ( $.isFunction( onError ) ) {
+                                onError( request, e );
+                            }
+                        }
+                    }
+                } else {
+                    if ( $.isFunction( onError ) ) {
+                        onError( request, e );
+                    }
                 }
             }
         },

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2069,7 +2069,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
                         try {
                             xdr.open('GET', url);
                             xdr.send();
-                        } catch (e) {
+                        } catch (e2) {
                             if ( $.isFunction( onError ) ) {
                                 onError( request, e );
                             }


### PR DESCRIPTION
Added XDomainRequest as fallback method for ajax requests, if XMLHttpRequest fails.

< IE10 fails because of lacking CORS abilities. Instead of just posting an error message, I am trying out XDomainRequest as a fallback. If it works, I just mimic an xhr object. It's butt ugly, dirty and might imply some terrible maintainability issues. However it does work at the moment, and I thought I would share it with the world, given that I might not be the only one forced to deal with older ie browsers.

After adding this hack, I believe the second example in [IIIF Tile Source](http://openseadragon.github.io/examples/tilesource-iiif/) should work also in < ie10

The notice to developers is still printed out in the console, even if XDomainRequest fixes the json load.