### PR TITLE
Removed redundant event handler in navigator

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -223,12 +223,6 @@ $.Navigator = function( options ){
         }
     });
 
-    this.addHandler("reset-size", function() {
-        if (_this.viewport) {
-            _this.viewport.goHome(true);
-        }
-    });
-
     viewer.world.addHandler("item-index-change", function(event) {
         var item = _this.world.getItemAt(event.previousIndex);
         _this.world.setItemIndex(item, event.newIndex);


### PR DESCRIPTION
As found by @adgoncal: 

https://github.com/openseadragon/openseadragon/commit/a08e361512b6ba8ae430df42ff2d8e1f8968deac#commitcomment-14962121