### PR TITLE
removed automatic focus from reference strip, which caused HTML pages…

### DIFF
--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -276,7 +276,6 @@ $.extend( $.ReferenceStrip.prototype, $.EventSource.prototype, $.Viewer.prototyp
             }
 
             this.currentPage = page;
-            $.getElement( element.id + '-displayregion' ).focus();
             onStripEnter.call( this, { eventSource: this.innerTracker } );
         }
     },


### PR DESCRIPTION
… to jump unwantedly to the reference strip upon loading