### PR TITLE
Fixed issue 788. I'm not sure if this is the correct way of doing thi…

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2720,7 +2720,7 @@ function onCanvasPinch( event ) {
             if( !this.panVertical ) {
                 panByPt.y = 0;
             }
-            this.viewport.zoomBy( event.distance / event.lastDistance, centerPt, true );
+            this.viewport.zoomBy( event.distance / event.lastDistance, centerPt, false );
             this.viewport.panBy( panByPt, true );
             this.viewport.applyConstraints();
         }


### PR DESCRIPTION
I'm not sure if this is the correct way of doing this. But I noticed that a parameter passed to viewport.zoomBy immediate caused the zoomspring to constantly be reset. By setting this parameter to false zooming worked the way i expected it.
