### PR TITLE
Take rotation into account in viewport getBounds and fitBounds methods

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -306,8 +306,8 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
             this.updateSize();
         }
 
-        if( viewport && this.viewport ) {
-            bounds      = viewport.getBounds( true );
+        if (viewport && this.viewport) {
+            bounds      = viewport.getBoundsNoRotate(true);
             topleft     = this.viewport.pixelFromPointNoRotate(bounds.getTopLeft(), false);
             bottomright = this.viewport.pixelFromPointNoRotate(bounds.getBottomRight(), false)
                 .minus( this.totalBorderWidths );

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -795,6 +795,7 @@ function updateViewport( tiledImage ) {
         levelOpacity,
         levelVisibility;
 
+    viewportBounds = viewportBounds.getBoundingBox();
     viewportBounds.x -= tiledImage._xSpring.current.value;
     viewportBounds.y -= tiledImage._ySpring.current.value;
 
@@ -802,18 +803,6 @@ function updateViewport( tiledImage ) {
     while ( tiledImage.lastDrawn.length > 0 ) {
         tile = tiledImage.lastDrawn.pop();
         tile.beingDrawn = false;
-    }
-
-    //Change bounds for rotation
-    if (degrees === 90 || degrees === 270) {
-        viewportBounds = viewportBounds.rotate( degrees );
-    } else if (degrees !== 0 && degrees !== 180) {
-        // This is just an approximation.
-        var orthBounds = viewportBounds.rotate(90);
-        viewportBounds.x -= orthBounds.width / 2;
-        viewportBounds.y -= orthBounds.height / 2;
-        viewportBounds.width += orthBounds.width;
-        viewportBounds.height += orthBounds.height;
     }
 
     var viewportTL = viewportBounds.getTopLeft();

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2981,11 +2981,13 @@ function updateOnce( viewer ) {
         if ( !containerSize.equals( THIS[ viewer.hash ].prevContainerSize ) ) {
             if ( viewer.preserveImageSizeOnResize ) {
                 var prevContainerSize = THIS[ viewer.hash ].prevContainerSize;
-                var bounds = viewer.viewport.getBounds(true);
+                var bounds = viewer.viewport.getBoundsNoRotate(true);
                 var deltaX = (containerSize.x - prevContainerSize.x);
                 var deltaY = (containerSize.y - prevContainerSize.y);
-                var viewportDiff = viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(deltaX, deltaY), true);
-                viewer.viewport.resize(new OpenSeadragon.Point(containerSize.x, containerSize.y), false);
+                var viewportDiff = viewer.viewport.deltaPointsFromPixels(
+                    new $.Point(deltaX, deltaY), true);
+                viewer.viewport.resize(
+                    new $.Point(containerSize.x, containerSize.y), false);
 
                 // Keep the center of the image in the center and just adjust the amount of image shown
                 bounds.width += viewportDiff.x;
@@ -2996,7 +2998,7 @@ function updateOnce( viewer ) {
             }
             else {
                 // maintain image position
-                var oldBounds = viewer.viewport.getBounds();
+                var oldBounds = viewer.viewport.getBoundsNoRotate();
                 var oldCenter = viewer.viewport.getCenter();
                 resizeViewportAndRecenter(viewer, containerSize, oldBounds, oldCenter);
             }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -584,7 +584,8 @@ $.Viewport.prototype = {
         if (bounds.x !== constrainedBounds.x ||
             bounds.y !== constrainedBounds.y ||
             immediately) {
-            this.fitBounds(constrainedBounds.rotate(this.getRotation()),
+            this.fitBounds(
+                constrainedBounds.rotate(-this.getRotation()),
                 immediately);
         }
         return this;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -555,40 +555,27 @@ $.Viewport.prototype = {
     },
 
     /**
+     * Enforces the minZoom, maxZoom and visibilityRatio constraints by
+     * zooming and panning to the closest acceptable zoom and location.
      * @function
+     * @param {Boolean} [immediately=false]
      * @return {OpenSeadragon.Viewport} Chainable.
      * @fires OpenSeadragon.Viewer.event:constrain
      */
-    applyConstraints: function( immediately ) {
-        var actualZoom = this.getZoom(),
-            constrainedZoom = Math.max(
-                Math.min( actualZoom, this.getMaxZoom() ),
-                this.getMinZoom()
-            ),
-            bounds,
-            constrainedBounds;
-
-        if ( actualZoom != constrainedZoom ) {
-            this.zoomTo( constrainedZoom, this.zoomPoint, immediately );
-        }
-
-        bounds = this.getBoundsNoRotate();
-
-        constrainedBounds = this._applyBoundaryConstraints( bounds, immediately );
-
-        if ( bounds.x !== constrainedBounds.x || bounds.y !== constrainedBounds.y || immediately ){
-            this.fitBounds( constrainedBounds, immediately );
-        }
-
+    applyConstraints: function(immediately) {
+        this.fitBoundsWithConstraints(this.getBounds(), immediately);
         return this;
     },
 
     /**
+     * Equivalent to {@link OpenSeadragon.Viewport#applyConstraints}
      * @function
-     * @param {Boolean} immediately
+     * @param {Boolean} [immediately=false]
+     * @return {OpenSeadragon.Viewport} Chainable.
+     * @fires OpenSeadragon.Viewer.event:constrain
      */
-    ensureVisible: function( immediately ) {
-        return this.applyConstraints( immediately );
+    ensureVisible: function(immediately) {
+        return this.applyConstraints(immediately);
     },
 
     /**
@@ -670,29 +657,41 @@ $.Viewport.prototype = {
     },
 
     /**
+     * Makes the viewport zoom and pan so that the specified bounds take
+     * as much space as possible in the viewport.
+     * Note: this method ignores the constraints (minZoom, maxZoom and
+     * visibilityRatio).
+     * Use {@link OpenSeadragon.Viewport#fitBoundsWithConstraints} to enforce
+     * them.
      * @function
      * @param {OpenSeadragon.Rect} bounds
-     * @param {Boolean} immediately
+     * @param {Boolean} [immediately=false]
      * @return {OpenSeadragon.Viewport} Chainable.
      */
-    fitBounds: function( bounds, immediately ) {
-        return this._fitBounds( bounds, {
+    fitBounds: function(bounds, immediately) {
+        return this._fitBounds(bounds, {
             immediately: immediately,
             constraints: false
-        } );
+        });
     },
 
     /**
+     * Makes the viewport zoom and pan so that the specified bounds take
+     * as much space as possible in the viewport while enforcing the constraints
+     * (minZoom, maxZoom and visibilityRatio).
+     * Note: because this method enforces the constraints, part of the
+     * provided bounds may end up outside of the viewport.
+     * Use {@link OpenSeadragon.Viewport#fitBounds} to ignore them.
      * @function
      * @param {OpenSeadragon.Rect} bounds
-     * @param {Boolean} immediately
+     * @param {Boolean} [immediately=false]
      * @return {OpenSeadragon.Viewport} Chainable.
      */
-    fitBoundsWithConstraints: function( bounds, immediately ) {
-        return this._fitBounds( bounds, {
+    fitBoundsWithConstraints: function(bounds, immediately) {
+        return this._fitBounds(bounds, {
             immediately: immediately,
             constraints: true
-        } );
+        });
     },
 
     /**

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -5,6 +5,7 @@
     var VIEWER_ID = "example";
     var PREFIX_URL = "/build/openseadragon/images/";
     var SPRING_STIFFNESS = 100; // Faster animation = faster tests
+    var EPSILON = 0.0000000001;
 
      module("viewport", {
         setup: function () {
@@ -218,7 +219,27 @@
         });
     });
 
-    asyncTest('getHomeBoundsWithRotation', function() {
+    asyncTest('getHomeBoundsNoRotate with rotation', function() {
+        function openHandler() {
+            viewer.removeHandler('open', openHandler);
+            var viewport = viewer.viewport;
+            viewport.setRotation(-675);
+            Util.assertRectangleEquals(
+                viewport.getHomeBoundsNoRotate(),
+                new OpenSeadragon.Rect(
+                    (1 - Math.sqrt(2)) / 2,
+                    (1 - Math.sqrt(2)) / 2,
+                    Math.sqrt(2),
+                    Math.sqrt(2)),
+                0.00000001,
+                "Test getHomeBoundsNoRotate with degrees = -675");
+            start();
+        }
+        viewer.addHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
+
+    asyncTest('getHomeBounds with rotation', function() {
         function openHandler() {
             viewer.removeHandler('open', openHandler);
             var viewport = viewer.viewport;
@@ -226,10 +247,11 @@
             Util.assertRectangleEquals(
                 viewport.getHomeBounds(),
                 new OpenSeadragon.Rect(
-                    (1 - Math.sqrt(2)) / 2,
-                    (1 - Math.sqrt(2)) / 2,
+                    0.5,
+                    -0.5,
                     Math.sqrt(2),
-                    Math.sqrt(2)),
+                    Math.sqrt(2),
+                    45),
                 0.00000001,
                 "Test getHomeBounds with degrees = -675");
             start();
@@ -420,6 +442,33 @@
         new OpenSeadragon.Rect(-0.3, -0.3, 0.5, 0.5)
     ];
 
+    var expectedRectsFitBoundsWithRotation = [
+        new OpenSeadragon.Rect(
+            0.25,
+            -1,
+            Math.sqrt(0.125) + Math.sqrt(0.5),
+            Math.sqrt(0.125) + Math.sqrt(0.5),
+            45),
+        new OpenSeadragon.Rect(
+            0.75,
+            -0.25,
+            Math.sqrt(0.125) + Math.sqrt(8 / 25),
+            Math.sqrt(0.125) + Math.sqrt(8 / 25),
+            45),
+        new OpenSeadragon.Rect(
+            1,
+            0.5,
+            Math.sqrt(0.125) * 2,
+            Math.sqrt(0.125) * 2,
+            45),
+        new OpenSeadragon.Rect(
+            -0.05,
+            -0.55,
+            Math.sqrt(0.125) * 2,
+            Math.sqrt(0.125) * 2,
+            45)
+    ];
+
     var expectedRectsFitBoundsWithConstraints = [
         new OpenSeadragon.Rect(-0.25, -0.5, 1, 1),
         new OpenSeadragon.Rect(0.35, 0, 0.8, 0.8),
@@ -438,6 +487,28 @@
                 propEqual(
                     viewport.getBounds(),
                     expectedRectsFitBounds[i],
+                    "Fit bounds correctly."
+                );
+            }
+            start();
+        };
+        viewer.addHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
+
+    asyncTest('fitBounds with viewport rotation', function(){
+        var openHandler = function(event) {
+            viewer.removeHandler('open', openHandler);
+            var viewport = viewer.viewport;
+            viewport.setRotation(45);
+
+            for(var i = 0; i < testRectsFitBounds.length; i++){
+                var rect = testRectsFitBounds[i];
+                viewport.fitBounds(rect, true);
+                Util.assertRectangleEquals(
+                    viewport.getBounds(),
+                    expectedRectsFitBoundsWithRotation[i],
+                    EPSILON,
                     "Fit bounds correctly."
                 );
             }

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -409,7 +409,7 @@
         viewer.open(DZI_PATH);
     });
 
-    asyncTest('ensureVisible', function(){
+    asyncTest('ensureVisible', function() {
         var openHandler = function(event) {
             viewer.removeHandler('open', openHandler);
             var viewport = viewer.viewport;
@@ -421,6 +421,45 @@
             viewport.ensureVisible(true);
             var bounds = viewport.getBounds();
             ok(bounds.getSize().x > 1 && bounds.getSize().y > 1, "Moved viewport so that image is visible.");
+            start();
+        };
+        viewer.addHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
+
+    asyncTest('applyConstraints', function() {
+        var openHandler = function() {
+            viewer.removeHandler('open', openHandler);
+            var viewport = viewer.viewport;
+
+            viewport.fitBounds(new OpenSeadragon.Rect(1, 1, 1, 1), true);
+            viewport.visibilityRatio = 0.3;
+            viewport.applyConstraints(true);
+            var bounds = viewport.getBounds();
+            Util.assertRectangleEquals(
+                bounds,
+                new OpenSeadragon.Rect(0.7, 0.7, 1, 1),
+                EPSILON,
+                "Viewport.applyConstraints should move viewport.");
+            start();
+        };
+        viewer.addHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
+
+    asyncTest('applyConstraints with rotation', function() {
+        var openHandler = function() {
+            viewer.removeHandler('open', openHandler);
+            var viewport = viewer.viewport;
+            viewport.setRotation(45);
+            viewport.fitBounds(new OpenSeadragon.Rect(1, 1, 1, 1), true);
+            viewport.applyConstraints(true);
+            var bounds = viewport.getBounds();
+            Util.assertRectangleEquals(
+                bounds,
+                new OpenSeadragon.Rect(1, 0, Math.sqrt(2), Math.sqrt(2), 45),
+                EPSILON,
+                "Viewport.applyConstraints with rotation should move viewport.");
             start();
         };
         viewer.addHandler('open', openHandler);

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -471,14 +471,16 @@
         new OpenSeadragon.Rect(0, -0.75, 0.5, 1),
         new OpenSeadragon.Rect(0.5, 0, 0.5, 0.8),
         new OpenSeadragon.Rect(0.75, 0.75, 0.5, 0.5),
-        new OpenSeadragon.Rect(-0.3, -0.3, 0.5, 0.5)
+        new OpenSeadragon.Rect(-0.3, -0.3, 0.5, 0.5),
+        new OpenSeadragon.Rect(0.5, 0.25, Math.sqrt(0.125), Math.sqrt(0.125), 45)
     ];
 
     var expectedRectsFitBounds = [
         new OpenSeadragon.Rect(-0.25, -0.75, 1, 1),
         new OpenSeadragon.Rect(0.35, 0, 0.8, 0.8),
         new OpenSeadragon.Rect(0.75, 0.75, 0.5, 0.5),
-        new OpenSeadragon.Rect(-0.3, -0.3, 0.5, 0.5)
+        new OpenSeadragon.Rect(-0.3, -0.3, 0.5, 0.5),
+        new OpenSeadragon.Rect(0.25, 0.25, 0.5, 0.5)
     ];
 
     var expectedRectsFitBoundsWithRotation = [
@@ -505,6 +507,12 @@
             -0.55,
             Math.sqrt(0.125) * 2,
             Math.sqrt(0.125) * 2,
+            45),
+        new OpenSeadragon.Rect(
+            0.5,
+            0.25,
+            Math.sqrt(0.125),
+            Math.sqrt(0.125),
             45)
     ];
 
@@ -512,7 +520,8 @@
         new OpenSeadragon.Rect(-0.25, -0.5, 1, 1),
         new OpenSeadragon.Rect(0.35, 0, 0.8, 0.8),
         new OpenSeadragon.Rect(0.75, 0.75, 0.5, 0.5),
-        new OpenSeadragon.Rect(-0.25, -0.25, 0.5, 0.5)
+        new OpenSeadragon.Rect(-0.25, -0.25, 0.5, 0.5),
+        new OpenSeadragon.Rect(0.25, 0.25, 0.5, 0.5)
     ];
 
     asyncTest('fitBounds', function(){

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -405,26 +405,7 @@
         viewer.open(DZI_PATH);
     });
 
-    asyncTest('fitBounds', function(){
-        var openHandler = function(event) {
-            viewer.removeHandler('open', openHandler);
-            var viewport = viewer.viewport;
-
-            for(var i = 0; i < testRects.length; i++){
-                var rect = testRects[i].times(viewport.getContainerSize());
-                viewport.fitBounds(rect, true);
-                propEqual(
-                    viewport.getBounds(),
-                    rect,
-                    "Fit bounds correctly."
-                );
-            }
-            start();
-        };
-        viewer.addHandler('open', openHandler);
-        viewer.open(DZI_PATH);
-    });
-
+    // Fit bounds tests
     var testRectsFitBounds = [
         new OpenSeadragon.Rect(0, -0.75, 0.5, 1),
         new OpenSeadragon.Rect(0.5, 0, 0.5, 0.8),
@@ -433,11 +414,38 @@
     ];
 
     var expectedRectsFitBounds = [
+        new OpenSeadragon.Rect(-0.25, -0.75, 1, 1),
+        new OpenSeadragon.Rect(0.35, 0, 0.8, 0.8),
+        new OpenSeadragon.Rect(0.75, 0.75, 0.5, 0.5),
+        new OpenSeadragon.Rect(-0.3, -0.3, 0.5, 0.5)
+    ];
+
+    var expectedRectsFitBoundsWithConstraints = [
         new OpenSeadragon.Rect(-0.25, -0.5, 1, 1),
         new OpenSeadragon.Rect(0.35, 0, 0.8, 0.8),
         new OpenSeadragon.Rect(0.75, 0.75, 0.5, 0.5),
         new OpenSeadragon.Rect(-0.25, -0.25, 0.5, 0.5)
     ];
+
+    asyncTest('fitBounds', function(){
+        var openHandler = function(event) {
+            viewer.removeHandler('open', openHandler);
+            var viewport = viewer.viewport;
+
+            for(var i = 0; i < testRectsFitBounds.length; i++){
+                var rect = testRectsFitBounds[i];
+                viewport.fitBounds(rect, true);
+                propEqual(
+                    viewport.getBounds(),
+                    expectedRectsFitBounds[i],
+                    "Fit bounds correctly."
+                );
+            }
+            start();
+        };
+        viewer.addHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
 
     asyncTest('fitBoundsWithConstraints', function(){
         var openHandler = function(event) {
@@ -450,7 +458,7 @@
                 viewport.fitBoundsWithConstraints(rect, true);
                 propEqual(
                     viewport.getBounds(),
-                    expectedRectsFitBounds[i],
+                    expectedRectsFitBoundsWithConstraints[i],
                     "Fit bounds correctly."
                 );
             }
@@ -491,6 +499,7 @@
         viewer.addHandler('open', openHandler);
         viewer.open(WIDE_PATH);
     });
+    // End fitBounds tests.
 
     asyncTest('panBy', function(){
         var openHandler = function(event) {


### PR DESCRIPTION
I still need to test:

- [x] resize is still working
- [x] fitBounds with a rotated rectangle as parameter (seems to work, I want to add unit tests)
- [x] fitBounds with constraints