### PR TITLE
Added cancel pending images to world.removeAll

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1243,7 +1243,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         };
 
         function raiseAddItemFailed( event ) {
-            for (var i = 0; i < _this._loadQueue; i++) {
+            for (var i = 0; i < _this._loadQueue.length; i++) {
                 if (_this._loadQueue[i] === myQueueItem) {
                     _this._loadQueue.splice(i, 1);
                     break;
@@ -1982,6 +1982,13 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         for ( i = 0; i < length; i++ ) {
             this.currentOverlays[ i ].drawHTML( this.overlaysContainer, this.viewport );
         }
+    },
+
+    /**
+     * Cancel the "in flight" images.
+     */
+    _cancelPendingImages: function() {
+        this._loadQueue = [];
     }
 });
 

--- a/src/world.js
+++ b/src/world.js
@@ -202,6 +202,8 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
      * @fires OpenSeadragon.World.event:metrics-change
      */
     removeAll: function() {
+        // We need to make sure any pending images are canceled so the world items don't get messed up
+        this.viewer._cancelPendingImages();
         var item;
         for (var i = 0; i < this._items.length; i++) {
             item = this._items[i];


### PR DESCRIPTION
Fixed problem with missing .length in for loop of raiseAddItemFailed event.
Added viewer._cancelPendingImages method that clears the loadQueue.
Added call to _cancelPendingImages from within the world.removeAll method.

Should also fix: https://github.com/openseadragon/openseadragon/issues/629