### PR TITLE
Overlays improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ OPENSEADRAGON CHANGELOG
 
 * BREAKING CHANGE: Viewport.homeBounds, Viewport.contentSize, Viewport.contentAspectX and
     Viewport.contentAspectY have been removed. (#846)
+* BREAKING CHANGE: Overlay.scales, Overlay.bounds and Overlay.position have been removed. (#896)
 * DEPRECATION: Viewport.setHomeBounds has been deprecated (#846)
 * DEPRECATION: the Viewport constructor is now ignoring the contentSize option (#846)
 * Tile edge smoothing at high zoom (#764)
@@ -30,7 +31,8 @@ OPENSEADRAGON CHANGELOG
 * Fixed issue causing HTML pages to jump unwantedly to the reference strip upon loading (#872)
 * Added addOnceHandler method to EventSource (#887)
 * Added TiledImage.fitBounds method (#888)
-* Added scaledWidth and scaleHeight options to Rect overlays to allow to scale in only one dimension.
+* Overlays can now be scaled in only one dimension by providing a point location and either width or height (#896)
+* Added full rotation support to overlays (#729, #193)
 
 2.1.0:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,9 @@ OPENSEADRAGON CHANGELOG
 * BREAKING CHANGE: Viewport.homeBounds, Viewport.contentSize, Viewport.contentAspectX and
     Viewport.contentAspectY have been removed. (#846)
 * BREAKING CHANGE: Overlay.scales, Overlay.bounds and Overlay.position have been removed. (#896)
+    * Overlay.scales can be replaced by Overlay.width !== null && Overlay.height !== null
+    * The Overlay.getBounds method can be used to get the bounds of the overlay in viewport coordinates
+    * Overlay.location replaces Overlay.position
 * DEPRECATION: Viewport.setHomeBounds has been deprecated (#846)
 * DEPRECATION: the Viewport constructor is now ignoring the contentSize option (#846)
 * Tile edge smoothing at high zoom (#764)
@@ -31,7 +34,7 @@ OPENSEADRAGON CHANGELOG
 * Fixed issue causing HTML pages to jump unwantedly to the reference strip upon loading (#872)
 * Added addOnceHandler method to EventSource (#887)
 * Added TiledImage.fitBounds method (#888)
-* Overlays can now be scaled in only one dimension by providing a point location and either width or height (#896)
+* Overlays can now be scaled in a single dimension by providing a point location and either width or height (#896)
 * Added full rotation support to overlays (#729, #193)
 
 2.1.0:

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,9 +5,11 @@ OPENSEADRAGON CHANGELOG
 
 * BREAKING CHANGE: Viewport.homeBounds, Viewport.contentSize, Viewport.contentAspectX and
     Viewport.contentAspectY have been removed. (#846)
-* BREAKING CHANGE: Overlay.scales, Overlay.bounds and Overlay.position have been removed. (#896)
-    * Overlay.scales can be replaced by Overlay.width !== null && Overlay.height !== null
-    * The Overlay.getBounds method can be used to get the bounds of the overlay in viewport coordinates
+* BREAKING CHANGE: The Overlay.getBounds method now takes the viewport as parameter. (#896)
+* DEPRECATION: Overlay.scales, Overlay.bounds and Overlay.position have been deprecated. (#896)
+    * Overlay.width !== null should be used to test whether the overlay scales horizontally
+    * Overlay.height !== null should be used to test whether the overlay scales vertically
+    * The Overlay.getBounds method should be used to get the bounds of the overlay in viewport coordinates
     * Overlay.location replaces Overlay.position
 * DEPRECATION: Viewport.setHomeBounds has been deprecated (#846)
 * DEPRECATION: the Viewport constructor is now ignoring the contentSize option (#846)

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ OPENSEADRAGON CHANGELOG
 * Fixed issue causing HTML pages to jump unwantedly to the reference strip upon loading (#872)
 * Added addOnceHandler method to EventSource (#887)
 * Added TiledImage.fitBounds method (#888)
+* Added scaledWidth and scaleHeight options to Rect overlays to allow to scale in only one dimension.
 
 2.1.0:
 

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1337,6 +1337,49 @@ if (typeof define === 'function' && define.amd) {
                 return window.getComputedStyle( element, "" );
             },
 
+        /**
+         * Returns the property with the correct vendor prefix appended.
+         * @param {String} property the property name
+         * @returns {String} the property with the correct prefix or null if not
+         * supported.
+         */
+        getCssPropertyWithVendorPrefix: function(property) {
+            var memo = {};
+
+            $.getCssPropertyWithVendorPrefix = function(property) {
+                if (memo[property] !== undefined) {
+                    return memo[property];
+                }
+                var style = document.createElement('div').style;
+                var result = null;
+                if (style[property] !== undefined) {
+                    result = property;
+                } else {
+                    var prefixes = ['Webkit', 'Moz', 'MS', 'O',
+                        'webkit', 'moz', 'ms', 'o'];
+                    var suffix = $.capitalizeFirstLetter(property);
+                    for (var i = 0; i < prefixes.length; i++) {
+                        var prop = prefixes[i] + suffix;
+                        if (style[prop] !== undefined) {
+                            result = prop;
+                            break;
+                        }
+                    }
+                }
+                memo[property] = result;
+                return result;
+            };
+            return $.getCssPropertyWithVendorPrefix(property);
+        },
+
+        /**
+         * Capitalizes the first letter of a string
+         * @param {String} string
+         * @returns {String} The string with the first letter capitalized
+         */
+        capitalizeFirstLetter: function(string) {
+            return string.charAt(0).toUpperCase() + string.slice(1);
+        },
 
         /**
          * Determines if a point is within the bounding rectangle of the given element (hit-test).

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -140,10 +140,16 @@
             this.onDraw = options.onDraw;
             this.checkResize = options.checkResize === undefined ?
                 true : options.checkResize;
+
+            // When this.width is not null, the overlay get scaled horizontally
             this.width = options.width === undefined ? null : options.width;
+
+            // When this.height is not null, the overlay get scaled vertically
             this.height = options.height === undefined ? null : options.height;
+
             this.rotationMode = options.rotationMode || $.OverlayRotationMode.EXACT;
 
+            // Having a rect as location is a syntactic sugar
             if (this.location instanceof $.Rect) {
                 this.width = this.location.width;
                 this.height = this.location.height;
@@ -231,6 +237,9 @@
                 element.prevElementParent = element.parentNode;
                 element.prevNextSibling = element.nextSibling;
                 container.appendChild(element);
+
+                // this.size is used by overlays which don't get scaled in at
+                // least one direction when this.checkResize is set to false.
                 this.size = $.getElementSize(element);
             }
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -417,7 +417,7 @@
          * @returns {OpenSeadragon.Rect} overlay bounds
          */
         getBounds: function(viewport) {
-            $.console.assert(!viewport, 'Calling Overlay.getBounds withouth ' +
+            $.console.assert(viewport, 'Calling Overlay.getBounds withouth ' +
                 'specifying a viewport is deprecated.');
             var width = this.width;
             var height = this.height;
@@ -442,11 +442,22 @@
                 this.rotationMode === $.OverlayRotationMode.EXACT) {
                 return bounds;
             }
-            // If overlay not fully scalable, BOUNDING_BOX falls back to EXACT
-            if (this.rotationMode === $.OverlayRotationMode.BOUNDING_BOX &&
-                (this.width === null || this.height === null)) {
-                return bounds;
+            if (this.rotationMode === $.OverlayRotationMode.BOUNDING_BOX) {
+                // If overlay not fully scalable, BOUNDING_BOX falls back to EXACT
+                if (this.width === null || this.height === null) {
+                    return bounds;
+                }
+                // It is easier to just compute the position and size and
+                // convert to viewport coordinates.
+                var positionAndSize = this._getOverlayPositionAndSize(viewport);
+                return viewport.viewerElementToViewportRectangle(new $.Rect(
+                    positionAndSize.position.x,
+                    positionAndSize.position.y,
+                    positionAndSize.size.x,
+                    positionAndSize.size.y));
             }
+
+            // NO_ROTATION case
             return bounds.rotate(-viewport.degrees,
                 this._getPlacementPoint(bounds));
         }

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -383,9 +383,9 @@
             var width = this.width;
             var height = this.height;
             if (width === null || height === null) {
-                $.console.assert(viewport, 'The viewport must be specified to' +
+                $.console.assert(!viewport, 'The viewport must be specified to' +
                     ' get the bounds of a not entirely scaling overlay');
-                var size = viewport.deltaPointsFromPixels(this.size, true);
+                var size = viewport.deltaPointsFromPixelsNoRotate(this.size, true);
                 if (width === null) {
                     width = size.x;
                 }
@@ -393,8 +393,9 @@
                     height = size.y;
                 }
             }
-            return new $.Rect(
-                this.location.x, this.location.y, width, height);
+            var location = this.location.clone();
+            this.adjust(location, new $.Point(width, height));
+            return new $.Rect(location.x, location.y, width, height);
         }
     };
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -156,6 +156,12 @@
                 this.location = this.location.getTopLeft();
                 this.placement = $.Placement.TOP_LEFT;
             }
+
+            // Deprecated properties kept for backward compatibility.
+            this.scales = this.width !== null && this.height !== null;
+            this.bounds = new $.Rect(
+                this.location.x, this.location.y, this.width, this.height);
+            this.position = this.location;
         },
 
         /**

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -257,12 +257,18 @@
                         style.height = size.y + "px";
                     }
                 }
-                if (rotate) {
-                    style.transformOrigin = this._getTransformOrigin();
-                    style.transform = "rotate(" + rotate + "deg)";
-                } else {
-                    style.transformOrigin = "";
-                    style.transform = "";
+                var transformOriginProp = $.getCssPropertyWithVendorPrefix(
+                    'transformOrigin');
+                var transformProp = $.getCssPropertyWithVendorPrefix(
+                    'transform');
+                if (transformOriginProp && transformProp) {
+                    if (rotate) {
+                        style[transformOriginProp] = this._getTransformOrigin();
+                        style[transformProp] = "rotate(" + rotate + "deg)";
+                    } else {
+                        style[transformOriginProp] = "";
+                        style[transformProp] = "";
+                    }
                 }
                 style.position = "absolute";
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -241,9 +241,6 @@
             var size = this.size = positionAndSize.size;
             var rotate = positionAndSize.rotate;
 
-            position = position.apply(Math.round);
-            size = size.apply(Math.round);
-
             // call the onDraw callback if it exists to allow one to overwrite
             // the drawing/positioning/sizing of the overlay
             if (this.onDraw) {

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -423,8 +423,8 @@
          * @returns {OpenSeadragon.Rect} overlay bounds
          */
         getBounds: function(viewport) {
-            $.console.assert(viewport, 'Calling Overlay.getBounds withouth ' +
-                'specifying a viewport is deprecated.');
+            $.console.assert(viewport,
+                'A viewport must now be passed to Overlay.getBounds.');
             var width = this.width;
             var height = this.height;
             if (width === null || height === null) {
@@ -442,6 +442,7 @@
                 viewport, new $.Rect(location.x, location.y, width, height));
         },
 
+        // private
         _adjustBoundsForRotation: function(viewport, bounds) {
             if (!viewport ||
                 viewport.degrees === 0 ||

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -419,7 +419,7 @@
         /**
          * Returns the current bounds of the overlay in viewport coordinates
          * @function
-         * @param {OpenSeadragon.Viewport} [viewport] the viewport
+         * @param {OpenSeadragon.Viewport} viewport the viewport
          * @returns {OpenSeadragon.Rect} overlay bounds
          */
         getBounds: function(viewport) {

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -131,6 +131,7 @@
 
     /** @lends OpenSeadragon.Overlay.prototype */
     $.Overlay.prototype = {
+
         // private
         _init: function(options) {
             this.location = options.location;
@@ -156,6 +157,7 @@
                 this.placement = $.Placement.TOP_LEFT;
             }
         },
+
         /**
          * Internal function to adjust the position of an overlay
          * depending on it size and placement.
@@ -179,6 +181,7 @@
                 position.y -= size.y;
             }
         },
+
         /**
          * @function
          */
@@ -222,6 +225,7 @@
                 style[transformProp] = "";
             }
         },
+
         /**
          * @function
          * @param {Element} container
@@ -279,6 +283,7 @@
                 }
             }
         },
+
         // private
         _getOverlayPositionAndSize: function(viewport) {
             var position = viewport.pixelFromPoint(this.location, true);
@@ -307,6 +312,7 @@
                 rotate: rotate
             };
         },
+
         // private
         _getSizeInPixels: function(viewport) {
             var width = this.size.x;
@@ -333,11 +339,13 @@
             }
             return new $.Point(width, height);
         },
+
         // private
         _getBoundingBox: function(rect, degrees) {
             var refPoint = this._getPlacementPoint(rect);
             return rect.rotate(degrees, refPoint).getBoundingBox();
         },
+
         // private
         _getPlacementPoint: function(rect) {
             var result = new $.Point(rect.x, rect.y);
@@ -356,6 +364,7 @@
             }
             return result;
         },
+
         // private
         _getTransformOrigin: function() {
             var result = "";
@@ -375,6 +384,7 @@
             }
             return result;
         },
+
         /**
          * Changes the overlay settings.
          * @function
@@ -399,6 +409,7 @@
                 rotationMode: options.rotationMode || this.rotationMode
             });
         },
+
         /**
          * Returns the current bounds of the overlay in viewport coordinates
          * @function

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -287,7 +287,7 @@
         // private
         _getOverlayPositionAndSize: function(viewport) {
             var position = viewport.pixelFromPoint(this.location, true);
-            var size = this._getSizeinPixels(viewport);
+            var size = this._getSizeInPixels(viewport);
             this.adjust(position, size);
 
             var rotate = 0;
@@ -314,7 +314,7 @@
         },
 
         // private
-        _getSizeinPixels: function(viewport) {
+        _getSizeInPixels: function(viewport) {
             var width = this.size.x;
             var height = this.size.y;
             if (this.width !== null || this.height !== null) {

--- a/src/rectangle.js
+++ b/src/rectangle.js
@@ -110,6 +110,33 @@ $.Rect = function(x, y, width, height, degrees) {
     }
 };
 
+/**
+ * Builds a rectangle having the 3 specified points as summits.
+ * @static
+ * @memberof OpenSeadragon.Rect
+ * @param {OpenSeadragon.Point} topLeft
+ * @param {OpenSeadragon.Point} topRight
+ * @param {OpenSeadragon.Point} bottomLeft
+ * @returns {OpenSeadragon.Rect}
+ */
+$.Rect.fromSummits = function(topLeft, topRight, bottomLeft) {
+    var width = topLeft.distanceTo(topRight);
+    var height = topLeft.distanceTo(bottomLeft);
+    var diff = topRight.minus(topLeft);
+    var radians = Math.atan(diff.y / diff.x);
+    if (diff.x < 0) {
+        radians += Math.PI;
+    } else if (diff.y < 0) {
+        radians += 2 * Math.PI;
+    }
+    return new $.Rect(
+        topLeft.x,
+        topLeft.y,
+        width,
+        height,
+        radians / Math.PI * 180);
+};
+
 /** @lends OpenSeadragon.Rect.prototype */
 $.Rect.prototype = {
     /**
@@ -284,7 +311,7 @@ $.Rect.prototype = {
      * Rotates a rectangle around a point.
      * @function
      * @param {Number} degrees The angle in degrees to rotate.
-     * @param {OpenSeadragon.Point} pivot The point about which to rotate.
+     * @param {OpenSeadragon.Point} [pivot] The point about which to rotate.
      * Defaults to the center of the rectangle.
      * @return {OpenSeadragon.Rect}
      */

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1788,7 +1788,9 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * is closed which include when changing page.
      * @method
      * @param {Element|String|Object} element - A reference to an element or an id for
-     *      the element which will be overlayed. Or an Object specifying the configuration for the overlay
+     *      the element which will be overlayed. Or an Object specifying the configuration for the overlay.
+     *      If using an object, see {@link OpenSeadragon.Overlay} for a list of
+     *      all available options.
      * @param {OpenSeadragon.Point|OpenSeadragon.Rect} location - The point or
      *      rectangle which will be overlayed. This is a viewport relative location.
      * @param {OpenSeadragon.Placement} placement - The position of the
@@ -2237,7 +2239,9 @@ function getOverlayObject( viewer, overlay ) {
         location: location,
         placement: placement,
         onDraw: overlay.onDraw,
-        checkResize: overlay.checkResize
+        checkResize: overlay.checkResize,
+        scaleWidth: overlay.scaleWidth,
+        scaleHeight: overlay.scaleHeight
     });
 }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2240,8 +2240,8 @@ function getOverlayObject( viewer, overlay ) {
         placement: placement,
         onDraw: overlay.onDraw,
         checkResize: overlay.checkResize,
-        scaleWidth: overlay.scaleWidth,
-        scaleHeight: overlay.scaleHeight,
+        width: overlay.width,
+        height: overlay.height,
         rotationMode: overlay.rotationMode
     });
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2241,7 +2241,8 @@ function getOverlayObject( viewer, overlay ) {
         onDraw: overlay.onDraw,
         checkResize: overlay.checkResize,
         scaleWidth: overlay.scaleWidth,
-        scaleHeight: overlay.scaleHeight
+        scaleHeight: overlay.scaleHeight,
+        rotationMode: overlay.rotationMode
     });
 }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2201,32 +2201,23 @@ function getOverlayObject( viewer, overlay ) {
     }
 
     var location = overlay.location;
-    if ( !location ) {
-        if ( overlay.width && overlay.height ) {
-            location = overlay.px !== undefined ?
-                viewer.viewport.imageToViewportRectangle( new $.Rect(
-                    overlay.px,
-                    overlay.py,
-                    overlay.width,
-                    overlay.height
-                ) ) :
-                new $.Rect(
-                    overlay.x,
-                    overlay.y,
-                    overlay.width,
-                    overlay.height
-                );
-        } else {
-            location = overlay.px !== undefined ?
-                viewer.viewport.imageToViewportCoordinates( new $.Point(
-                    overlay.px,
-                    overlay.py
-                ) ) :
-                new $.Point(
-                    overlay.x,
-                    overlay.y
-                );
+    var width = overlay.width;
+    var height = overlay.height;
+    if (!location) {
+        var x = overlay.x;
+        var y = overlay.y;
+        if (overlay.px !== undefined) {
+            var rect = viewer.viewport.imageToViewportRectangle(new $.Rect(
+                overlay.px,
+                overlay.py,
+                width || 0,
+                height || 0));
+            x = rect.x;
+            y = rect.y;
+            width = width !== undefined ? rect.width : undefined;
+            height = height !== undefined ? rect.height : undefined;
         }
+        location = new $.Point(x, y);
     }
 
     var placement = overlay.placement;
@@ -2240,8 +2231,8 @@ function getOverlayObject( viewer, overlay ) {
         placement: placement,
         onDraw: overlay.onDraw,
         checkResize: overlay.checkResize,
-        width: overlay.width,
-        height: overlay.height,
+        width: width,
+        height: height,
         rotationMode: overlay.rotationMode
     });
 }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1263,6 +1263,20 @@ $.Viewport.prototype = {
     },
 
     /**
+     * Convert a rectangle in viewport coordinates to pixel coordinates relative
+     * to the viewer element.
+     * @param {OpenSeadragon.Rect} rectangle the rectangle to convert
+     * @returns {OpenSeadragon.Rect} the converted rectangle
+     */
+    viewportToViewerElementRectangle: function(rectangle) {
+        return $.Rect.fromSummits(
+            this.pixelFromPoint(rectangle.getTopLeft(), true),
+            this.pixelFromPoint(rectangle.getTopRight(), true),
+            this.pixelFromPoint(rectangle.getBottomLeft(), true)
+        );
+    },
+
+    /**
      * Convert pixel coordinates relative to the window to viewport coordinates.
      * @param {OpenSeadragon.Point} pixel
      * @returns {OpenSeadragon.Point}

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1263,6 +1263,20 @@ $.Viewport.prototype = {
     },
 
     /**
+     * Convert a rectangle in pixel coordinates relative to the viewer element
+     * to viewport coordinates.
+     * @param {OpenSeadragon.Rect} rectangle the rectangle to convert
+     * @returns {OpenSeadragon.Rect} the converted rectangle
+     */
+    viewerElementToViewportRectangle: function(rectangle) {
+        return $.Rect.fromSummits(
+            this.pointFromPixel(rectangle.getTopLeft(), true),
+            this.pointFromPixel(rectangle.getTopRight(), true),
+            this.pointFromPixel(rectangle.getBottomLeft(), true)
+        );
+    },
+
+    /**
      * Convert a rectangle in viewport coordinates to pixel coordinates relative
      * to the viewer element.
      * @param {OpenSeadragon.Rect} rectangle the rectangle to convert

--- a/test/demo/overlay.html
+++ b/test/demo/overlay.html
@@ -15,6 +15,8 @@
     <div id="contentDiv" class="openseadragon1"></div>
     <div id="annotation-div">
         <input type="button" value="Hide Overlays" id="hideOverlays">
+        <input type="button" value="Rotate" id="rotate">
+        <span id="degrees">0deg</span>
     </div>
 
     <script type="text/javascript">
@@ -31,9 +33,14 @@
             var elt = document.createElement("div");
             elt.className = "runtime-overlay";
             elt.style.background = "green";
-            elt.style.border = "1px solid red";
+            elt.style.outline = "3px solid red";
+            elt.style.opacity = "0.7";
             elt.textContent = "Scaled overlay";
-            viewer.addOverlay(elt, new OpenSeadragon.Rect(0.2, 0.2, 0.1, 0.1));
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Rect(0.21, 0.21, 0.099, 0.099),
+                rotationMode: OpenSeadragon.OverlayRotationMode.EXACT
+            });
 
             elt = document.createElement("div");
             elt.className = "runtime-overlay";
@@ -43,8 +50,9 @@
             elt.textContent = "Scaled vertically";
             viewer.addOverlay({
                 element: elt,
-                location: new OpenSeadragon.Rect(0.6, 0.6, 0.1, 0.1),
-                scaleWidth: false
+                location: new OpenSeadragon.Point(0.6, 0.6),
+                height: 0.1,
+                placement: OpenSeadragon.Placement.TOP_LEFT
             });
 
             elt = document.createElement("div");
@@ -56,27 +64,33 @@
             elt.textContent = "Scaled horizontally";
             viewer.addOverlay({
                 element: elt,
-                location: new OpenSeadragon.Rect(0.1, 0.5, 0.1, 0.1),
-                scaleHeight: false
+                location: new OpenSeadragon.Point(0.1, 0.5),
+                width: 0.1,
+                rotationMode: OpenSeadragon.OverlayRotationMode.BOUNDING_BOX
             });
 
             elt = document.createElement("div");
             elt.className = "runtime-overlay";
             elt.style.background = "white";
             elt.style.opacity = "0.5";
-            elt.style.border = "1px solid pink";
+            elt.style.border = "5px solid pink";
             elt.style.width = "100px";
             elt.style.height = "100px";
             elt.textContent = "Not scaled, centered in the middle";
             viewer.addOverlay({
                 element: elt,
                 location: new OpenSeadragon.Point(0.5, 0.5),
-                placement: OpenSeadragon.Placement.CENTER
+                placement: OpenSeadragon.Placement.CENTER,
+                checkResize: false
             });
 
         });
         $("#hideOverlays").click(function(){
             $(".runtime-overlay").toggle();
+        });
+        $("#rotate").click(function() {
+            viewer.viewport.setRotation(viewer.viewport.getRotation() + 22.5);
+            $("#degrees").text(viewer.viewport.getRotation() + "deg");
         });
 
     </script>

--- a/test/demo/overlay.html
+++ b/test/demo/overlay.html
@@ -39,41 +39,41 @@
             viewer.addOverlay({
                 element: elt,
                 location: new OpenSeadragon.Rect(0.21, 0.21, 0.099, 0.099),
-                rotationMode: OpenSeadragon.OverlayRotationMode.EXACT
-            });
-
-            elt = document.createElement("div");
-            elt.className = "runtime-overlay";
-            elt.style.background = "white";
-            elt.style.border = "3px solid red";
-            elt.style.width = "100px";
-            elt.textContent = "Scaled vertically";
-            viewer.addOverlay({
-                element: elt,
-                location: new OpenSeadragon.Point(0.6, 0.6),
-                height: 0.1,
-                placement: OpenSeadragon.Placement.TOP_LEFT
-            });
-
-            elt = document.createElement("div");
-            elt.className = "runtime-overlay";
-            elt.style.background = "white";
-            elt.style.opacity = "0.5";
-            elt.style.border = "1px solid blue";
-            elt.style.height = "100px";
-            elt.textContent = "Scaled horizontally";
-            viewer.addOverlay({
-                element: elt,
-                location: new OpenSeadragon.Point(0.1, 0.5),
-                width: 0.1,
                 rotationMode: OpenSeadragon.OverlayRotationMode.BOUNDING_BOX
             });
 
             elt = document.createElement("div");
             elt.className = "runtime-overlay";
             elt.style.background = "white";
+            elt.style.outline = "3px solid red";
+            elt.style.width = "100px";
+            elt.textContent = "Scaled vertically";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Point(0.6, 0.6),
+                height: 0.1,
+                placement: OpenSeadragon.Placement.TOP_LEFT,
+                rotationMode: OpenSeadragon.OverlayRotationMode.NO_ROTATION
+            });
+
+            elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "white";
             elt.style.opacity = "0.5";
-            elt.style.border = "5px solid pink";
+            elt.style.outline = "1px solid blue";
+            elt.style.height = "100px";
+            elt.textContent = "Scaled horizontally";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Point(0.1, 0.5),
+                width: 0.1
+            });
+
+            elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "white";
+            elt.style.opacity = "0.5";
+            elt.style.outline = "5px solid pink";
             elt.style.width = "100px";
             elt.style.height = "100px";
             elt.textContent = "Not scaled, centered in the middle";
@@ -81,7 +81,8 @@
                 element: elt,
                 location: new OpenSeadragon.Point(0.5, 0.5),
                 placement: OpenSeadragon.Placement.CENTER,
-                checkResize: false
+                checkResize: false,
+                rotationMode: OpenSeadragon.OverlayRotationMode.EXACT
             });
 
         });

--- a/test/demo/overlay.html
+++ b/test/demo/overlay.html
@@ -14,7 +14,7 @@
 <body>
     <div id="contentDiv" class="openseadragon1"></div>
     <div id="annotation-div">
-        <input type="button" value="Hide Overlay" id="hideOverlay">
+        <input type="button" value="Hide Overlays" id="hideOverlays">
     </div>
 
     <script type="text/javascript">
@@ -22,19 +22,61 @@
         var viewer = OpenSeadragon({
             id: "contentDiv",
             prefixUrl: "../../build/openseadragon/images/",
-            tileSources: "../data/testpattern.dzi"
+            tileSources: "../data/testpattern.dzi",
+            minZoomImageRatio: 0,
+            maxZoomPixelRatio: 10
         });
 
         viewer.addHandler("open", function(event) {
             var elt = document.createElement("div");
+            elt.className = "runtime-overlay";
             elt.style.background = "green";
-            elt.id = "runtime-overlay";
             elt.style.border = "1px solid red";
-            viewer.addOverlay( elt, new OpenSeadragon.Rect(0.2, 0.2, 0.75, 0.75)  );
-        });
+            elt.textContent = "Scaled overlay";
+            viewer.addOverlay(elt, new OpenSeadragon.Rect(0.2, 0.2, 0.1, 0.1));
 
-        $("#hideOverlay").click(function(){
-            $("#runtime-overlay").toggle();
+            elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "white";
+            elt.style.border = "3px solid red";
+            elt.style.width = "100px";
+            elt.textContent = "Scaled vertically";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Rect(0.6, 0.6, 0.1, 0.1),
+                scaleWidth: false
+            });
+
+            elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "white";
+            elt.style.opacity = "0.5";
+            elt.style.border = "1px solid blue";
+            elt.style.height = "100px";
+            elt.textContent = "Scaled horizontally";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Rect(0.1, 0.5, 0.1, 0.1),
+                scaleHeight: false
+            });
+
+            elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "white";
+            elt.style.opacity = "0.5";
+            elt.style.border = "1px solid pink";
+            elt.style.width = "100px";
+            elt.style.height = "100px";
+            elt.textContent = "Not scaled, centered in the middle";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Point(0.5, 0.5),
+                placement: OpenSeadragon.Placement.CENTER
+            });
+
+        });
+        $("#hideOverlays").click(function(){
+            $(".runtime-overlay").toggle();
         });
 
     </script>

--- a/test/modules/overlays.js
+++ b/test/modules/overlays.js
@@ -658,6 +658,7 @@
         });
     });
 
+    // ----------
     asyncTest('Overlay.getBounds', function() {
         viewer = OpenSeadragon({
             id: 'example-overlays',
@@ -710,7 +711,7 @@
             viewer._drawOverlays();
 
             var actualBounds = viewer.getOverlayById("fully-scaled-overlay")
-                .getBounds();
+                .getBounds(viewer.viewport);
             var expectedBounds = new OpenSeadragon.Rect(0, 0, 1, 1);
             ok(expectedBounds.equals(actualBounds),
                 "The fully scaled overlay should have bounds " +
@@ -745,4 +746,240 @@
         });
     });
 
+    // ----------
+    asyncTest('Fully scaled overlay rotation mode NO_ROTATION', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100, // Faster animation = faster tests
+            degrees: 45,
+            overlays: [{
+                    id: "fully-scaled-overlay",
+                    x: 1,
+                    y: 1,
+                    width: 1,
+                    height: 1,
+                    placement: OpenSeadragon.Placement.BOTTOM_RIGHT,
+                    rotationMode: OpenSeadragon.OverlayRotationMode.NO_ROTATION
+                }]
+        });
+
+        viewer.addOnceHandler('open', function() {
+            var viewport = viewer.viewport;
+
+            var $overlay = $("#fully-scaled-overlay");
+            var expectedSize = viewport.deltaPixelsFromPointsNoRotate(
+                new OpenSeadragon.Point(1, 1));
+            var expectedPosition = viewport.viewportToViewerElementCoordinates(
+                new OpenSeadragon.Point(1, 1))
+                .minus(expectedSize);
+            var actualPosition = $overlay.position();
+            Util.assessNumericValue(actualPosition.left, expectedPosition.x, epsilon,
+                "Scaled overlay position.x should adjust to rotation.");
+            Util.assessNumericValue(actualPosition.top, expectedPosition.y, epsilon,
+                "Scaled overlay position.y should adjust to rotation.");
+
+            var actualWidth = $overlay.width();
+            var actualHeight = $overlay.height();
+            Util.assessNumericValue(actualWidth, expectedSize.x, epsilon,
+                "Scaled overlay width should not adjust to rotation.");
+            Util.assessNumericValue(actualHeight, expectedSize.y, epsilon,
+                "Scaled overlay height should not adjust to rotation.");
+
+            var actualBounds = viewer.getOverlayById("fully-scaled-overlay")
+                .getBounds(viewport);
+            var expectedBounds = new OpenSeadragon.Rect(0, 0, 1, 1)
+                .rotate(-45, new OpenSeadragon.Point(1, 1));
+            ok(expectedBounds.equals(actualBounds),
+                "The fully scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+            start();
+        });
+    });
+
+    // ----------
+    asyncTest('Horizontally scaled overlay rotation mode NO_ROTATION', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100, // Faster animation = faster tests
+            degrees: 45,
+            overlays: [{
+                    id: "horizontally-scaled-overlay",
+                    x: 0.5,
+                    y: 0.5,
+                    width: 1,
+                    placement: OpenSeadragon.Placement.CENTER,
+                    rotationMode: OpenSeadragon.OverlayRotationMode.NO_ROTATION
+                }]
+        });
+
+        viewer.addOnceHandler('open', function() {
+            var $overlay = $("#horizontally-scaled-overlay");
+            var notScaledWidth = 100;
+            var notScaledHeight = 100;
+            $overlay.get(0).style.height = notScaledHeight + "px";
+
+            var viewport = viewer.viewport;
+            var notScaledSize = viewport.deltaPointsFromPixelsNoRotate(
+                new OpenSeadragon.Point(notScaledWidth, notScaledHeight));
+
+            // Force refresh to takes new dimensions into account.
+            viewer._drawOverlays();
+
+            var expectedWidth = viewport.deltaPixelsFromPointsNoRotate(
+                new OpenSeadragon.Point(1, 1)).x;
+            var expectedPosition = viewport.viewportToViewerElementCoordinates(
+                new OpenSeadragon.Point(0.5, 0.5))
+                .minus(new OpenSeadragon.Point(expectedWidth / 2, notScaledHeight / 2));
+            var actualPosition = $overlay.position();
+            Util.assessNumericValue(actualPosition.left, expectedPosition.x, epsilon,
+                "Horizontally scaled overlay position.x should adjust to rotation.");
+            Util.assessNumericValue(actualPosition.top, expectedPosition.y, epsilon,
+                "Horizontally scaled overlay position.y should adjust to rotation.");
+
+            var actualWidth = $overlay.width();
+            var actualHeight = $overlay.height();
+            Util.assessNumericValue(actualWidth, expectedWidth, epsilon,
+                "Horizontally scaled overlay width should not adjust to rotation.");
+            Util.assessNumericValue(actualHeight, notScaledHeight, epsilon,
+                "Horizontally scaled overlay height should not adjust to rotation.");
+
+            var actualBounds = viewer.getOverlayById("horizontally-scaled-overlay")
+                .getBounds(viewport);
+            var expectedBounds = new OpenSeadragon.Rect(
+                0, 0.5 - notScaledSize.y / 2, 1, notScaledSize.y)
+                .rotate(-45, new OpenSeadragon.Point(0.5, 0.5));
+            ok(expectedBounds.equals(actualBounds),
+                "The horizontally scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+            start();
+        });
+    });
+
+    // ----------
+    asyncTest('Vertically scaled overlay rotation mode NO_ROTATION', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100, // Faster animation = faster tests
+            degrees: 45,
+            overlays: [{
+                    id: "vertically-scaled-overlay",
+                    x: 0,
+                    y: 0.5,
+                    height: 1,
+                    placement: OpenSeadragon.Placement.LEFT,
+                    rotationMode: OpenSeadragon.OverlayRotationMode.NO_ROTATION
+                }]
+        });
+
+        viewer.addOnceHandler('open', function() {
+            var $overlay = $("#vertically-scaled-overlay");
+            var notScaledWidth = 100;
+            var notScaledHeight = 100;
+            $overlay.get(0).style.width = notScaledWidth + "px";
+
+            var viewport = viewer.viewport;
+            var notScaledSize = viewport.deltaPointsFromPixelsNoRotate(
+                new OpenSeadragon.Point(notScaledWidth, notScaledHeight));
+
+            // Force refresh to takes new dimensions into account.
+            viewer._drawOverlays();
+
+            var expectedHeight = viewport.deltaPixelsFromPointsNoRotate(
+                new OpenSeadragon.Point(1, 1)).y;
+            var expectedPosition = viewport.viewportToViewerElementCoordinates(
+                new OpenSeadragon.Point(0, 0.5))
+                .minus(new OpenSeadragon.Point(0, expectedHeight / 2));
+            var actualPosition = $overlay.position();
+            Util.assessNumericValue(actualPosition.left, expectedPosition.x, epsilon,
+                "Vertically scaled overlay position.x should adjust to rotation.");
+            Util.assessNumericValue(actualPosition.top, expectedPosition.y, epsilon,
+                "Vertically scaled overlay position.y should adjust to rotation.");
+
+            var actualWidth = $overlay.width();
+            var actualHeight = $overlay.height();
+            Util.assessNumericValue(actualWidth, notScaledWidth, epsilon,
+                "Vertically scaled overlay width should not adjust to rotation.");
+            Util.assessNumericValue(actualHeight, expectedHeight, epsilon,
+                "Vertically scaled overlay height should not adjust to rotation.");
+
+            var actualBounds = viewer.getOverlayById("vertically-scaled-overlay")
+                .getBounds(viewport);
+            var expectedBounds = new OpenSeadragon.Rect(
+                0, 0, notScaledSize.x, 1)
+                .rotate(-45, new OpenSeadragon.Point(0, 0.5));
+            ok(expectedBounds.equals(actualBounds),
+                "The vertically scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+            start();
+        });
+    });
+
+    // ----------
+    asyncTest('Not scaled overlay rotation mode NO_ROTATION', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100, // Faster animation = faster tests
+            degrees: 45,
+            overlays: [{
+                    id: "not-scaled-overlay",
+                    x: 1,
+                    y: 0,
+                    placement: OpenSeadragon.Placement.TOP_RIGHT,
+                    rotationMode: OpenSeadragon.OverlayRotationMode.NO_ROTATION
+                }]
+        });
+
+        viewer.addOnceHandler('open', function() {
+            var $overlay = $("#not-scaled-overlay");
+            var notScaledWidth = 100;
+            var notScaledHeight = 100;
+            $overlay.get(0).style.width = notScaledWidth + "px";
+            $overlay.get(0).style.height = notScaledHeight + "px";
+
+            var viewport = viewer.viewport;
+            var notScaledSize = viewport.deltaPointsFromPixelsNoRotate(
+                new OpenSeadragon.Point(notScaledWidth, notScaledHeight));
+
+            // Force refresh to takes new dimensions into account.
+            viewer._drawOverlays();
+
+            var expectedPosition = viewport.viewportToViewerElementCoordinates(
+                new OpenSeadragon.Point(1, 0))
+                .minus(new OpenSeadragon.Point(notScaledWidth, 0));
+            var actualPosition = $overlay.position();
+            Util.assessNumericValue(actualPosition.left, expectedPosition.x, epsilon,
+                "Not scaled overlay position.x should adjust to rotation.");
+            Util.assessNumericValue(actualPosition.top, expectedPosition.y, epsilon,
+                "Not scaled overlay position.y should adjust to rotation.");
+
+            var actualWidth = $overlay.width();
+            var actualHeight = $overlay.height();
+            Util.assessNumericValue(actualWidth, notScaledWidth, epsilon,
+                "Not scaled overlay width should not adjust to rotation.");
+            Util.assessNumericValue(actualHeight, notScaledHeight, epsilon,
+                "Not scaled overlay height should not adjust to rotation.");
+
+            var actualBounds = viewer.getOverlayById("not-scaled-overlay")
+                .getBounds(viewport);
+            var expectedBounds = new OpenSeadragon.Rect(
+                1 - notScaledSize.x, 0, notScaledSize.x, notScaledSize.y)
+                .rotate(-45, new OpenSeadragon.Point(1, 0));
+            ok(expectedBounds.equals(actualBounds),
+                "Not scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+            start();
+        });
+    });
 })();

--- a/test/modules/overlays.js
+++ b/test/modules/overlays.js
@@ -2,6 +2,8 @@
 
 ( function() {
     var viewer;
+    // jQuery.position can give results quite different than what set in style.left
+    var epsilon = 1;
 
     module( "Overlays", {
         setup: function() {
@@ -237,30 +239,38 @@
                 } ]
         } );
 
-        function checkOverlayPosition( contextMessage ) {
+        function checkOverlayPosition(contextMessage) {
             var viewport = viewer.viewport;
 
             var expPosition = viewport.imageToViewerElementCoordinates(
-                new OpenSeadragon.Point( 13, 120 ) ).apply( Math.round );
-            var actPosition = $( "#overlay" ).position();
-            equal( actPosition.left, expPosition.x, "X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Y position mismatch " + contextMessage );
+                new OpenSeadragon.Point(13, 120));
+            var actPosition = $("#overlay").position();
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Y position mismatch " + contextMessage);
 
-            var zoom = viewport.viewportToImageZoom( viewport.getZoom( true ) );
-            var expectedWidth = Math.round( 124 * zoom );
-            var expectedHeight = Math.round( 132 * zoom );
-            equal( $( "#overlay" ).width(), expectedWidth, "Width mismatch " + contextMessage );
-            equal( $( "#overlay" ).height( ), expectedHeight, "Height mismatch " + contextMessage );
+            var zoom = viewport.viewportToImageZoom(viewport.getZoom(true));
+            var expectedWidth = 124 * zoom;
+            var expectedHeight = 132 * zoom;
+            Util.assessNumericValue($("#overlay").width(), expectedWidth, epsilon,
+                "Width mismatch " + contextMessage);
+            Util.assessNumericValue($("#overlay").height(), expectedHeight, epsilon,
+                "Height mismatch " + contextMessage);
 
 
             expPosition = viewport.imageToViewerElementCoordinates(
-                new OpenSeadragon.Point( 400, 500 ) ).apply( Math.round );
-            actPosition = $( "#fixed-overlay" ).position();
-            equal( actPosition.left, expPosition.x, "Fixed overlay X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Fixed overlay Y position mismatch " + contextMessage );
+                new OpenSeadragon.Point(400, 500));
+            actPosition = $("#fixed-overlay").position();
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "Fixed overlay X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Fixed overlay Y position mismatch " + contextMessage);
 
-            equal( $( "#fixed-overlay" ).width(), 70, "Fixed overlay width mismatch " + contextMessage );
-            equal( $( "#fixed-overlay" ).height( ), 60, "Fixed overlay height mismatch " + contextMessage );
+            Util.assessNumericValue($("#fixed-overlay").width(), 70, epsilon,
+                "Fixed overlay width mismatch " + contextMessage);
+            Util.assessNumericValue($("#fixed-overlay").height(), 60, epsilon,
+                "Fixed overlay height mismatch " + contextMessage);
         }
 
         waitForViewer( function() {
@@ -305,25 +315,33 @@
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
-                new OpenSeadragon.Point( 0.2, 0.1 ) ).apply( Math.round );
+                new OpenSeadragon.Point(0.2, 0.1));
             var actPosition = $( "#overlay" ).position();
-            equal( actPosition.left, expPosition.x, "X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Y position mismatch " + contextMessage );
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Y position mismatch " + contextMessage);
 
             var expectedSize = viewport.deltaPixelsFromPoints(
-                new OpenSeadragon.Point( 0.5, 0.1 ) );
-            equal( $( "#overlay" ).width(), expectedSize.x, "Width mismatch " + contextMessage );
-            equal( $( "#overlay" ).height(), expectedSize.y, "Height mismatch " + contextMessage );
+                new OpenSeadragon.Point(0.5, 0.1));
+            Util.assessNumericValue($("#overlay").width(), expectedSize.x, epsilon,
+                "Width mismatch " + contextMessage);
+            Util.assessNumericValue($("#overlay").height(), expectedSize.y, epsilon,
+                "Height mismatch " + contextMessage);
 
 
             expPosition = viewport.viewportToViewerElementCoordinates(
-                new OpenSeadragon.Point( 0.5, 0.6 ) ).apply( Math.round );
-            actPosition = $( "#fixed-overlay" ).position();
-            equal( actPosition.left, expPosition.x, "Fixed overlay X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Fixed overlay Y position mismatch " + contextMessage );
+                new OpenSeadragon.Point(0.5, 0.6));
+            actPosition = $("#fixed-overlay").position();
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "Fixed overlay X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Fixed overlay Y position mismatch " + contextMessage);
 
-            equal( $( "#fixed-overlay" ).width(), 70, "Fixed overlay width mismatch " + contextMessage );
-            equal( $( "#fixed-overlay" ).height( ), 60, "Fixed overlay height mismatch " + contextMessage );
+            Util.assessNumericValue($("#fixed-overlay").width(), 70, epsilon,
+                "Fixed overlay width mismatch " + contextMessage);
+            Util.assessNumericValue($("#fixed-overlay").height(), 60, epsilon,
+                "Fixed overlay height mismatch " + contextMessage);
         }
 
         waitForViewer( function() {
@@ -373,22 +391,25 @@
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
-                new OpenSeadragon.Point( 0.2, 0.1 ) ).apply( Math.round );
-            var actPosition = $( "#overlay" ).position();
-            equal( actPosition.left, expPosition.x, "X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Y position mismatch " + contextMessage );
+                new OpenSeadragon.Point(0.2, 0.1));
+            var actPosition = $("#overlay").position();
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Y position mismatch " + contextMessage);
         }
 
         function checkFixedOverlayPosition( expectedOffset, contextMessage ) {
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
-                new OpenSeadragon.Point( 0.5, 0.6 ) )
-                .apply( Math.round )
-                .plus( expectedOffset );
-            var actPosition = $( "#fixed-overlay" ).position();
-            equal( actPosition.left, expPosition.x, "Fixed overlay X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Fixed overlay Y position mismatch " + contextMessage );
+                new OpenSeadragon.Point(0.5, 0.6))
+                .plus(expectedOffset);
+            var actPosition = $("#fixed-overlay").position();
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "Fixed overlay X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Fixed overlay Y position mismatch " + contextMessage);
         }
 
         waitForViewer( function() {
@@ -448,12 +469,13 @@
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
-                new OpenSeadragon.Point( 0.5, 0.6 ) )
-                .apply( Math.round )
-                .plus( expectedOffset );
-            var actPosition = $( "#fixed-overlay" ).position();
-            equal( actPosition.left, expPosition.x, "Fixed overlay X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Fixed overlay Y position mismatch " + contextMessage );
+                new OpenSeadragon.Point(0.5, 0.6))
+                .plus(expectedOffset);
+            var actPosition = $("#fixed-overlay").position();
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "Fixed overlay X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Fixed overlay Y position mismatch " + contextMessage);
         }
 
         waitForViewer( function() {
@@ -502,12 +524,13 @@
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
-                new OpenSeadragon.Point( 0.5, 0.6 ) )
-                .apply( Math.round )
-                .plus( expectedOffset );
+                new OpenSeadragon.Point(0.5, 0.6))
+                .plus(expectedOffset);
             var actPosition = $( "#fixed-overlay" ).position();
-            equal( actPosition.left, expPosition.x, "Fixed overlay X position mismatch " + contextMessage );
-            equal( actPosition.top, expPosition.y, "Fixed overlay Y position mismatch " + contextMessage );
+            Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
+                "Fixed overlay X position mismatch " + contextMessage);
+            Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
+                "Fixed overlay Y position mismatch " + contextMessage);
         }
 
         waitForViewer( function() {

--- a/test/modules/overlays.js
+++ b/test/modules/overlays.js
@@ -982,4 +982,63 @@
             start();
         });
     });
+
+    // ----------
+    asyncTest('Fully scaled overlay rotation mode BOUNDING_BOX', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100, // Faster animation = faster tests
+            degrees: 45,
+            overlays: [{
+                    id: "fully-scaled-overlay",
+                    x: 1,
+                    y: 1,
+                    width: 1,
+                    height: 1,
+                    placement: OpenSeadragon.Placement.BOTTOM_RIGHT,
+                    rotationMode: OpenSeadragon.OverlayRotationMode.BOUNDING_BOX
+                }]
+        });
+
+        viewer.addOnceHandler('open', function() {
+            var viewport = viewer.viewport;
+
+            var $overlay = $("#fully-scaled-overlay");
+            var expectedRect = viewport.viewportToViewerElementRectangle(
+                new OpenSeadragon.Rect(0, 0, 1, 1)).getBoundingBox();
+            var actualPosition = $overlay.position();
+            Util.assessNumericValue(actualPosition.left, expectedRect.x, epsilon,
+                "Scaled overlay position.x should adjust to rotation.");
+            Util.assessNumericValue(actualPosition.top, expectedRect.y, epsilon,
+                "Scaled overlay position.y should adjust to rotation.");
+
+            var actualWidth = $overlay.width();
+            var actualHeight = $overlay.height();
+            Util.assessNumericValue(actualWidth, expectedRect.width, epsilon,
+                "Scaled overlay width should not adjust to rotation.");
+            Util.assessNumericValue(actualHeight, expectedRect.height, epsilon,
+                "Scaled overlay height should not adjust to rotation.");
+
+            var actualBounds = viewer.getOverlayById("fully-scaled-overlay")
+                .getBounds(viewport);
+            var expectedBounds = new OpenSeadragon.Rect(
+                    0.5, -0.5, Math.sqrt(2), Math.sqrt(2), 45);
+            var boundsEpsilon = 0.000001;
+            Util.assessNumericValue(actualBounds.x, expectedBounds.x, boundsEpsilon,
+                "The fully scaled overlay should have adjusted bounds.x");
+            Util.assessNumericValue(actualBounds.y, expectedBounds.y, boundsEpsilon,
+                "The fully scaled overlay should have adjusted bounds.y");
+            Util.assessNumericValue(actualBounds.width, expectedBounds.width, boundsEpsilon,
+                "The fully scaled overlay should have adjusted bounds.width");
+            Util.assessNumericValue(actualBounds.height, expectedBounds.height, boundsEpsilon,
+                "The fully scaled overlay should have adjusted bounds.height");
+            Util.assessNumericValue(actualBounds.degrees, expectedBounds.degrees, boundsEpsilon,
+                "The fully scaled overlay should have adjusted bounds.degrees");
+
+            start();
+        });
+    });
+
 })();

--- a/test/modules/overlays.js
+++ b/test/modules/overlays.js
@@ -715,7 +715,7 @@
             var expectedBounds = new OpenSeadragon.Rect(0, 0, 1, 1);
             ok(expectedBounds.equals(actualBounds),
                 "The fully scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
 
             actualBounds = viewer.getOverlayById("horizontally-scaled-overlay")
@@ -724,7 +724,7 @@
                 0, 0.5 - notScaledSize.y / 2, 1, notScaledSize.y);
             ok(expectedBounds.equals(actualBounds),
                 "The horizontally scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
             actualBounds = viewer.getOverlayById("vertically-scaled-overlay")
                 .getBounds(viewer.viewport);
@@ -732,7 +732,7 @@
                 0, 0, notScaledSize.x, 1);
             ok(expectedBounds.equals(actualBounds),
                 "The vertically scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
             actualBounds = viewer.getOverlayById("not-scaled-overlay")
                 .getBounds(viewer.viewport);
@@ -740,7 +740,7 @@
                 1 - notScaledSize.x, 0, notScaledSize.x, notScaledSize.y);
             ok(expectedBounds.equals(actualBounds),
                 "The not scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
             start();
         });
@@ -793,7 +793,7 @@
                 .rotate(-45, new OpenSeadragon.Point(1, 1));
             ok(expectedBounds.equals(actualBounds),
                 "The fully scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
             start();
         });
@@ -855,7 +855,7 @@
                 .rotate(-45, new OpenSeadragon.Point(0.5, 0.5));
             ok(expectedBounds.equals(actualBounds),
                 "The horizontally scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
             start();
         });
@@ -917,7 +917,7 @@
                 .rotate(-45, new OpenSeadragon.Point(0, 0.5));
             ok(expectedBounds.equals(actualBounds),
                 "The vertically scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
             start();
         });
@@ -977,7 +977,7 @@
                 .rotate(-45, new OpenSeadragon.Point(1, 0));
             ok(expectedBounds.equals(actualBounds),
                 "Not scaled overlay should have bounds " +
-                expectedBounds.toString() + " but found " + actualBounds);
+                expectedBounds + " but found " + actualBounds);
 
             start();
         });
@@ -1041,4 +1041,69 @@
         });
     });
 
+    // ----------
+    asyncTest('Fully scaled overlay rotation mode EXACT', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100, // Faster animation = faster tests
+            degrees: 45,
+            overlays: [{
+                    id: "fully-scaled-overlay",
+                    x: 1,
+                    y: 1,
+                    width: 1,
+                    height: 1,
+                    placement: OpenSeadragon.Placement.BOTTOM_RIGHT,
+                    rotationMode: OpenSeadragon.OverlayRotationMode.EXACT
+                }]
+        });
+
+        viewer.addOnceHandler('open', function() {
+            var viewport = viewer.viewport;
+
+            var $overlay = $("#fully-scaled-overlay");
+            var expectedSize = viewport.deltaPixelsFromPointsNoRotate(
+                new OpenSeadragon.Point(1, 1));
+            var expectedPosition = viewport.pixelFromPoint(
+                new OpenSeadragon.Point(1, 1))
+                .minus(expectedSize);
+            // We can't rely on jQuery.position with transforms.
+            var actualStyle = $overlay.get(0).style;
+            var left = Number(actualStyle.left.replace("px", ""));
+            var top = Number(actualStyle.top.replace("px", ""));
+            Util.assessNumericValue(left, expectedPosition.x, epsilon,
+                "Scaled overlay position.x should adjust to rotation.");
+            Util.assessNumericValue(top, expectedPosition.y, epsilon,
+                "Scaled overlay position.y should adjust to rotation.");
+
+            var actualWidth = $overlay.width();
+            var actualHeight = $overlay.height();
+            Util.assessNumericValue(actualWidth, expectedSize.x, epsilon,
+                "Scaled overlay width should not adjust to rotation.");
+            Util.assessNumericValue(actualHeight, expectedSize.y, epsilon,
+                "Scaled overlay height should not adjust to rotation.");
+
+            var transformOriginProp = OpenSeadragon.getCssPropertyWithVendorPrefix(
+                'transformOrigin');
+            var transformProp = OpenSeadragon.getCssPropertyWithVendorPrefix(
+                'transform');
+            var transformOrigin = actualStyle[transformOriginProp];
+            // Some browsers replace "right bottom" by "100% 100%"
+            ok(transformOrigin.match(/(100% 100%)|(right bottom)/),
+                "Transform origin should be right bottom. Got: " + transformOrigin);
+            equal(actualStyle[transformProp], "rotate(45deg)",
+                "Transform should be rotate(45deg).");
+
+            var actualBounds = viewer.getOverlayById("fully-scaled-overlay")
+                .getBounds(viewport);
+            var expectedBounds = new OpenSeadragon.Rect(0, 0, 1, 1);
+            ok(expectedBounds.equals(actualBounds),
+                "The fully scaled overlay should have bounds " +
+                expectedBounds + " but found " + actualBounds);
+
+            start();
+        });
+    });
 })();

--- a/test/modules/overlays.js
+++ b/test/modules/overlays.js
@@ -1,111 +1,111 @@
 /* global QUnit, module, Util, $, console, test, asyncTest, start, ok, equal, testLog */
 
-( function() {
+(function() {
     var viewer;
     // jQuery.position can give results quite different than what set in style.left
     var epsilon = 1;
 
-    module( "Overlays", {
+    module("Overlays", {
         setup: function() {
-            var example = $( '<div id="example-overlays"></div>' ).appendTo( "#qunit-fixture" );
-            var fixedOverlay = $( '<div id="fixed-overlay"></div>' ).appendTo( example );
-            fixedOverlay.width( 70 );
-            fixedOverlay.height( 60 );
+            var example = $('<div id="example-overlays"></div>').appendTo("#qunit-fixture");
+            var fixedOverlay = $('<div id="fixed-overlay"></div>').appendTo(example);
+            fixedOverlay.width(70);
+            fixedOverlay.height(60);
 
             testLog.reset();
         },
         teardown: function() {
             resetTestVariables();
         }
-    } );
+    });
 
     var resetTestVariables = function() {
-        if ( viewer ) {
+        if (viewer) {
             viewer.close();
         }
     };
 
-    function waitForViewer( handler, count ) {
-        if ( typeof count !== "number" ) {
+    function waitForViewer(handler, count) {
+        if (typeof count !== "number") {
             count = 0;
         }
         var ready = viewer.isOpen() &&
             viewer.drawer !== null &&
             !viewer.world.needsDraw() &&
-            Util.equalsWithVariance( viewer.viewport.getBounds( true ).x,
-                viewer.viewport.getBounds().x, 0.000 ) &&
-            Util.equalsWithVariance( viewer.viewport.getBounds( true ).y,
-                viewer.viewport.getBounds().y, 0.000 ) &&
-            Util.equalsWithVariance( viewer.viewport.getBounds( true ).width,
-                viewer.viewport.getBounds().width, 0.000 );
+            Util.equalsWithVariance(viewer.viewport.getBounds(true).x,
+                viewer.viewport.getBounds().x, 0.000) &&
+            Util.equalsWithVariance(viewer.viewport.getBounds(true).y,
+                viewer.viewport.getBounds().y, 0.000) &&
+            Util.equalsWithVariance(viewer.viewport.getBounds(true).width,
+                viewer.viewport.getBounds().width, 0.000);
 
-        if ( ready ) {
+        if (ready) {
             handler();
-        } else if ( count < 50 ) {
+        } else if (count < 50) {
             count++;
-            setTimeout( function() {
-                waitForViewer( handler, count );
-            }, 100 );
+            setTimeout(function() {
+                waitForViewer(handler, count);
+            }, 100);
         } else {
-            console.log( "waitForViewer:" + viewer.isOpen( ) + ":" + viewer.drawer +
-                ":" + viewer.world.needsDraw() );
+            console.log("waitForViewer:" + viewer.isOpen( ) + ":" + viewer.drawer +
+                ":" + viewer.world.needsDraw());
             handler();
         }
     }
 
-    asyncTest( 'Overlays via viewer options', function() {
+    asyncTest('Overlays via viewer options', function() {
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
-            tileSources: [ '/test/data/testpattern.dzi', '/test/data/testpattern.dzi' ],
+            tileSources: ['/test/data/testpattern.dzi', '/test/data/testpattern.dzi'],
             springStiffness: 100, // Faster animation = faster tests
-            overlays: [ {
+            overlays: [{
                     x: 0.1,
                     y: 0.4,
                     width: 0.09,
                     height: 0.09,
                     id: "overlay"
-                } ]
-        } );
-        viewer.addHandler( 'open', openHandler );
+                }]
+        });
+        viewer.addHandler('open', openHandler);
 
         function openHandler() {
-            viewer.removeHandler( 'open', openHandler );
+            viewer.removeHandler('open', openHandler);
 
-            equal( viewer.overlays.length, 1, "Global overlay should be added." );
-            equal( viewer.currentOverlays.length, 1, "Global overlay should be open." );
+            equal(viewer.overlays.length, 1, "Global overlay should be added.");
+            equal(viewer.currentOverlays.length, 1, "Global overlay should be open.");
 
-            viewer.addHandler( 'open', openPageHandler );
-            viewer.goToPage( 1 );
+            viewer.addHandler('open', openPageHandler);
+            viewer.goToPage(1);
         }
 
         function openPageHandler() {
-            viewer.removeHandler( 'open', openPageHandler );
+            viewer.removeHandler('open', openPageHandler);
 
-            equal( viewer.overlays.length, 1, "Global overlay should stay after page switch." );
-            equal( viewer.currentOverlays.length, 1, "Global overlay should re-open after page switch." );
+            equal(viewer.overlays.length, 1, "Global overlay should stay after page switch.");
+            equal(viewer.currentOverlays.length, 1, "Global overlay should re-open after page switch.");
 
-            viewer.addHandler( 'close', closeHandler );
+            viewer.addHandler('close', closeHandler);
             viewer.close();
         }
 
         function closeHandler() {
-            viewer.removeHandler( 'close', closeHandler );
+            viewer.removeHandler('close', closeHandler);
 
-            equal( viewer.overlays.length, 1, "Global overlay should not be removed on close." );
-            equal( viewer.currentOverlays.length, 0, "Global overlay should be closed on close." );
+            equal(viewer.overlays.length, 1, "Global overlay should not be removed on close.");
+            equal(viewer.currentOverlays.length, 0, "Global overlay should be closed on close.");
 
             start();
         }
-    } );
+    });
 
-    asyncTest( 'Page Overlays via viewer options', function() {
+    asyncTest('Page Overlays via viewer options', function() {
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
-            tileSources: [ {
+            tileSources: [{
                     Image: {
                         xmlns: "http://schemas.microsoft.com/deepzoom/2008",
                         Url: "/test/data/testpattern_files/",
@@ -117,13 +117,13 @@
                             Height: 1000
                         }
                     },
-                    overlays: [ {
+                    overlays: [{
                             x: 0.1,
                             y: 0.4,
                             width: 0.09,
                             height: 0.09,
                             id: "overlay"
-                        } ]
+                        }]
                 }, {
                     Image: {
                         xmlns: "http://schemas.microsoft.com/deepzoom/2008",
@@ -136,96 +136,96 @@
                             Height: 1000
                         }
                     }
-                } ],
+                }],
             springStiffness: 100 // Faster animation = faster tests
-        } );
-        viewer.addHandler( 'open', openHandler );
+        });
+        viewer.addHandler('open', openHandler);
 
         function openHandler() {
-            viewer.removeHandler( 'open', openHandler );
+            viewer.removeHandler('open', openHandler);
 
-            equal( viewer.overlays.length, 0, "No global overlay should be added." );
-            equal( viewer.currentOverlays.length, 1, "Page overlay should be open." );
+            equal(viewer.overlays.length, 0, "No global overlay should be added.");
+            equal(viewer.currentOverlays.length, 1, "Page overlay should be open.");
 
-            viewer.addHandler( 'open', openPageHandler );
-            viewer.goToPage( 1 );
+            viewer.addHandler('open', openPageHandler);
+            viewer.goToPage(1);
         }
 
         function openPageHandler() {
-            viewer.removeHandler( 'open', openPageHandler );
+            viewer.removeHandler('open', openPageHandler);
 
-            equal( viewer.overlays.length, 0, "No global overlay should be added after page switch." );
-            equal( viewer.currentOverlays.length, 0, "No page overlay should be opened after page switch." );
+            equal(viewer.overlays.length, 0, "No global overlay should be added after page switch.");
+            equal(viewer.currentOverlays.length, 0, "No page overlay should be opened after page switch.");
 
-            viewer.addHandler( 'close', closeHandler );
+            viewer.addHandler('close', closeHandler);
             viewer.close();
         }
 
         function closeHandler() {
-            viewer.removeHandler( 'close', closeHandler );
+            viewer.removeHandler('close', closeHandler);
 
-            equal( viewer.overlays.length, 0, "No global overlay should be added on close." );
-            equal( viewer.currentOverlays.length, 0, "Page overlay should be closed on close." );
+            equal(viewer.overlays.length, 0, "No global overlay should be added on close.");
+            equal(viewer.currentOverlays.length, 0, "Page overlay should be closed on close.");
 
             start();
         }
-    } );
+    });
 
-    asyncTest( 'Overlays via addOverlay method', function() {
+    asyncTest('Overlays via addOverlay method', function() {
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
-            tileSources: [ '/test/data/testpattern.dzi', '/test/data/testpattern.dzi' ],
+            tileSources: ['/test/data/testpattern.dzi', '/test/data/testpattern.dzi'],
             springStiffness: 100 // Faster animation = faster tests
-        } );
-        viewer.addHandler( 'open', openHandler );
+        });
+        viewer.addHandler('open', openHandler);
 
         function openHandler() {
-            viewer.removeHandler( 'open', openHandler );
+            viewer.removeHandler('open', openHandler);
 
-            equal( viewer.overlays.length, 0, "No global overlay should be added." );
-            equal( viewer.currentOverlays.length, 0, "No overlay should be open." );
+            equal(viewer.overlays.length, 0, "No global overlay should be added.");
+            equal(viewer.currentOverlays.length, 0, "No overlay should be open.");
 
-            var rect = new OpenSeadragon.Rect( 0.1, 0.1, 0.1, 0.1 );
-            var overlay = $( "<div/>" ).prop( "id", "overlay" ).get( 0 );
-            viewer.addOverlay( overlay, rect );
-            equal( viewer.overlays.length, 0, "No manual overlay should be added as global overlay." );
-            equal( viewer.currentOverlays.length, 1, "A manual overlay should be open." );
+            var rect = new OpenSeadragon.Rect(0.1, 0.1, 0.1, 0.1);
+            var overlay = $("<div/>").prop("id", "overlay").get(0);
+            viewer.addOverlay(overlay, rect);
+            equal(viewer.overlays.length, 0, "No manual overlay should be added as global overlay.");
+            equal(viewer.currentOverlays.length, 1, "A manual overlay should be open.");
 
-            viewer.addHandler( 'open', openPageHandler );
-            viewer.goToPage( 1 );
+            viewer.addHandler('open', openPageHandler);
+            viewer.goToPage(1);
         }
 
         function openPageHandler() {
-            viewer.removeHandler( 'open', openPageHandler );
+            viewer.removeHandler('open', openPageHandler);
 
-            equal( viewer.overlays.length, 0, "No global overlay should be added after page switch." );
-            equal( viewer.currentOverlays.length, 0, "Manual overlay should be removed after page switch." );
+            equal(viewer.overlays.length, 0, "No global overlay should be added after page switch.");
+            equal(viewer.currentOverlays.length, 0, "Manual overlay should be removed after page switch.");
 
-            viewer.addHandler( 'close', closeHandler );
+            viewer.addHandler('close', closeHandler);
             viewer.close();
         }
 
         function closeHandler() {
-            viewer.removeHandler( 'close', closeHandler );
+            viewer.removeHandler('close', closeHandler);
 
-            equal( viewer.overlays.length, 0, "No global overlay should be added on close." );
-            equal( viewer.currentOverlays.length, 0, "Manual overlay should be removed on close." );
+            equal(viewer.overlays.length, 0, "No global overlay should be added on close.");
+            equal(viewer.currentOverlays.length, 0, "Manual overlay should be removed on close.");
 
             start();
         }
 
-    } );
+    });
 
-    asyncTest( 'Overlays size in pixels', function() {
+    asyncTest('Overlays size in pixels', function() {
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
             tileSources: '/test/data/testpattern.dzi',
             springStiffness: 100, // Faster animation = faster tests
-            overlays: [ {
+            overlays: [{
                     px: 13,
                     py: 120,
                     width: 124,
@@ -236,8 +236,8 @@
                     py: 500,
                     id: "fixed-overlay",
                     placement: "TOP_LEFT"
-                } ]
-        } );
+                }]
+        });
 
         function checkOverlayPosition(contextMessage) {
             var viewport = viewer.viewport;
@@ -273,31 +273,31 @@
                 "Fixed overlay height mismatch " + contextMessage);
         }
 
-        waitForViewer( function() {
-            checkOverlayPosition( "after opening using image coordinates" );
+        waitForViewer(function() {
+            checkOverlayPosition("after opening using image coordinates");
 
-            viewer.viewport.zoomBy( 1.1 ).panBy( new OpenSeadragon.Point( 0.1, 0.2 ) );
-            waitForViewer( function() {
-                checkOverlayPosition( "after zoom and pan using image coordinates" );
+            viewer.viewport.zoomBy(1.1).panBy(new OpenSeadragon.Point(0.1, 0.2));
+            waitForViewer(function() {
+                checkOverlayPosition("after zoom and pan using image coordinates");
 
                 viewer.viewport.goHome();
-                waitForViewer( function() {
-                    checkOverlayPosition( "after goHome using image coordinates" );
+                waitForViewer(function() {
+                    checkOverlayPosition("after goHome using image coordinates");
                     start();
-                } );
-            } );
+                });
+            });
 
-        } );
-    } );
+        });
+    });
 
-    asyncTest( 'Overlays size in points', function() {
+    asyncTest('Overlays size in points', function() {
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
             tileSources: '/test/data/testpattern.dzi',
             springStiffness: 100, // Faster animation = faster tests
-            overlays: [ {
+            overlays: [{
                     x: 0.2,
                     y: 0.1,
                     width: 0.5,
@@ -308,15 +308,15 @@
                     y: 0.6,
                     id: "fixed-overlay",
                     placement: "TOP_LEFT"
-                } ]
-        } );
+                }]
+        });
 
-        function checkOverlayPosition( contextMessage ) {
+        function checkOverlayPosition(contextMessage) {
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
                 new OpenSeadragon.Point(0.2, 0.1));
-            var actPosition = $( "#overlay" ).position();
+            var actPosition = $("#overlay").position();
             Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
                 "X position mismatch " + contextMessage);
             Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
@@ -344,34 +344,34 @@
                 "Fixed overlay height mismatch " + contextMessage);
         }
 
-        waitForViewer( function() {
-            checkOverlayPosition( "after opening using viewport coordinates" );
+        waitForViewer(function() {
+            checkOverlayPosition("after opening using viewport coordinates");
 
-            viewer.viewport.zoomBy( 1.1 ).panBy( new OpenSeadragon.Point( 0.1, 0.2 ) );
-            waitForViewer( function() {
-                checkOverlayPosition( "after zoom and pan using viewport coordinates" );
+            viewer.viewport.zoomBy(1.1).panBy(new OpenSeadragon.Point(0.1, 0.2));
+            waitForViewer(function() {
+                checkOverlayPosition("after zoom and pan using viewport coordinates");
 
                 viewer.viewport.goHome();
-                waitForViewer( function() {
-                    checkOverlayPosition( "after goHome using viewport coordinates" );
+                waitForViewer(function() {
+                    checkOverlayPosition("after goHome using viewport coordinates");
                     start();
-                } );
-            } );
+                });
+            });
 
-        } );
-    } );
+        });
+    });
 
-    asyncTest( 'Overlays placement', function() {
+    asyncTest('Overlays placement', function() {
 
-        var scalableOverlayLocation = new OpenSeadragon.Rect( 0.2, 0.1, 0.5, 0.1 );
-        var fixedOverlayLocation = new OpenSeadragon.Point( 0.5, 0.6 );
+        var scalableOverlayLocation = new OpenSeadragon.Rect(0.2, 0.1, 0.5, 0.1);
+        var fixedOverlayLocation = new OpenSeadragon.Point(0.5, 0.6);
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
             tileSources: '/test/data/testpattern.dzi',
             springStiffness: 100, // Faster animation = faster tests
-            overlays: [ {
+            overlays: [{
                     x: scalableOverlayLocation.x,
                     y: scalableOverlayLocation.y,
                     width: scalableOverlayLocation.width,
@@ -383,11 +383,11 @@
                     y: fixedOverlayLocation.y,
                     id: "fixed-overlay",
                     placement: "TOP_LEFT"
-                } ]
-        } );
+                }]
+        });
 
         // Scalable overlays are always TOP_LEFT
-        function checkScalableOverlayPosition( contextMessage ) {
+        function checkScalableOverlayPosition(contextMessage) {
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
@@ -399,7 +399,7 @@
                 "Y position mismatch " + contextMessage);
         }
 
-        function checkFixedOverlayPosition( expectedOffset, contextMessage ) {
+        function checkFixedOverlayPosition(expectedOffset, contextMessage) {
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
@@ -412,60 +412,60 @@
                 "Fixed overlay Y position mismatch " + contextMessage);
         }
 
-        waitForViewer( function() {
+        waitForViewer(function() {
 
-            checkScalableOverlayPosition( "with TOP_LEFT placement." );
-            checkFixedOverlayPosition( new OpenSeadragon.Point( 0, 0 ),
-                "with TOP_LEFT placement." );
+            checkScalableOverlayPosition("with TOP_LEFT placement.");
+            checkFixedOverlayPosition(new OpenSeadragon.Point(0, 0),
+                "with TOP_LEFT placement.");
 
             // Check that legacy OpenSeadragon.OverlayPlacement is still working
-            viewer.updateOverlay( "overlay", scalableOverlayLocation,
-                OpenSeadragon.OverlayPlacement.CENTER );
-            viewer.updateOverlay( "fixed-overlay", fixedOverlayLocation,
-                OpenSeadragon.OverlayPlacement.CENTER );
+            viewer.updateOverlay("overlay", scalableOverlayLocation,
+                OpenSeadragon.OverlayPlacement.CENTER);
+            viewer.updateOverlay("fixed-overlay", fixedOverlayLocation,
+                OpenSeadragon.OverlayPlacement.CENTER);
 
-            setTimeout( function() {
-                checkScalableOverlayPosition( "with CENTER placement." );
-                checkFixedOverlayPosition( new OpenSeadragon.Point( -35, -30 ),
-                    "with CENTER placement." );
+            setTimeout(function() {
+                checkScalableOverlayPosition("with CENTER placement.");
+                checkFixedOverlayPosition(new OpenSeadragon.Point(-35, -30),
+                    "with CENTER placement.");
 
                 // Check that new OpenSeadragon.Placement is working
-                viewer.updateOverlay( "overlay", scalableOverlayLocation,
-                    OpenSeadragon.Placement.BOTTOM_RIGHT );
-                viewer.updateOverlay( "fixed-overlay", fixedOverlayLocation,
-                    OpenSeadragon.Placement.BOTTOM_RIGHT );
-                setTimeout( function() {
-                    checkScalableOverlayPosition( "with BOTTOM_RIGHT placement." );
-                    checkFixedOverlayPosition( new OpenSeadragon.Point( -70, -60 ),
-                        "with BOTTOM_RIGHT placement." );
+                viewer.updateOverlay("overlay", scalableOverlayLocation,
+                    OpenSeadragon.Placement.BOTTOM_RIGHT);
+                viewer.updateOverlay("fixed-overlay", fixedOverlayLocation,
+                    OpenSeadragon.Placement.BOTTOM_RIGHT);
+                setTimeout(function() {
+                    checkScalableOverlayPosition("with BOTTOM_RIGHT placement.");
+                    checkFixedOverlayPosition(new OpenSeadragon.Point(-70, -60),
+                        "with BOTTOM_RIGHT placement.");
 
                     start();
-                }, 100 );
+                }, 100);
 
-            }, 100 );
+            }, 100);
 
-        } );
-    } );
+        });
+    });
 
-    asyncTest( 'Overlays placement and resizing check', function() {
+    asyncTest('Overlays placement and resizing check', function() {
 
-        var fixedOverlayLocation = new OpenSeadragon.Point( 0.5, 0.6 );
+        var fixedOverlayLocation = new OpenSeadragon.Point(0.5, 0.6);
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
             tileSources: '/test/data/testpattern.dzi',
             springStiffness: 100, // Faster animation = faster tests
-            overlays: [ {
+            overlays: [{
                     x: fixedOverlayLocation.x,
                     y: fixedOverlayLocation.y,
                     id: "fixed-overlay",
                     placement: "CENTER",
                     checkResize: true
-                } ]
-        } );
+                }]
+        });
 
-        function checkFixedOverlayPosition( expectedOffset, contextMessage ) {
+        function checkFixedOverlayPosition(expectedOffset, contextMessage) {
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
@@ -478,114 +478,271 @@
                 "Fixed overlay Y position mismatch " + contextMessage);
         }
 
-        waitForViewer( function() {
-            checkFixedOverlayPosition( new OpenSeadragon.Point( -35, -30 ),
-                "with overlay of size 70,60." );
+        waitForViewer(function() {
+            checkFixedOverlayPosition(new OpenSeadragon.Point(-35, -30),
+                "with overlay of size 70,60.");
 
-            $( "#fixed-overlay" ).width( 50 );
-            $( "#fixed-overlay" ).height( 40 );
+            $("#fixed-overlay").width(50);
+            $("#fixed-overlay").height(40);
 
             // The resizing of the overlays is not detected by the viewer's loop.
             viewer.forceRedraw();
 
-            setTimeout( function() {
-                checkFixedOverlayPosition( new OpenSeadragon.Point( -25, -20 ),
-                    "with overlay of size 50,40." );
+            setTimeout(function() {
+                checkFixedOverlayPosition(new OpenSeadragon.Point(-25, -20),
+                    "with overlay of size 50,40.");
 
                 // Restore original size
-                $( "#fixed-overlay" ).width( 70 );
-                $( "#fixed-overlay" ).height( 60 );
+                $("#fixed-overlay").width(70);
+                $("#fixed-overlay").height(60);
 
                 start();
-            }, 100 );
-        } );
+            }, 100);
+        });
 
-    } );
+    });
 
