### PR TITLE
Disable part of `8c4fcc9` when running on an iOS device

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -239,6 +239,8 @@
   *     A zoom percentage ( where 1 is 100% ) of the highest resolution level.
   *     When zoomed in beyond this value alternative compositing will be used to
   *     smooth out the edges between tiles. This will have a performance impact.
+  *     Can be set to Infinity to turn it off.
+  *     Note: This setting is ignored on iOS devices due to a known bug (See {@link https://github.com/openseadragon/openseadragon/issues/952})
   *
   * @property {Boolean} [iOSDevice=?]
   *     True if running on an iOS device, false otherwise.
@@ -986,16 +988,16 @@ if (typeof define === 'function' && define.amd) {
     };
 
     var isIOSDevice = function () {
-      if (typeof navigator !== 'object') {
-        return false;
-      }
-      var userAgent = navigator.userAgent;
-      if (typeof userAgent !== 'string') {
-        return false;
-      }
-      return userAgent.indexOf('iPhone') !== -1 ||
-             userAgent.indexOf('iPad') !== -1 ||
-             userAgent.indexOf('iPod') !== -1;
+        if (typeof navigator !== 'object') {
+            return false;
+        }
+        var userAgent = navigator.userAgent;
+        if (typeof userAgent !== 'string') {
+            return false;
+        }
+        return userAgent.indexOf('iPhone') !== -1 ||
+               userAgent.indexOf('iPad') !== -1 ||
+               userAgent.indexOf('iPod') !== -1;
     };
 
     $.extend( $, /** @lends OpenSeadragon */{

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -240,6 +240,10 @@
   *     When zoomed in beyond this value alternative compositing will be used to
   *     smooth out the edges between tiles. This will have a performance impact.
   *
+  * @property {Boolean} [iOSDevice=?]
+  *     True if running on an iOS device, false otherwise.
+  *     Used to disable certain features that behave differently on iOS devices.
+  *
   * @property {Boolean} [autoResize=true]
   *     Set to false to prevent polling for viewer size changes. Useful for providing custom resize behavior.
   *
@@ -981,6 +985,18 @@ if (typeof define === 'function' && define.amd) {
         return target;
     };
 
+    var isIOSDevice = function () {
+      if (typeof navigator !== 'object') {
+        return false;
+      }
+      var userAgent = navigator.userAgent;
+      if (typeof userAgent !== 'string') {
+        return false;
+      }
+      return userAgent.indexOf('iPhone') !== -1 ||
+             userAgent.indexOf('iPad') !== -1 ||
+             userAgent.indexOf('iPod') !== -1;
+    };
 
     $.extend( $, /** @lends OpenSeadragon */{
         /**
@@ -1031,6 +1047,7 @@ if (typeof define === 'function' && define.amd) {
             minZoomImageRatio:      0.9, //-> closer to 0 allows zoom out to infinity
             maxZoomPixelRatio:      1.1, //-> higher allows 'over zoom' into pixels
             smoothTileEdgesMinZoom: 1.1, //-> higher than maxZoomPixelRatio disables it
+            iOSDevice:              isIOSDevice(),
             pixelsPerWheelLine:     40,
             autoResize:             true,
             preserveImageSizeOnResize: false, // requires autoResize=true

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -69,6 +69,7 @@
  * @param {Boolean} [options.alwaysBlend] - See {@link OpenSeadragon.Options}.
  * @param {Number} [options.minPixelRatio] - See {@link OpenSeadragon.Options}.
  * @param {Number} [options.smoothTileEdgesMinZoom] - See {@link OpenSeadragon.Options}.
+ * @param {Boolean} [options.iOSDevice] - See {@link OpenSeadragon.Options}.
  * @param {Number} [options.opacity=1] - Opacity the tiled image should be drawn at.
  * @param {String} [options.compositeOperation] - How the image is composited onto other images; see compositeOperation in {@link OpenSeadragon.Options} for possible values.
  * @param {Boolean} [options.debugMode] - See {@link OpenSeadragon.Options}.
@@ -153,6 +154,7 @@ $.TiledImage = function( options ) {
         alwaysBlend:            $.DEFAULT_SETTINGS.alwaysBlend,
         minPixelRatio:          $.DEFAULT_SETTINGS.minPixelRatio,
         smoothTileEdgesMinZoom: $.DEFAULT_SETTINGS.smoothTileEdgesMinZoom,
+        iOSDevice:              $.DEFAULT_SETTINGS.iOSDevice,
         debugMode:              $.DEFAULT_SETTINGS.debugMode,
         crossOriginPolicy:      $.DEFAULT_SETTINGS.crossOriginPolicy,
         placeholderFillStyle:   $.DEFAULT_SETTINGS.placeholderFillStyle,
@@ -1434,9 +1436,10 @@ function drawTiles( tiledImage, lastDrawn ) {
 
     var zoom = tiledImage.viewport.getZoom(true);
     var imageZoom = tiledImage.viewportToImageZoom(zoom);
-    if (imageZoom > tiledImage.smoothTileEdgesMinZoom) {
+    if (imageZoom > tiledImage.smoothTileEdgesMinZoom && !tiledImage.iOSDevice) {
         // When zoomed in a lot (>100%) the tile edges are visible.
         // So we have to composite them at ~100% and scale them up together.
+        // Note: Disabled on iOS devices per default as it causes a native crash
         useSketch = true;
         sketchScale = tile.getScaleForEdgeSmoothing();
         sketchTranslate = tile.getTranslationForEdgeSmoothing(sketchScale,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1375,6 +1375,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     alwaysBlend: _this.alwaysBlend,
                     minPixelRatio: _this.minPixelRatio,
                     smoothTileEdgesMinZoom: _this.smoothTileEdgesMinZoom,
+                    iOSDevice: _this.iOSDevice,
                     crossOriginPolicy: _this.crossOriginPolicy,
                     debugMode: _this.debugMode
                 });


### PR DESCRIPTION
This is my attempt to fix https://github.com/openseadragon/openseadragon/issues/952

## Solution

- Introduce configuration variable `iOSDevice` that defaults to `true` when running on an iOS device, `false` otherwise
- If `iOSDevice === true` disable the iOS-specific broken part of https://github.com/openseadragon/openseadragon/commit/8c4fcc9 (special handling of `>100%` zoom)
- Update comments documentation to reflect the new configuration variable
- The configuration variable `iOSDevice` is a variable such that
 1. It can be overwritten if a user requires that behaviour
 2. It can be read on `viewer`

## Test Suite

```
Running "qunit:normal" (qunit) task
Testing http://localhost:8000/test/test.html ......................................................................................................................................................................................................OK
>> 2132 assertions passed (51213ms)

Done, without errors.
```