### PR TITLE
registers an AMD module if possible

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,7 @@
   "unused": false,
 
   "globals": {
-    "OpenSeadragon": true
+    "OpenSeadragon": true,
+    "define": false
   }
 }

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -682,10 +682,14 @@
   * @returns {OpenSeadragon.Viewer}
   */
 window.OpenSeadragon = window.OpenSeadragon || function( options ){
-
     return new OpenSeadragon.Viewer( options );
-
 };
+
+if (typeof define === 'function' && define.amd) {
+   define(function () {
+       return (window.OpenSeadragon);
+   });
+}
 
 
 (function( $ ){

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -682,7 +682,9 @@
   * @returns {OpenSeadragon.Viewer}
   */
 window.OpenSeadragon = window.OpenSeadragon || function( options ){
+
     return new OpenSeadragon.Viewer( options );
+
 };
 
 if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Sets it as an AMD module with no deps if required, apart from setting the global object.

This is a small fix. It tries not to change too much how things work in terms of modules or the build process. I guess bigger changes could be made, if the project wants to take that route.

cheers! - fixes #691