-    asyncTest( 'Overlays placement and no resizing check', function() {
+    asyncTest('Overlays placement and no resizing check', function() {
 
-        var fixedOverlayLocation = new OpenSeadragon.Point( 0.5, 0.6 );
+        var fixedOverlayLocation = new OpenSeadragon.Point(0.5, 0.6);
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
             tileSources: '/test/data/testpattern.dzi',
             springStiffness: 100, // Faster animation = faster tests
-            overlays: [ {
+            overlays: [{
                     x: fixedOverlayLocation.x,
                     y: fixedOverlayLocation.y,
                     id: "fixed-overlay",
                     placement: "CENTER",
                     checkResize: false
-                } ]
-        } );
+                }]
+        });
 
-        function checkFixedOverlayPosition( expectedOffset, contextMessage ) {
+        function checkFixedOverlayPosition(expectedOffset, contextMessage) {
             var viewport = viewer.viewport;
 
             var expPosition = viewport.viewportToViewerElementCoordinates(
                 new OpenSeadragon.Point(0.5, 0.6))
                 .plus(expectedOffset);
-            var actPosition = $( "#fixed-overlay" ).position();
+            var actPosition = $("#fixed-overlay").position();
             Util.assessNumericValue(actPosition.left, expPosition.x, epsilon,
                 "Fixed overlay X position mismatch " + contextMessage);
             Util.assessNumericValue(actPosition.top, expPosition.y, epsilon,
                 "Fixed overlay Y position mismatch " + contextMessage);
         }
 
-        waitForViewer( function() {
-            checkFixedOverlayPosition( new OpenSeadragon.Point( -35, -30 ),
-                "with overlay of size 70,60." );
+        waitForViewer(function() {
+            checkFixedOverlayPosition(new OpenSeadragon.Point(-35, -30),
+                "with overlay of size 70,60.");
 
-            $( "#fixed-overlay" ).width( 50 );
-            $( "#fixed-overlay" ).height( 40 );
+            $("#fixed-overlay").width(50);
+            $("#fixed-overlay").height(40);
 
             // The resizing of the overlays is not detected by the viewer's loop.
             viewer.forceRedraw();
 
-            setTimeout( function() {
-                checkFixedOverlayPosition( new OpenSeadragon.Point( -35, -30 ),
-                    "with overlay of size 50,40." );
+            setTimeout(function() {
+                checkFixedOverlayPosition(new OpenSeadragon.Point(-35, -30),
+                    "with overlay of size 50,40.");
 
                 // Restore original size
-                $( "#fixed-overlay" ).width( 70 );
-                $( "#fixed-overlay" ).height( 60 );
+                $("#fixed-overlay").width(70);
+                $("#fixed-overlay").height(60);
 
                 start();
-            }, 100 );
-        } );
+            }, 100);
+        });
 
-    } );
+    });
 
     // ----------
     asyncTest('overlays appear immediately', function() {
         equal($('#immediate-overlay0').length, 0, 'overlay 0 does not exist');
         equal($('#immediate-overlay1').length, 0, 'overlay 1 does not exist');
 
-        viewer = OpenSeadragon( {
+        viewer = OpenSeadragon({
             id: 'example-overlays',
             prefixUrl: '/build/openseadragon/images/',
             tileSources: '/test/data/testpattern.dzi',
             springStiffness: 100, // Faster animation = faster tests
-            overlays: [ {
+            overlays: [{
                     x: 0,
                     y: 0,
                     id: "immediate-overlay0"
-                } ]
-        } );
+                }]
+        });
 
         viewer.addHandler('open', function() {
             equal($('#immediate-overlay0').length, 1, 'overlay 0 exists');
 
-            viewer.addOverlay( {
+            viewer.addOverlay({
                 x: 0,
                 y: 0,
                 id: "immediate-overlay1"
-            } );
+            });
 
             equal($('#immediate-overlay1').length, 1, 'overlay 1 exists');
             start();
         });
     });
 
