### PR TITLE
[=] Wrap fix for #555

### DIFF
--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -171,9 +171,7 @@
          * @param {Number} level
          * @param {OpenSeadragon.Point} point
          */
-        getTileAtPoint: function (level, point) {
-            return new $.Point(0, 0);
-        },
+        getTileAtPoint: $.TileSource.prototype.getTileAtPoint,
         /**
          * Retrieves a tile url
          * @function

--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -167,12 +167,6 @@
             }
         },
         /**
-         * @function
-         * @param {Number} level
-         * @param {OpenSeadragon.Point} point
-         */
-        getTileAtPoint: $.TileSource.prototype.getTileAtPoint,
-        /**
          * Retrieves a tile url
          * @function
          * @param {Number} level Level of the tile

--- a/src/legacytilesource.js
+++ b/src/legacytilesource.js
@@ -170,14 +170,6 @@ $.extend( $.LegacyTileSource.prototype, $.TileSource.prototype, /** @lends OpenS
     },
 
     /**
-     * @function
-     * @param {Number} level
-     * @param {OpenSeadragon.Point} point
-     */
-    getTileAtPoint: $.TileSource.prototype.getTileAtPoint,
-
-
-    /**
      * This method is not implemented by this class other than to throw an Error
      * announcing you have to implement it.  Because of the variety of tile
      * server technologies, and various specifications for building image

--- a/src/legacytilesource.js
+++ b/src/legacytilesource.js
@@ -174,9 +174,7 @@ $.extend( $.LegacyTileSource.prototype, $.TileSource.prototype, /** @lends OpenS
      * @param {Number} level
      * @param {OpenSeadragon.Point} point
      */
-    getTileAtPoint: function( level, point ) {
-        return new $.Point( 0, 0 );
-    },
+    getTileAtPoint: $.TileSource.prototype.getTileAtPoint,
 
 
     /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -967,10 +967,14 @@ function updateLevel( tiledImage, haveDrawn, drawLevel, level, levelOpacity, lev
 
     resetCoverage( tiledImage.coverage, level );
 
-    if ( !tiledImage.wrapHorizontal ) {
+    if ( tiledImage.wrapHorizontal ) {
+        tileTL.x -= 1; // left invisible column (othervise we will have empty space after scroll at left)
+    } else {
         tileBR.x = Math.min( tileBR.x, numberOfTiles.x - 1 );
     }
-    if ( !tiledImage.wrapVertical ) {
+    if ( tiledImage.wrapVertical ) {
+        tileTL.y -= 1; // top invisible row (othervise we will have empty space after scroll at top)
+    } else {
         tileBR.y = Math.min( tileBR.y, numberOfTiles.y - 1 );
     }
 

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -345,9 +345,11 @@ $.TileSource.prototype = {
      * @param {OpenSeadragon.Point} point
      */
     getTileAtPoint: function( level, point ) {
-        var pixel = point.times( this.dimensions.x ).times( this.getLevelScale(level) ),
-            tx = Math.floor( pixel.x / this.getTileWidth(level) ),
-            ty = Math.floor( pixel.y / this.getTileHeight(level) );
+        var levelScale = this.getLevelScale( level ),
+            numTiles = this.getNumTiles( level ),
+            pixel = point.times( this.dimensions.x * levelScale ),
+            tx = Math.floor( (pixel.x * numTiles.x) / (this.dimensions.x * levelScale) ),
+            ty = Math.floor( (pixel.y * numTiles.y) / (this.dimensions.y * levelScale) );
 
         return new $.Point( tx, ty );
     },

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -345,13 +345,11 @@ $.TileSource.prototype = {
      * @param {OpenSeadragon.Point} point
      */
     getTileAtPoint: function( level, point ) {
-        var levelScale = this.getLevelScale( level ),
-            numTiles = this.getNumTiles( level ),
-            pixel = point.times( this.dimensions.x * levelScale ),
-            tx = Math.floor( (pixel.x * numTiles.x) / (this.dimensions.x * levelScale) ),
-            ty = Math.floor( (pixel.y * numTiles.y) / (this.dimensions.y * levelScale) );
-
-        return new $.Point( tx, ty );
+        var numTiles = this.getNumTiles( level );
+        return new $.Point(
+            Math.floor( (point.x * numTiles.x) / 1 ),
+            Math.floor( (point.y * numTiles.y * this.dimensions.x) / this.dimensions.y )
+        );
     },
 
     /**


### PR DESCRIPTION
1. Fix for horizontal and vertical wrap. Problem was in
`getTileAtPoint`: it was working only for points inside viewer - thanks
to @avandecreme for finding this.
2. Was small bug in not rendering top row and left column - after scroll
there are empty space and need some time for rendering.

Issue #555 