### PR TITLE
Fix for issue with tiledImages loading tiles at every level instead of just the best level: 

### DIFF
--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -332,7 +332,7 @@ $.TileSource.prototype = /** @lends OpenSeadragon.TileSource.prototype */{
               Math.floor( rect.y / this.getTileHeight(i) )
             );
             
-            if( tiles.x + 1 >= tilesPerSide.x || tiles.y + 1 >= tilesPerSide.y ){
+            if( tiles.x + 1 >= tilesPerSide.x && tiles.y + 1 >= tilesPerSide.y ){
                 break;
             }
         }


### PR DESCRIPTION
using && instead of || means the tiledImage's longest side is used for comparison instead of the shortest side.