### PR TITLE
Added autoRefigureSizes flag for disabling calls to _figureSizes …

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -283,10 +283,10 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
 
     /**
      * As a performance optimization, setting this flag to false allows the bounds-change event handler
-     * on tiledImages to skip calls to _figureSizes. If a lot of images are going to be positioned in
-     * rapid succession, this is a good idea. _autoRefigureSizes should be set back to true when finished,
-     * or the system may behave oddly,
-     * @param {Boolean} [value] The value to which to set autoRefigureSizes.
+     * on tiledImages to skip calculations on the world bounds. If a lot of images are going to be positioned in
+     * rapid succession, this is a good idea. When finished, setAutoRefigureSizes should be called with true
+     * or the system may behave oddly.
+     * @param {Boolean} [value] The value to which to set the flag.
      */
     setAutoRefigureSizes: function(value) {
         this._autoRefigureSizes = value;

--- a/src/world.js
+++ b/src/world.js
@@ -52,8 +52,11 @@ $.World = function( options ) {
     this.viewer = options.viewer;
     this._items = [];
     this._needsDraw = false;
+    this._autoRefigureSizes = true;
     this._delegatedFigureSizes = function(event) {
-        _this._figureSizes();
+        if (this._autoRefigureSizes) {
+            _this._figureSizes();
+        }
     };
 
     this._figureSizes();
@@ -276,6 +279,17 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
     },
 
     /**
+     * As a performance optimization, setting this flag to false allows the bounds-change event handler
+     * on tiledImages to skip calls to _figureSizes. If a lot of images are going to be positioned in
+     * rapid succession, this is a good idea. _figuresSizes only needs to be called once when the
+     * positioning is done.
+     * @param {Boolean} [value] The value to which to set autoRefigureSizes.
+     */
+    setAutoRefigureSizes: function(value) {
+        this._autoRefigureSizes = value;
+    },
+
+    /**
      * Arranges all of the TiledImages with the specified settings.
      * @param {Object} options - Specifies how to arrange.
      * @param {Boolean} [options.immediately=false] - Whether to animate to the new arrangement.
@@ -304,6 +318,8 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
         var x = 0;
         var y = 0;
         var item, box, width, height, position;
+
+        this.setAutoRefigureSizes(false);
         for (var i = 0; i < this._items.length; i++) {
             if (i && (i % wrap) === 0) {
                 if (layout === 'horizontal') {
@@ -336,6 +352,8 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
                 y += increment;
             }
         }
+        this.setAutoRefigureSizes(true);
+        this._figureSizes();
     },
 
     // private

--- a/src/world.js
+++ b/src/world.js
@@ -54,7 +54,7 @@ $.World = function( options ) {
     this._needsDraw = false;
     this._autoRefigureSizes = true;
     this._delegatedFigureSizes = function(event) {
-        if (this._autoRefigureSizes) {
+        if (_this._autoRefigureSizes) {
             _this._figureSizes();
         }
     };
@@ -282,7 +282,8 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
      * As a performance optimization, setting this flag to false allows the bounds-change event handler
      * on tiledImages to skip calls to _figureSizes. If a lot of images are going to be positioned in
      * rapid succession, this is a good idea. _figuresSizes only needs to be called once when the
-     * positioning is done.
+     * positioning is done. _autoRefigureSizes should be set back to true when finished, or the system
+     * may behave oddly,
      * @param {Boolean} [value] The value to which to set autoRefigureSizes.
      */
     setAutoRefigureSizes: function(value) {

--- a/src/world.js
+++ b/src/world.js
@@ -53,9 +53,12 @@ $.World = function( options ) {
     this._items = [];
     this._needsDraw = false;
     this._autoRefigureSizes = true;
+    this._needsSizesFigured = false;
     this._delegatedFigureSizes = function(event) {
         if (_this._autoRefigureSizes) {
             _this._figureSizes();
+        } else {
+            _this._needsSizesFigured = true;
         }
     };
 
@@ -281,13 +284,16 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
     /**
      * As a performance optimization, setting this flag to false allows the bounds-change event handler
      * on tiledImages to skip calls to _figureSizes. If a lot of images are going to be positioned in
-     * rapid succession, this is a good idea. _figuresSizes only needs to be called once when the
-     * positioning is done. _autoRefigureSizes should be set back to true when finished, or the system
-     * may behave oddly,
+     * rapid succession, this is a good idea. _autoRefigureSizes should be set back to true when finished,
+     * or the system may behave oddly,
      * @param {Boolean} [value] The value to which to set autoRefigureSizes.
      */
     setAutoRefigureSizes: function(value) {
         this._autoRefigureSizes = value;
+        if (value & this._needsSizesFigured) {
+            this._figureSizes();
+            this._needsSizesFigured = false;
+        }
     },
 
     /**
@@ -354,7 +360,6 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
             }
         }
         this.setAutoRefigureSizes(true);
-        this._figureSizes();
     },
 
     // private


### PR DESCRIPTION
…during bounds-change event handlers. This improves performance when a lot of bounds-change events are fired in quick succession. Used flag to optimize world._arrange.