### PR TITLE
Partial fix for drag release outside an iframe

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1367,7 +1367,7 @@
                 eventParams = getCaptureEventParams( tracker, $.MouseTracker.havePointerEvents ? 'pointerevent' : pointerType );
                 // We emulate mouse capture by hanging listeners on the document object.
                 //    (Note we listen on the capture phase so the captured handlers will get called first)
-                if (isInIframe() && canAccessEvents(window.top)) {
+                if (isInIframe && canAccessEvents(window.top)) {
                     $.addEvent(
                         window.top,
                         eventParams.upName,
@@ -1410,7 +1410,7 @@
                 eventParams = getCaptureEventParams( tracker, $.MouseTracker.havePointerEvents ? 'pointerevent' : pointerType );
                 // We emulate mouse capture by hanging listeners on the document object.
                 //    (Note we listen on the capture phase so the captured handlers will get called first)
-                if (isInIframe() && canAccessEvents(window.top)) {
+                if (isInIframe && canAccessEvents(window.top)) {
                     $.removeEvent(
                         window.top,
                         eventParams.upName,
@@ -3266,19 +3266,19 @@
     }
     
     /**
-     * @function
+     * True if inside an iframe, otherwise false.
+     * @member {Boolean} isInIframe
      * @private
      * @inner
-     * @returns {Boolean} True if inside an iframe, otherwise false.
      */
-    function isInIframe () {
+    var isInIframe = (function() {
         try {
             return window.self !== window.top;
         } catch (e) {
             return true;
         }
-    }
-    
+    })();
+ 
     /**
      * @function
      * @private

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -3265,12 +3265,10 @@
         }
     }
     
-    /**
-     * True if inside an iframe, otherwise false.
-     * @member {Boolean} isInIframe
-     * @private
-     * @inner
-     */
+    // True if inside an iframe, otherwise false.
+    // @member {Boolean} isInIframe
+    // @private
+    // @inner
     var isInIframe = (function() {
         try {
             return window.self !== window.top;
@@ -3279,12 +3277,10 @@
         }
     })();
  
-    /**
-     * @function
-     * @private
-     * @inner
-     * @returns {Boolean} True if the target has access rights to events, otherwise false.
-     */
+    // @function
+    // @private
+    // @inner
+    // @returns {Boolean} True if the target has access rights to events, otherwise false.
     function canAccessEvents (target) {
         try {
             return target.addEventListener && target.removeEventListener;

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1367,6 +1367,14 @@
                 eventParams = getCaptureEventParams( tracker, $.MouseTracker.havePointerEvents ? 'pointerevent' : pointerType );
                 // We emulate mouse capture by hanging listeners on the document object.
                 //    (Note we listen on the capture phase so the captured handlers will get called first)
+                if (isInIframe() && canAccessEvents(window.top)) {
+                    $.addEvent(
+                        window.top,
+                        eventParams.upName,
+                        eventParams.upHandler,
+                        true
+                    );
+                }
                 $.addEvent(
                     $.MouseTracker.captureElement,
                     eventParams.upName,
@@ -1402,6 +1410,14 @@
                 eventParams = getCaptureEventParams( tracker, $.MouseTracker.havePointerEvents ? 'pointerevent' : pointerType );
                 // We emulate mouse capture by hanging listeners on the document object.
                 //    (Note we listen on the capture phase so the captured handlers will get called first)
+                if (isInIframe() && canAccessEvents(window.top)) {
+                    $.removeEvent(
+                        window.top,
+                        eventParams.upName,
+                        eventParams.upHandler,
+                        true
+                    );
+                }
                 $.removeEvent(
                     $.MouseTracker.captureElement,
                     eventParams.moveName,
@@ -3246,6 +3262,34 @@
                 preventDefaultAction: false,
                 userData:             tracker.userData
             } );
+        }
+    }
+    
+    /**
+     * @function
+     * @private
+     * @inner
+     * @returns {Boolean} True if inside an iframe, otherwise false.
+     */
+    function isInIframe () {
+        try {
+            return window.self !== window.top;
+        } catch (e) {
+            return true;
+        }
+    }
+    
+    /**
+     * @function
+     * @private
+     * @inner
+     * @returns {Boolean} True if the target has access rights to events, otherwise false.
+     */
+    function canAccessEvents (target) {
+        try {
+            return target.addEventListener && target.removeEventListener;
+        } catch (e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
Hi!

I think I've got at least a partial fix for issues #427 and #464. 

This patch tries to detect if the viewer is inside an iframe and if the iframe has access rights to the containing window. In that case it listens to the mouseup and pointerup events from that window in addition to the the usual events. This works as long as the iframe and the containing page are on the same domain, otherwise it will act exactly as before.

I'm not too familiar with how the OSD event model works so please check if I've broken something, but 
I've tested it in Chrome, Firefox, IE 8 and IE 11, all on Windows, and it seems to work as expected.

