### PR TITLE
Add Viewer.getOverlayById and Overlay.getBounds functions

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -312,6 +312,14 @@
             this.placement  = location instanceof $.Point ?
                 placement :
                 $.OverlayPlacement.TOP_LEFT;
+        },
+        /**
+         * @function
+         * @returns {OpenSeadragon.Rect} overlay bounds
+         */
+        getBounds: function() {
+
+            return this.bounds;
         }
 
     };

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -319,7 +319,7 @@
          */
         getBounds: function() {
 
-            return this.bounds;
+            return this.bounds.clone();
         }
 
     };

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1950,7 +1950,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * and returns it as an object, return null if not found.
      * @method
      * @param {Element|String} element - A reference to the element or an
-     *      element id which represent the ovelay content to be removed.
+     *      element id which represent the overlay content.
      * @return {OpenSeadragon.Overlay} the matching overlay or null if none found.
      */
     getOverlayById: function( element ) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1944,7 +1944,28 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         this.raiseEvent( 'clear-overlay', {} );
         return this;
     },
+    
+     /**
+     * Finds an overlay identified by the reference element or element id
+     * and returns it as an object, return false if not found.
+     * @method
+     * @param {Element|String} element - A reference to the element or an
+     *      element id which represent the ovelay content to be removed.
+     * @return {OpenSeadragon.Overlay} Chainable.
+     */
+    getOverlayById: function( element ) {
+        var i;
 
+        element = $.getElement( element );
+        i = getOverlayIndex( this.currentOverlays, element );    
+        
+        if (i>=0) {
+            return this.currentOverlays[i];
+        } else {
+            return false;
+        }
+        
+    },
     /**
      * Updates the sequence buttons.
      * @function OpenSeadragon.Viewer.prototype._updateSequenceButtons

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1947,11 +1947,11 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     
      /**
      * Finds an overlay identified by the reference element or element id
-     * and returns it as an object, return false if not found.
+     * and returns it as an object, return null if not found.
      * @method
      * @param {Element|String} element - A reference to the element or an
      *      element id which represent the ovelay content to be removed.
-     * @return {OpenSeadragon.Overlay} Chainable.
+     * @return {OpenSeadragon.Overlay} the matching overlay or null if none found.
      */
     getOverlayById: function( element ) {
         var i;
@@ -1962,7 +1962,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         if (i>=0) {
             return this.currentOverlays[i];
         } else {
-            return false;
+            return null;
         }
         
     },


### PR DESCRIPTION
Add `Viewer.getOverlayById(element)`, returns overlay or `false`, if nothing found,
and `Overlay.getBounds()` functions