### PR TITLE
Fixed issue in iOS devices that would cause all touch events to fail …

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2190,16 +2190,10 @@
     function onTouchCancel( tracker, event ) {
         var i,
             touchCount = event.changedTouches.length,
-            gPoints = [];
-
-        for ( i = 0; i < touchCount; i++ ) {
-            gPoints.push( {
-                id: event.changedTouches[ i ].identifier,
-                type: 'touch'
-            } );
-        }
-
-        updatePointersCancel( tracker, event, gPoints );
+            gPoints = [],
+            pointsList = tracker.getActivePointersListByType( 'touch' );
+        
+        abortTouchContacts( tracker, event, pointsList );
     }
 
 


### PR DESCRIPTION
…after a Multitasking Gesture was triggered. The fix works by aborting all touch contacts after a touch has been cancelled. 

The bug would occur in iOS when switching from Safari to another App by using a four finger multitasking gesture, while pinching on an openseadragon instance.
