### PR TITLE
Optimize sketch canvas clearing and blending.

### DIFF
--- a/src/rectangle.js
+++ b/src/rectangle.js
@@ -368,6 +368,20 @@ $.Rect.prototype = {
     },
 
     /**
+     * Retrieves the smallest horizontal (degrees=0) rectangle which contains
+     * this rectangle and has integers x, y, width and height
+     * @returns {OpenSeadragon.Rect}
+     */
+    getIntegerBoundingBox: function() {
+        var boundingBox = this.getBoundingBox();
+        var x = Math.floor(boundingBox.x);
+        var y = Math.floor(boundingBox.y);
+        var width = Math.ceil(boundingBox.width + boundingBox.x - x);
+        var height = Math.ceil(boundingBox.height + boundingBox.y - y);
+        return new $.Rect(x, y, width, height);
+    },
+
+    /**
      * Provides a string representation of the rectangle which is useful for
      * debugging.
      * @function

--- a/src/tile.js
+++ b/src/tile.js
@@ -195,7 +195,7 @@ $.Tile.prototype = {
 
     // private
     _hasTransparencyChannel: function() {
-        return this.context2D || this.url.match('.png');
+        return !!this.context2D || this.url.match('.png');
     },
 
     /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1454,7 +1454,9 @@ function drawTiles( tiledImage, lastDrawn ) {
             // Except when edge smoothing, we only clean the part of the
             // sketch canvas we are going to use for performance reasons.
             bounds = tiledImage.viewport.viewportToViewerElementRectangle(
-                tiledImage.getClippedBounds(true)).getIntegerBoundingBox();
+                tiledImage.getClippedBounds(true))
+                .getIntegerBoundingBox()
+                .times($.pixelDensityRatio);
         }
         tiledImage._drawer._clear(true, bounds);
     }

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1448,8 +1448,15 @@ function drawTiles( tiledImage, lastDrawn ) {
             tiledImage._drawer.getCanvasSize(true));
     }
 
-    if ( useSketch ) {
-        tiledImage._drawer._clear( true );
+    var bounds;
+    if (useSketch) {
+        if (!sketchScale) {
+            // Except when edge smoothing, we only clean the part of the
+            // sketch canvas we are going to use for performance reasons.
+            bounds = tiledImage.viewport.viewportToViewerElementRectangle(
+                tiledImage.getClippedBounds(true)).getIntegerBoundingBox();
+        }
+        tiledImage._drawer._clear(true, bounds);
     }
 
     // When scaling, we must rotate only when blending the sketch canvas to avoid
@@ -1532,7 +1539,13 @@ function drawTiles( tiledImage, lastDrawn ) {
         if (offsetForRotation) {
             tiledImage._drawer._offsetForRotation(tiledImage.viewport.degrees, false);
         }
-        tiledImage._drawer.blendSketch(tiledImage.opacity, sketchScale, sketchTranslate, tiledImage.compositeOperation);
+        tiledImage._drawer.blendSketch({
+            opacity: tiledImage.opacity,
+            scale: sketchScale,
+            translate: sketchTranslate,
+            compositeOperation: tiledImage.compositeOperation,
+            bounds: bounds
+        });
         if (offsetForRotation) {
             tiledImage._drawer._restoreRotationChanges(false);
         }


### PR DESCRIPTION
Fix #926 
Performance is much better :+1: 

On my use case:
Before the fix, drawImage and clearRect are taking 35%+ CPU time each.
After the fix, drawImage is below 20% and clearRect below 10%.

Of course, the bigger the canvas, the bigger the performance improvement.