### PR TITLE
fixed tabIndex to handle empty string

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -234,7 +234,7 @@ $.Viewer = function( options ) {
         style.left     = "0px";
     }(this.canvas.style));
     $.setElementTouchActionNone( this.canvas );
-    this.canvas.tabIndex = options.tabIndex || 0;
+    this.canvas.tabIndex = options.tabIndex || 0 || "" ;
 
     //the container is created through applying the ControlDock constructor above
     this.container.className = "openseadragon-container";

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -234,7 +234,7 @@ $.Viewer = function( options ) {
         style.left     = "0px";
     }(this.canvas.style));
     $.setElementTouchActionNone( this.canvas );
-    this.canvas.tabIndex = options.tabIndex || 0 || "" ;
+    this.canvas.tabIndex = (options.tabIndex === undefined ? 0 : options.tabIndex);
 
     //the container is created through applying the ControlDock constructor above
     this.container.className = "openseadragon-container";


### PR DESCRIPTION
chrome acts buggy and jumps when tabindex is not set to empty string.

fixes #769