### PR TITLE
escape HTML in documentation

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -176,7 +176,7 @@ $.TiledImage = function( options ) {
       /**
        * This event is fired just before the tile is drawn giving the application a chance to alter the image.
        *
-       * NOTE: This event is only fired when the drawer is using a <canvas>.
+       * NOTE: This event is only fired when the drawer is using a &lt;canvas&gt;.
        *
        * @event tile-drawing
        * @memberof OpenSeadragon.Viewer


### PR DESCRIPTION
Corrected fixes for HTML escape of "<canvas>".