### PR TITLE
Added 'tile-load-failed' event

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1030,11 +1030,11 @@ function onTileLoad( tiledImage, tile, time, image, errorMsg ) {
          * @memberof OpenSeadragon.Viewer
          * @type {object}
          * @property {OpenSeadragon.TiledImage} tiledImage - The tiled image of the unloaded tile.
-         * @property {OpenSeadragon.Tile} tile - The tile which has been unloaded.
-         * @property {number} time - The current time in milliseconds when the tile load began.
+         * @property {OpenSeadragon.Tile} tile - The tile that failed to load.
+         * @property {number} time - The time in milliseconds when the tile load began.
          * @property {string} message - The error message.
          */
-        tiledImage.viewer.raiseEvent("tile-open-failed", {tile: tile, tiledImage: tiledImage, time: time, message: errorMsg});
+        tiledImage.viewer.raiseEvent("tile-load-failed", {tile: tile, tiledImage: tiledImage, time: time, message: errorMsg});
         if( !tiledImage.debugMode ){
             tile.loading = false;
             tile.exists = false;

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1023,6 +1023,18 @@ function loadTile( tiledImage, tile, time ) {
 function onTileLoad( tiledImage, tile, time, image, errorMsg ) {
     if ( !image ) {
         $.console.log( "Tile %s failed to load: %s - error: %s", tile, tile.url, errorMsg );
+        /**
+         * Triggered when a tile fails to load.
+         *
+         * @event tile-open-failed
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.TiledImage} tiledImage - The tiled image of the unloaded tile.
+         * @property {OpenSeadragon.Tile} tile - The tile which has been unloaded.
+         * @property {number} time - The current time in milliseconds when the tile load began.
+         * @property {string} message - The error message.
+         */
+        tiledImage.viewer.raiseEvent("tile-open-failed", {tile: tile, tiledImage: tiledImage, time: time, message: errorMsg});
         if( !tiledImage.debugMode ){
             tile.loading = false;
             tile.exists = false;


### PR DESCRIPTION
Added 'tile-load-failed' event to notify the app when a tile fails to load.
This can happen when the image has authentication or other restrictions.
This is extra helpful when using a 'legacy-image' source type (e.g. thumbnails, etc.)