### PR TITLE
Fix Viewport.update with zoomPoint.

### DIFF
--- a/src/spring.js
+++ b/src/spring.js
@@ -234,6 +234,15 @@ $.Spring.prototype = {
         } else {
             this.current.value = currentValue;
         }
+    },
+
+    /**
+     * Returns whether the spring is at the target value
+     * @function
+     * @returns {Boolean} True if at target value, false otherwise
+     */
+    isAtTargetValue: function() {
+        return this.current.value === this.target.value;
     }
 };
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -888,37 +888,37 @@ $.Viewport.prototype = {
     },
 
     /**
+     * Update the zoom and center (X and Y) springs.
      * @function
+     * @returns {Boolean} True if any change has been made, false otherwise.
      */
     update: function() {
-        var oldZoomPixel,
-            newZoomPixel,
-            deltaZoomPixels,
-            deltaZoomPoints;
 
         if (this.zoomPoint) {
-            oldZoomPixel = this.pixelFromPoint( this.zoomPoint, true );
-        }
+            var oldZoomPixel = this.pixelFromPoint(this.zoomPoint, true);
+            this.zoomSpring.update();
+            var newZoomPixel = this.pixelFromPoint(this.zoomPoint, true);
 
-        this.zoomSpring.update();
+            var deltaZoomPixels = newZoomPixel.minus(oldZoomPixel);
+            var deltaZoomPoints = this.deltaPointsFromPixels(
+                deltaZoomPixels, true);
 
-        if (this.zoomPoint && this.zoomSpring.current.value != this._oldZoom) {
-            newZoomPixel    = this.pixelFromPoint( this.zoomPoint, true );
-            deltaZoomPixels = newZoomPixel.minus( oldZoomPixel );
-            deltaZoomPoints = this.deltaPointsFromPixels( deltaZoomPixels, true );
+            this.centerSpringX.shiftBy(deltaZoomPoints.x);
+            this.centerSpringY.shiftBy(deltaZoomPoints.y);
 
-            this.centerSpringX.shiftBy( deltaZoomPoints.x );
-            this.centerSpringY.shiftBy( deltaZoomPoints.y );
+            if (this.zoomSpring.isAtTargetValue()) {
+                this.zoomPoint = null;
+            }
         } else {
-            this.zoomPoint = null;
+            this.zoomSpring.update();
         }
 
         this.centerSpringX.update();
         this.centerSpringY.update();
 
-        var changed = this.centerSpringX.current.value != this._oldCenterX ||
-            this.centerSpringY.current.value != this._oldCenterY ||
-            this.zoomSpring.current.value != this._oldZoom;
+        var changed = this.centerSpringX.current.value !== this._oldCenterX ||
+            this.centerSpringY.current.value !== this._oldCenterY ||
+            this.zoomSpring.current.value !== this._oldZoom;
 
         this._oldCenterX = this.centerSpringX.current.value;
         this._oldCenterY = this.centerSpringY.current.value;


### PR DESCRIPTION
I noticed that `viewport.fitBounds` or `viewport.goHome` were sometimes not zooming to the correct location.

After investigation, it appears that the test to reset the zoom reference point in `viewport.update` was incorrect.
The main change of this commit is to change `this.zoomSpring.current.value == this._oldZoom` to `this.zoomSpring.isAtTargetValue()` as the condition to reset `this.zoomPoint` to null.
The previous test was working most of the time but with some bad luck on the timing `this.zoomPoint` was reset to early.