### PR TITLE
Disable sequences and join_vars in uglify.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,12 +116,15 @@ module.exports = function(grunt) {
             options: {
                 preserveComments: false,
                 banner: banner,
+                compress: {
+                    sequences: false,
+                    join_vars: false
+                },
                 sourceMap: true,
-                sourceMapName: 'build/openseadragon/openseadragon.min.js.map',
-                sourceMapIn: 'build/openseadragon/openseadragon.js.map'
+                sourceMapName: 'build/openseadragon/openseadragon.min.js.map'
             },
             openseadragon: {
-                src: [ distribution ],
+                src: sources,
                 dest: minified
             }
         },


### PR DESCRIPTION
This up for discussion, but there are 2 problems with the current source map openseadragon.min.js.map:
* the sourceMapIn parameter doesn't look to work correctly in uglify so I removed it. I pass the sources as input. We could pass the concat result as well (this is what was done in the previous versions).
* "sequences" and "join_vars" optimizations make the debugger jump over multiple statements. See https://github.com/mishoo/UglifyJS2/issues/493 When disabling them, the minified version is 192.7KiB instead of 191.4KiB.