### PR TITLE
Handle simultaneous touch events

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1357,11 +1357,11 @@
      * @private
      * @inner
      */
-    function capturePointer( tracker, pointerType ) {
+    function capturePointer( tracker, pointerType, touchCount ) {
         var pointsList = tracker.getActivePointersListByType( pointerType ),
             eventParams;
 
-        pointsList.captureCount++;
+        pointsList.captureCount += (pointerType === 'touch' ? touchCount : 1);
 
         if ( pointsList.captureCount === 1 ) {
             if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
@@ -1400,11 +1400,11 @@
      * @private
      * @inner
      */
-    function releasePointer( tracker, pointerType ) {
+    function releasePointer( tracker, pointerType, touchCount ) {
         var pointsList = tracker.getActivePointersListByType( pointerType ),
             eventParams;
 
-        pointsList.captureCount--;
+        pointsList.captureCount -= (pointerType === 'touch' ? touchCount : 1);
 
         if ( pointsList.captureCount === 0 ) {
             if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
@@ -2074,7 +2074,7 @@
 
         if ( updatePointersDown( tracker, event, gPoints, 0 ) ) { // 0 means primary button press/release or touch contact
             $.stopEvent( event );
-            capturePointer( tracker, 'touch' );
+            capturePointer( tracker, 'touch', touchCount );
         }
 
         $.cancelEvent( event );
@@ -2128,7 +2128,7 @@
         }
 
         if ( updatePointersUp( tracker, event, gPoints, 0 ) ) {
-            releasePointer( tracker, 'touch' );
+            releasePointer( tracker, 'touch', touchCount );
         }
 
         // simulate touchleave on our tracked element

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1357,11 +1357,11 @@
      * @private
      * @inner
      */
-    function capturePointer( tracker, pointerType, touchCount ) {
+    function capturePointer( tracker, pointerType, pointerCount ) {
         var pointsList = tracker.getActivePointersListByType( pointerType ),
             eventParams;
 
-        pointsList.captureCount += (pointerType === 'touch' ? touchCount : 1);
+        pointsList.captureCount += (pointerCount || 1);
 
         if ( pointsList.captureCount === 1 ) {
             if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
@@ -1400,11 +1400,11 @@
      * @private
      * @inner
      */
-    function releasePointer( tracker, pointerType, touchCount ) {
+    function releasePointer( tracker, pointerType, pointerCount ) {
         var pointsList = tracker.getActivePointersListByType( pointerType ),
             eventParams;
 
-        pointsList.captureCount -= (pointerType === 'touch' ? touchCount : 1);
+        pointsList.captureCount -= (pointerCount || 1);
 
         if ( pointsList.captureCount === 0 ) {
             if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {

--- a/test/coverage.html
+++ b/test/coverage.html
@@ -53,6 +53,7 @@
     <!-- Helpers -->
     <script src="/test/helpers/legacy.mouse.shim.js"></script>
     <script src="/test/helpers/test.js"></script>
+    <script src="/test/helpers/touch.js"></script>
 
     <!-- Modules -->
     <!-- Polyfill must be inserted first because it is testing functions

--- a/test/helpers/touch.js
+++ b/test/helpers/touch.js
@@ -1,0 +1,134 @@
+/* global TouchUtil, $ */
+
+(function () {
+
+    var touches,
+        identifier,
+        target;
+      
+    // ----------
+    window.TouchUtil = {
+        reset: function () {
+            touches = [];
+            identifier = 0;
+        },
+
+        initTracker: function ( tracker ) {
+            // for testing in other touch-enabled browsers
+            if ( !('ontouchstart' in window) ) {
+                tracker.setTracking( false );
+                OpenSeadragon.MouseTracker.subscribeEvents.push( 'touchstart', 'touchend' );
+                tracker.setTracking( true );
+            }
+
+            target = tracker.element;
+        },
+
+        resetTracker: function ( tracker ) {
+            // for testing in other touch-enabled browsers
+            if ( !('ontouchstart' in window) ) {
+                tracker.setTracking( false );
+                ['touchstart', 'touchend'].forEach(function ( type ) { 
+                    var index = OpenSeadragon.MouseTracker.subscribeEvents.indexOf( type );
+                    if ( index > -1 ) {
+                      OpenSeadragon.MouseTracker.subscribeEvents.splice( index, 1 );
+                    }
+                });
+                tracker.setTracking( true );
+            }
+
+            target = null;
+        },
+
+        start: function () {
+            var touch,
+                event,
+                newTouches = [];
+
+            for ( var i = 0; i < arguments.length; i++ ) {
+                touch = createTouch(
+                    target.offsetLeft + arguments[ i ][ 0 ],
+                    target.offsetTop  + arguments[ i ][ 1 ]
+                );
+
+                touches.push( touch );
+                newTouches.push( touch );
+            }
+
+            event = createTouchEvent( 'touchstart', newTouches );
+            target.dispatchEvent( event );
+            return newTouches.length === 1 ? newTouches[ 0 ] : newTouches;
+        },
+
+        end: function ( changedTouches ) {
+            if ( !$.isArray( changedTouches ) ) {
+                changedTouches = [ changedTouches ];
+            }
+
+            var event;
+            touches = touches.filter(function ( touch ) {
+                return changedTouches.indexOf( touch ) === -1;
+            });
+
+            event = createTouchEvent( 'touchend', changedTouches );
+            target.dispatchEvent( event );
+        }
+
+    };
+
+    // ----------
+    function createTouch( x, y ) {
+        try {
+            // new spec
+            return new Touch({
+                identifier: identifier++,
+                target: target,
+                pageX: target.offsetLeft + x,
+                pageY: target.offsetTop + y
+            } );
+        } catch (e) {
+            // legacy
+            return document.createTouch( window, target, identifier++, x, y, x, y );
+        }
+    }
+
+    function createTouchList( touches ) {
+        // legacy
+        return document.createTouchList.apply( document, touches );
+    }
+
+    function createTouchEvent( type, changedTouches ) {
+        try {
+            // new spec
+            return new TouchEvent( type, {
+                view: window,
+                bubbles: true,
+                cancelable: true,
+                touches: touches,
+                targetTouches: touches,
+                changedTouches: changedTouches
+            } );
+        } catch (e) {
+            // legacy
+            var touchEvent = document.createEvent( 'TouchEvent' );
+            var touch1 = changedTouches[ 0 ];
+            touchEvent.initTouchEvent(
+                createTouchList( touches ),         // touches
+                createTouchList( touches ),         // targetTouches
+                createTouchList( changedTouches ),  // changedTouches
+                type,                               // type
+                window,                             // view
+                touch1.screenX,                     // screenX
+                touch1.screenY,                     // screenY
+                touch1.clientX,                     // clientX
+                touch1.clientY,                     // clientY
+                false,                              // ctrlKey
+                false,                              // altKey
+                false,                              // shiftKey
+                false                               // metaKey
+            );
+            return touchEvent;
+        }
+    }
+
+})();

--- a/test/test.html
+++ b/test/test.html
@@ -17,6 +17,7 @@
     <script src="/build/openseadragon/openseadragon.js"></script>
     <script src="/test/helpers/legacy.mouse.shim.js"></script>
     <script src="/test/helpers/test.js"></script>
+    <script src="/test/helpers/touch.js"></script>
 
     <!-- Polyfill must be inserted first because it is testing functions
          reassignments which could be done by other test. -->


### PR DESCRIPTION
There is currently an issue with simultaneous touch handling, whereby the following steps cause the page to become unresponsive:

1. Place a single finger on the screen
2. Place another finger on the screen
3. Simultaneously remove both fingers at the same time (needs to be timed well)

I tested this on an iPhone 5s w/ iOS 9.2 (with some additional logging to make sure I was accurately releasing both fingers at the same time lol).

I'm not sure how this behaves on other devices... It'd be helpful if someone could verify this change doesn't break them.

Closes #877