### PR TITLE
Make tileSources option smarter about detecting when a json string or…

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2121,9 +2121,11 @@ function getTileSourceImplementation( viewer, tileSource, imgOptions, successCal
 
     //allow plain xml strings or json strings to be parsed here
     if ( $.type( tileSource ) == 'string' ) {
-        if ( tileSource.match( /\s*<.*/ ) ) {
+        //xml should start with "<" and end with ">"
+        if ( tileSource.match( /^\s*<.*>\s*$/ ) ) {
             tileSource = $.parseXml( tileSource );
-        } else if ( tileSource.match( /\s*[\{\[].*/ ) ) {
+        //json should start with "{" or "[" and end with "}" or "]"
+        } else if ( tileSource.match(/^\s*[\{\[].*[\}\]]\s*$/ ) ) {
             tileSource = $.parseJSON(tileSource);
         }
     }


### PR DESCRIPTION
… xml string has been passed in

The tileSources option was only using a test looking for the presence of a "{" or "<" character to determine if a json string or xml string was passed in.  It is possible for a url to contain one of these characters as well which would break using the url as a tileSources parameter.  The following is an example of a breaking url:
http://myurl.org/{25fb14f0-a839-4c4d-8c97-dd1d67b2cb35}/MyImage.xml

This patch resolves this issue.