### PR TITLE
Added api for replacing the source of a tiledImage.

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -536,6 +536,22 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     },
 
     /**
+     * Resets tiledImage's aspect ratio and height or width, while maintaining the size of the largest of the original dimensions
+     * @param {OpenSeadragon.Size} dimensions - The new dimensions from which to calculate the aspect ratio
+     * @fires OpenSeadragon.TiledImage.event:bounds-change
+     */
+    resetAspect: function(dimensions) {
+        var scale = this._scaleSpring.current.value;
+
+        this.normHeight = dimensions.y / dimensions.x;
+        this.contentAspectX = dimensions.x / dimensions.y;
+        if (this.normHeight > 1) {
+            scale /= this.normHeight;
+        }
+        this._setScale(scale, true, true);
+    },
+
+    /**
      * @returns {OpenSeadragon.Rect|null} The TiledImage's current clip rectangle,
      * in image pixels, or null if none.
      */
@@ -581,17 +597,17 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     },
 
     // private
-    _setScale: function(scale, immediately) {
+    _setScale: function(scale, immediately, force) {
         var sameTarget = (this._scaleSpring.target.value === scale);
         if (immediately) {
-            if (sameTarget && this._scaleSpring.current.value === scale) {
+            if (sameTarget && this._scaleSpring.current.value === scale && !force) {
                 return;
             }
 
             this._scaleSpring.resetTo(scale);
             this._updateForScale();
         } else {
-            if (sameTarget) {
+            if (sameTarget && !force) {
                 return;
             }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1350,6 +1350,33 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         } );
     },
 
+    /**
+     * Loads and draws the TiledImage from a new tileSource.
+     * @param {$.Tile} {String|Object|Function} options.tileSource - The TileSource specifier. See Viewer.addTiledImage() documentation
+     * @param {Function} [options.success] A function that gets called when the tileSource is successfully replaced. It's passed the
+     * event object which contains a single property: "item", the resulting TiledImage.
+     * @param {Function} [options.error] A function that gets called if the tileSource replacement fails. It's passed the error event
+     * object, which contains "message" and "source" properties.
+     */
+    replaceTiledImageSource: function(item, options) {
+        $.console.assert(options, "[Viewer.replaceTiledImageSource] options is required");
+        $.console.assert(options.tileSource, "[Viewer.replaceTiledImageSource] options.tileSource is required");
+
+        var _this = this;
+        getTileSourceImplementation(_this, options.tileSource, function(tileSource) {
+            item.source = tileSource;
+            item.resetAspect(tileSource.dimensions);
+            item.reset();
+            if (options.success) {
+                options.success({item: item});
+            }
+        }, function(event) {
+            if (options.error) {
+                options.error(event);
+            }
+        });
+    },
+
     // deprecated
     addLayer: function( options ) {
         var _this = this;


### PR DESCRIPTION
This allows for smoothly swapping out the image of an item in the world, without having to remove it from the world and re-add it with a new tileSource.