### PR TITLE
Fixed CORS bug in IE 10

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2119,12 +2119,13 @@ if (typeof define === 'function' && define.amd) {
                 }
             };
 
-            if (withCredentials) {
-                request.withCredentials = true;
-            }
-
             try {
                 request.open( "GET", url, true );
+
+                if (withCredentials) {
+                    request.withCredentials = true;
+                }
+
                 request.send( null );
             } catch (e) {
                 var msg = e.message;


### PR DESCRIPTION
Hi!

This PR fixes CORS requests in IE 10, withCredentials have to be set after the request is opened for IE to be happy. In all other browsers I've tried it works either way.

Explanation:
http://stackoverflow.com/questions/19666809/cors-withcredentials-support-limited