-} )( );
+    // ----------
+    asyncTest('Overlay scaled horizontally only', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100 // Faster animation = faster tests
+        });
+
+        viewer.addHandler('open', function() {
+            viewer.addOverlay({
+                id: "horizontally-scaled-overlay",
+                x: 0,
+                y: 0,
+                width: 1
+            });
+
+            var width = $("#horizontally-scaled-overlay").width();
+            var height = 100;
+            var zoom = 1.1;
+            $("#horizontally-scaled-overlay").get(0).style.height = height + "px";
+
+            viewer.viewport.zoomBy(zoom);
+
+            waitForViewer(function() {
+                var newWidth = $("#horizontally-scaled-overlay").width();
+                var newHeight = $("#horizontally-scaled-overlay").height();
+                equal(newWidth, width * zoom, "Width should be scaled.");
+                equal(newHeight, height, "Height should not be scaled.");
+
+                start();
+            });
+        });
+    });
+
+    // ----------
+    asyncTest('Overlay scaled vertically only', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100 // Faster animation = faster tests
+        });
+
+        viewer.addHandler('open', function() {
+            viewer.addOverlay({
+                id: "vertically-scaled-overlay",
+                x: 0,
+                y: 0,
+                height: 1
+            });
+
+            var width = 100;
+            var height = $("#vertically-scaled-overlay").height();
+            var zoom = 1.1;
+            $("#vertically-scaled-overlay").get(0).style.width = width + "px";
+
+            viewer.viewport.zoomBy(zoom);
+
+            waitForViewer(function() {
+                var newWidth = $("#vertically-scaled-overlay").width();
+                var newHeight = $("#vertically-scaled-overlay").height();
+                equal(newWidth, width, "Width should not be scaled.");
+                equal(newHeight, height * zoom, "Height should be scaled.");
+
+                start();
+            });
+        });
+    });
+
+    asyncTest('Overlay.getBounds', function() {
+        viewer = OpenSeadragon({
+            id: 'example-overlays',
+            prefixUrl: '/build/openseadragon/images/',
+            tileSources: '/test/data/testpattern.dzi',
+            springStiffness: 100 // Faster animation = faster tests
+        });
+
+        viewer.addHandler('open', function() {
+            viewer.addOverlay({
+                id: "fully-scaled-overlay",
+                x: 1,
+                y: 1,
+                width: 1,
+                height: 1,
+                placement: OpenSeadragon.Placement.BOTTOM_RIGHT
+            });
+            viewer.addOverlay({
+                id: "horizontally-scaled-overlay",
+                x: 0.5,
+                y: 0.5,
+                width: 1,
+                placement: OpenSeadragon.Placement.CENTER
+            });
+            viewer.addOverlay({
+                id: "vertically-scaled-overlay",
+                x: 0,
+                y: 0.5,
+                height: 1,
+                placement: OpenSeadragon.Placement.LEFT
+            });
+            viewer.addOverlay({
+                id: "not-scaled-overlay",
+                x: 1,
+                y: 0,
+                placement: OpenSeadragon.Placement.TOP_RIGHT
+            });
+
+            var notScaledWidth = 100;
+            var notScaledHeight = 100;
+            $("#horizontally-scaled-overlay").get(0).style.height = notScaledHeight + "px";
+            $("#vertically-scaled-overlay").get(0).style.width = notScaledWidth + "px";
+            $("#not-scaled-overlay").get(0).style.width = notScaledWidth + "px";
+            $("#not-scaled-overlay").get(0).style.height = notScaledHeight + "px";
+
+            var notScaledSize = viewer.viewport.deltaPointsFromPixelsNoRotate(
+                new OpenSeadragon.Point(notScaledWidth, notScaledHeight));
+
+            // Force refresh to takes new dimensions into account.
+            viewer._drawOverlays();
+
+            var actualBounds = viewer.getOverlayById("fully-scaled-overlay")
+                .getBounds();
+            var expectedBounds = new OpenSeadragon.Rect(0, 0, 1, 1);
+            ok(expectedBounds.equals(actualBounds),
+                "The fully scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+
+            actualBounds = viewer.getOverlayById("horizontally-scaled-overlay")
+                .getBounds(viewer.viewport);
+            expectedBounds = new OpenSeadragon.Rect(
+                0, 0.5 - notScaledSize.y / 2, 1, notScaledSize.y);
+            ok(expectedBounds.equals(actualBounds),
+                "The horizontally scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+            actualBounds = viewer.getOverlayById("vertically-scaled-overlay")
+                .getBounds(viewer.viewport);
+            expectedBounds = new OpenSeadragon.Rect(
+                0, 0, notScaledSize.x, 1);
+            ok(expectedBounds.equals(actualBounds),
+                "The vertically scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+            actualBounds = viewer.getOverlayById("not-scaled-overlay")
+                .getBounds(viewer.viewport);
+            expectedBounds = new OpenSeadragon.Rect(
+                1 - notScaledSize.x, 0, notScaledSize.x, notScaledSize.y);
+            ok(expectedBounds.equals(actualBounds),
+                "The not scaled overlay should have bounds " +
+                expectedBounds.toString() + " but found " + actualBounds);
+
+            start();
+        });
+    });
+
+})();


### PR DESCRIPTION
For now I did some clean up and added the possibility to scale only along one dimension.

I removed the rotation code for now, so don't merge yet.

TODO:
~~- [ ] fix positioning and size when overlay has (big) borders~~ I just realized that instead of borders, I should really use [outlines](https://developer.mozilla.org/en-US/docs/Web/CSS/outline)
- [X] fix overlays with rotation