### PR TITLE
Fix JSDoc.

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -97,11 +97,6 @@
  */
 
 /**
- * @module OpenSeadragon
- *
- */
-
-/**
  * @namespace OpenSeadragon
  *
  * @classdesc The root namespace for OpenSeadragon.  All utility methods
@@ -691,8 +686,7 @@
   * This function serves as a single point of instantiation for an {@link OpenSeadragon.Viewer}, including all
   * combinations of out-of-the-box configurable features.
   *
-  * @function OpenSeadragon
-  * @memberof module:OpenSeadragon
+  * @function
   * @param {OpenSeadragon.Options} options - Viewer options.
   * @returns {OpenSeadragon.Viewer}
   */

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -83,22 +83,8 @@
 
 
 /**
- * @version  <%= pkg.name %> <%= pkg.version %>
- *
- * @file
- * <h2><strong>OpenSeadragon - Javascript Deep Zooming</strong></h2>
- * <p>
- * OpenSeadragon provides an html interface for creating
- * deep zoom user interfaces.  The simplest examples include deep
- * zoom for large resolution images, and complex examples include
- * zoomable map interfaces driven by SVG files.
- * </p>
- *
- */
-
-/**
  * @namespace OpenSeadragon
- *
+ * @version <%= pkg.name %> <%= pkg.version %>
  * @classdesc The root namespace for OpenSeadragon.  All utility methods
  * and classes are defined on or below this namespace.
  *
@@ -686,7 +672,6 @@
   * This function serves as a single point of instantiation for an {@link OpenSeadragon.Viewer}, including all
   * combinations of out-of-the-box configurable features.
   *
-  * @function
   * @param {OpenSeadragon.Options} options - Viewer options.
   * @returns {OpenSeadragon.Viewer}
   */

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -42,6 +42,7 @@
      * @member OverlayPlacement
      * @memberof OpenSeadragon
      * @static
+     * @readonly
      * @type {Object}
      * @property {Number} CENTER
      * @property {Number} TOP_LEFT
@@ -57,8 +58,10 @@
 
     /**
      * An enumeration of possible ways to handle overlays rotation
+     * @member OverlayRotationMode
      * @memberOf OpenSeadragon
      * @static
+     * @readonly
      * @property {Number} NO_ROTATION The overlay ignore the viewport rotation.
      * @property {Number} EXACT The overlay use CSS 3 transforms to rotate with
      * the viewport. If the overlay contains text, it will get rotated as well.
@@ -66,11 +69,11 @@
      * taking the size of the bounding box of the rotated bounds.
      * Only valid for overlays with Rect location and scalable in both directions.
      */
-    $.OverlayRotationMode = {
+    $.OverlayRotationMode = $.freezeObject({
         NO_ROTATION: 1,
         EXACT: 2,
         BOUNDING_BOX: 3
-    };
+    });
 
     /**
      * @class Overlay

--- a/src/placement.js
+++ b/src/placement.js
@@ -35,8 +35,10 @@
 
     /**
      * An enumeration of positions to anchor an element.
+     * @member Placement
      * @memberOf OpenSeadragon
      * @static
+     * @readonly
      * @property {OpenSeadragon.Placement} CENTER
      * @property {OpenSeadragon.Placement} TOP_LEFT
      * @property {OpenSeadragon.Placement} TOP

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -544,7 +544,7 @@ $.TileSource.prototype = {
 
     /**
      * Responsible for retriving the url which will return an image for the
-     * region speified by the given x, y, and level components.
+     * region specified by the given x, y, and level components.
      * This method is not implemented by this class other than to throw an Error
      * announcing you have to implement it.  Because of the variety of tile
      * server technologies, and various specifications for building image

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -40,14 +40,19 @@ var nextHash = 1;
 
 /**
  *
- * The main point of entry into creating a zoomable image on the page.
- *
+ * The main point of entry into creating a zoomable image on the page.<br>
+ * <br>
  * We have provided an idiomatic javascript constructor which takes
- * a single object, but still support the legacy positional arguments.
- *
+ * a single object, but still support the legacy positional arguments.<br>
+ * <br>
  * The options below are given in order that they appeared in the constructor
- * as arguments and we translate a positional call into an idiomatic call.
- *
+ * as arguments and we translate a positional call into an idiomatic call.<br>
+ * <br>
+ * To create a viewer, you can use either of this methods:<br>
+ * <ul>
+ * <li><code>var viewer = new OpenSeadragon.Viewer(options);</code></li>
+ * <li><code>var viewer = OpenSeadragon(options);</code></li>
+ * </ul>
  * @class Viewer
  * @classdesc The main OpenSeadragon viewer class.
  *

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -317,8 +317,8 @@ $.Viewport.prototype = {
     },
 
     /**
-     * @function
      * The margins push the "home" region in from the sides by the specified amounts.
+     * @function
      * @returns {Object} Properties (Numbers, in screen coordinates): left, top, right, bottom.
      */
     getMargins: function() {
@@ -326,8 +326,8 @@ $.Viewport.prototype = {
     },
 
     /**
-     * @function
      * The margins push the "home" region in from the sides by the specified amounts.
+     * @function
      * @param {Object} margins - Properties (Numbers, in screen coordinates): left, top, right, bottom.
      */
     setMargins: function(margins) {


### PR DESCRIPTION
The doc is broken with the latest version of JSDoc.
It looks like a module can't be a namespace as well. The problem is that I can't find a way to document the window.OpenSeadragon function anymore.

I also fixed an issue with the margins methods which created a bug in the menu (see global at http://openseadragon.github.io/docs/ )