### PR TITLE
Fixed zooming in with plus key on a swedish keyboard.

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2293,6 +2293,7 @@ function onCanvasKeyDown( event ) {
 function onCanvasKeyPress( event ) {
     if ( !event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
         switch( event.keyCode ){
+            case 43://=|+
             case 61://=|+
                 this.viewport.zoomBy(1.1);
                 this.viewport.applyConstraints();


### PR DESCRIPTION
Hi!

This patch fixes zooming in with both the plus keys on a swedish keyboard. Not really sure why the keycode is different.