### PR TITLE
Added a patch to help slow down the scroll devices that fire too fast…

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -255,7 +255,7 @@
   * @property {Boolean} [preserveImageSizeOnResize=false]
   *     Set to true to have the image size preserved when the viewer is resized. This requires autoResize=true (default).
   *
-  * @property {Number} [minScrollDeltaMS=3]
+  * @property {Number} [minScrollDeltaTime=50]
   *     Number of milliseconds between canvas-scroll events. This value helps normalize the rate of canvas-scroll
   *     events between different devices, causing the faster devices to slow down enough to make the zoom control
   *     more manageable.
@@ -1008,7 +1008,7 @@ if (typeof define === 'function' && define.amd) {
             pixelsPerWheelLine:     40,
             autoResize:             true,
             preserveImageSizeOnResize: false, // requires autoResize=true
-            minScrollDeltaMS:         3,
+            minScrollDeltaTime:     50,
 
             //DEFAULT CONTROL SETTINGS
             showSequenceControl:     true,  //SEQUENCE

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -255,6 +255,11 @@
   * @property {Boolean} [preserveImageSizeOnResize=false]
   *     Set to true to have the image size preserved when the viewer is resized. This requires autoResize=true (default).
   *
+  * @property {Number} [minScrollDelta=3]
+  *     Number of milliseconds between canvas-scroll events. This value helps normalize the rate of canvas-scroll
+  *     events between different devices, causing the faster devices to slow down enough to make the zoom control
+  *     more manageable.
+  *
   * @property {Number} [pixelsPerWheelLine=40]
   *     For pixel-resolution scrolling devices, the number of pixels equal to one scroll line.
   *
@@ -1003,6 +1008,7 @@ if (typeof define === 'function' && define.amd) {
             pixelsPerWheelLine:     40,
             autoResize:             true,
             preserveImageSizeOnResize: false, // requires autoResize=true
+            minScrollDelta:         3,
 
             //DEFAULT CONTROL SETTINGS
             showSequenceControl:     true,  //SEQUENCE

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -255,7 +255,7 @@
   * @property {Boolean} [preserveImageSizeOnResize=false]
   *     Set to true to have the image size preserved when the viewer is resized. This requires autoResize=true (default).
   *
-  * @property {Number} [minScrollDelta=3]
+  * @property {Number} [minScrollDeltaMS=3]
   *     Number of milliseconds between canvas-scroll events. This value helps normalize the rate of canvas-scroll
   *     events between different devices, causing the faster devices to slow down enough to make the zoom control
   *     more manageable.
@@ -1008,7 +1008,7 @@ if (typeof define === 'function' && define.amd) {
             pixelsPerWheelLine:     40,
             autoResize:             true,
             preserveImageSizeOnResize: false, // requires autoResize=true
-            minScrollDelta:         3,
+            minScrollDeltaMS:         3,
 
             //DEFAULT CONTROL SETTINGS
             showSequenceControl:     true,  //SEQUENCE

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2783,11 +2783,13 @@ function onCanvasScroll( event ) {
             shift: event.shift,
             originalEvent: event.originalEvent
         });
+        if (gestureSettings && gestureSettings.scrollToZoom) {
+            //cancels event
+            return false;
+        }
     }
-
-    if (gestureSettings && gestureSettings.scrollToZoom) {
-        //cancels event
-        return false;
+    else {
+        return false;   // We are swallowing this event
     }
 }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2747,7 +2747,7 @@ function onCanvasScroll( event ) {
      * this one and wait for the next event. */
     thisScroll = new Date().getTime();
     deltaScroll = thisScroll - lastScroll;
-    if (deltaScroll > this.minScrollDelta) {
+    if (deltaScroll > this.minScrollDeltaMS) {
         lastScroll = thisScroll;
 
         if ( !event.preventDefaultAction && this.viewport ) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -203,6 +203,8 @@ $.Viewer = function( options ) {
     this._loadQueue = [];
     this.currentOverlays = [];
 
+    this._lastScrollTime = $.now(); // variable used to help normalize the scroll event speed of different devices
+
     //Inherit some behaviors and properties
     $.EventSource.call( this );
 
@@ -2735,20 +2737,19 @@ function onCanvasPinch( event ) {
     return false;
 }
 
-var lastScroll = new Date().getTime();
 function onCanvasScroll( event ) {
     var gestureSettings,
         factor,
-        thisScroll,
-        deltaScroll;
+        thisScrollTime,
+        deltaScrollTime;
 
     /* Certain scroll devices fire the scroll event way too fast so we are injecting a simple adjustment to keep things
      * partially normalized. If we have already fired an event within the last 'minScrollDelta' milliseconds we skip
      * this one and wait for the next event. */
-    thisScroll = new Date().getTime();
-    deltaScroll = thisScroll - lastScroll;
-    if (deltaScroll > this.minScrollDeltaMS) {
-        lastScroll = thisScroll;
+    thisScrollTime = $.now();
+    deltaScrollTime = thisScrollTime - this._lastScrollTime;
+    if (deltaScrollTime > this.minScrollDeltaTime) {
+        this._lastScrollTime = thisScrollTime;
 
         if ( !event.preventDefaultAction && this.viewport ) {
             gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );


### PR DESCRIPTION
…. This new code reduces the number of 'canvas-scroll' events that fire and slows down the zoom process.

This should help resolve issue: https://github.com/openseadragon/openseadragon/issues/470
attn: @iangilman - I hope this is what you expected.