### PR TITLE
Optimized adding large numbers of items to the world.

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1250,6 +1250,10 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                 }
             }
 
+            if (_this._loadQueue.length === 0) {
+                refreshWorld(myQueueItem);
+            }
+
              /**
              * Raised when an error occurs while adding a item.
              * @event add-item-failed
@@ -1265,6 +1269,19 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
             if (options.error) {
                 options.error(event);
+            }
+        }
+
+        function refreshWorld(theItem) {
+            if (_this.collectionMode) {
+                _this.world.arrange({
+                    immediately: theItem.options.collectionImmediately,
+                    rows: _this.collectionRows,
+                    columns: _this.collectionColumns,
+                    layout: _this.collectionLayout,
+                    tileSize: _this.collectionTileSize,
+                    tileMargin: _this.collectionTileMargin
+                });
             }
         }
 
@@ -1328,19 +1345,16 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     debugMode: _this.debugMode
                 });
 
+                if (_this.collectionMode) {
+                    _this.world.setAutoRefigureSizes(false);
+                }
                 _this.world.addItem( tiledImage, {
                     index: queueItem.options.index
                 });
 
-                if (_this.collectionMode) {
-                    _this.world.arrange({
-                        immediately: queueItem.options.collectionImmediately,
-                        rows: _this.collectionRows,
-                        columns: _this.collectionColumns,
-                        layout: _this.collectionLayout,
-                        tileSize: _this.collectionTileSize,
-                        tileMargin: _this.collectionTileMargin
-                    });
+                if (_this._loadQueue.length === 0) {
+                    //this restores the autoRefigureSizes flag to true.
+                    refreshWorld(queueItem);
                 }
 
                 if (_this.world.getItemCount() === 1 && !_this.preserveViewport) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1282,6 +1282,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     tileSize: _this.collectionTileSize,
                     tileMargin: _this.collectionTileMargin
                 });
+                _this.world.setAutoRefigureSizes(true);
             }
         }
 

--- a/src/world.js
+++ b/src/world.js
@@ -85,7 +85,12 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
             this._items.push( item );
         }
 
-        this._figureSizes();
+        if (this._autoRefigureSizes) {
+            this._figureSizes();
+        } else {
+            this._needsSizesFigured = true;
+        }
+
         this._needsDraw = true;
 
         item.addHandler('bounds-change', this._delegatedFigureSizes);


### PR DESCRIPTION
These are more optimizations based on the idea of avoiding recalculating the world bounds until necessary with massive boasts to the performance of adding large numbers of items. (My tests showed a 3/4 reduction of the time it takes to add 2000 items). First, it sets autoRefigureSizes to false to cancel the world bounds calculation in world.addItem. Second, it only calls world.arrange at the end of each loadQueue.

I see that this could cause a loss of information about the items being arranged, but the only existing option that would be affected is collectionImmediately, and only if different values are set on items within the same loadQueue. I don't know if it was meant to support mixing up animating and snapping images into position because it didn't appear to work even before my changes, but if this seems like a thing we should support, I can look into ways to track that information.