### PR TITLE
Fix viewport margins with rotation. Fix #1007

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -536,7 +536,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      */
     viewportToImageZoom: function( viewportZoom ) {
         var ratio = this._scaleSpring.current.value *
-                this.viewport._containerInnerSize.x / this.source.dimensions.x;
+                this.viewport.containerSize.x / this.source.dimensions.x;
         return ratio * viewportZoom ;
     },
 
@@ -553,7 +553,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      */
     imageToViewportZoom: function( imageZoom ) {
         var ratio = this._scaleSpring.current.value *
-                this.viewport._containerInnerSize.x / this.source.dimensions.x;
+                this.viewport.containerSize.x / this.source.dimensions.x;
         return imageZoom / ratio;
     },
 
@@ -803,7 +803,7 @@ function updateViewport( tiledImage ) {
         best            = null,
         haveDrawn       = false,
         currentTime     = $.now(),
-        viewportBounds  = tiledImage.viewport.getBoundsWithMargins( true ),
+        viewportBounds  = tiledImage.viewport.getBounds(true),
         zeroRatioC      = tiledImage.viewport.deltaPixelsFromPointsNoRotate(
             tiledImage.source.getPixelRatio( 0 ),
             true

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -220,8 +220,14 @@ $.Viewport.prototype = {
 
         var homeWidth = this.containerSize.x - this._margins.left -
             this._margins.right;
+        if (homeWidth <= 0) {
+            homeWidth = 1;
+        }
         var homeHeight = this.containerSize.y - this._margins.top -
             this._margins.bottom;
+        if (homeHeight <= 0) {
+            homeHeight = 1;
+        }
         var homeAspectRatio = homeWidth / homeHeight;
         var aspectFactor = this._contentAspectRatio / homeAspectRatio;
         var output;
@@ -267,10 +273,11 @@ $.Viewport.prototype = {
         var marginRight = this._margins.right / pointFromPixelFactor;
         var marginTop = this._margins.top / pointFromPixelFactor;
         var marginBottom = this._margins.bottom / pointFromPixelFactor;
+        var epsilon = 1e-9;
 
         var horizontalMargins = width - contentBounds.width;
         var x = horizontalMargins / 2;
-        if (x >= 0) {
+        if (x >= 0 && horizontalMargins + epsilon >= marginLeft + marginRight) {
             if (x < marginLeft) {
                 x = marginLeft;
             }
@@ -282,7 +289,7 @@ $.Viewport.prototype = {
 
         var verticalMargins = height - contentBounds.height;
         var y = verticalMargins / 2;
-        if (y >= 0) {
+        if (y >= 0 && verticalMargins + epsilon >= marginTop + marginBottom) {
             if (y < marginTop) {
                 y = marginTop;
             }
@@ -438,8 +445,6 @@ $.Viewport.prototype = {
             "this function is deprecated; [Viewport.getBounds] " +
             "already takes the margins into account.");
         return this.getBounds(current);
-        return this.getBoundsNoRotateWithMargins(current).rotate(
-            -this.getRotation(), this.getCenter(current));
     },
 
     /**

--- a/test/modules/units.js
+++ b/test/modules/units.js
@@ -107,6 +107,88 @@
         viewer.open('/test/data/testpattern.dzi');
     });
 
+    // ----------
+    asyncTest('Single image coordinates conversions with viewport margins', function () {
+
+        viewer.addOnceHandler("open", function () {
+            var viewport = viewer.viewport;
+            var tiledImage = viewer.world.getItemAt(0);
+
+            var point0_0 = new OpenSeadragon.Point(0, 0);
+            var point = viewport.viewerElementToViewportCoordinates(point0_0);
+            pointEqual(new OpenSeadragon.Point(-0.25, -0.125), point,
+                'When opening, viewer coordinate 0,0 is point -0.25,-0.125');
+            var viewportPixel = viewport.viewerElementToImageCoordinates(point0_0);
+            pointEqual(new OpenSeadragon.Point(-250, -125), viewportPixel,
+                'When opening, viewport coordinate 0,0 is viewer pixel -250,-125');
+            var imagePixel = tiledImage.viewerElementToImageCoordinates(point0_0);
+            pointEqual(new OpenSeadragon.Point(-250, -125), imagePixel,
+                'When opening, viewer coordinate 0,0 is image pixel -250,-125');
+
+            var viewerWidth = $(viewer.element).width();
+            var viewerTopRight = new OpenSeadragon.Point(viewerWidth, 0);
+
+            point = viewport.viewerElementToViewportCoordinates(viewerTopRight);
+            pointEqual(new OpenSeadragon.Point(1, -0.125), point,
+                'Viewer top right has viewport coordinates -0.125,0.');
+            imagePixel = viewport.viewerElementToImageCoordinates(viewerTopRight);
+            pointEqual(new OpenSeadragon.Point(-250, -125), viewportPixel,
+                'Viewer top right has image pixel coordinates -250,-125.');
+
+            checkPoint(' after opening');
+            viewer.addOnceHandler('animation-finish', function() {
+                checkPoint(' after zoom and pan');
+                start();
+            });
+            viewer.viewport.zoomTo(0.8).panTo(new OpenSeadragon.Point(0.1, 0.2));
+        });
+        viewer.viewport.setMargins({
+            left: 100
+        });
+        viewer.open('/test/data/testpattern.dzi');
+    });
+
+    // ----------
+    asyncTest('Single image coordinates conversions with viewport margins and rotation', function () {
+
+        viewer.addOnceHandler("open", function () {
+            var viewport = viewer.viewport;
+            var tiledImage = viewer.world.getItemAt(0);
+
+            var point0_0 = new OpenSeadragon.Point(0, 0);
+            var point = viewport.viewerElementToViewportCoordinates(point0_0);
+            pointEqual(new OpenSeadragon.Point(-0.875, 0.625), point,
+                'When opening, viewer coordinate 0,0 is point -0.875,0.625');
+            var viewportPixel = viewport.viewerElementToImageCoordinates(point0_0);
+            pointEqual(new OpenSeadragon.Point(-875, 625), viewportPixel,
+                'When opening, viewport coordinate 0,0 is viewer pixel -875,625');
+            var imagePixel = tiledImage.viewerElementToImageCoordinates(point0_0);
+            pointEqual(new OpenSeadragon.Point(-875, 625), imagePixel,
+                'When opening, viewer coordinate 0,0 is image pixel -875,625');
+
+            var viewerWidth = $(viewer.element).width();
+            var viewerTopRight = new OpenSeadragon.Point(viewerWidth, 0);
+
+            point = viewport.viewerElementToViewportCoordinates(viewerTopRight);
+            pointEqual(new OpenSeadragon.Point(0.375, -0.625), point,
+                'Viewer top right has viewport coordinates 0.375,-0.625.');
+            imagePixel = viewport.viewerElementToImageCoordinates(viewerTopRight);
+            pointEqual(new OpenSeadragon.Point(-875, 625), viewportPixel,
+                'Viewer top right has image pixel coordinates -875,625.');
+
+            checkPoint(' after opening');
+            viewer.addOnceHandler('animation-finish', function() {
+                checkPoint(' after zoom and pan');
+                start();
+            });
+            viewer.viewport.zoomTo(0.8).panTo(new OpenSeadragon.Point(0.1, 0.2));
+        });
+        viewer.viewport.setMargins({
+            left: 100
+        });
+        viewer.viewport.setRotation(45);
+        viewer.open('/test/data/testpattern.dzi');
+    });
 
     // ---------
     asyncTest('Multiple images coordinates conversion', function () {

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -219,6 +219,23 @@
         });
     });
 
+    asyncTest('getHomeBounds with margins', function() {
+        function openHandler() {
+            var viewport = viewer.viewport;
+            viewport.setMargins({
+                top: 100
+            });
+            Util.assertRectangleEquals(
+                viewport.getHomeBounds(),
+                new OpenSeadragon.Rect(-0.125, -0.25, 1.25, 1.25),
+                0.00000001,
+                "Test getHomeBounds with margins");
+            start();
+        }
+        viewer.addOnceHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
+
     asyncTest('getHomeBoundsNoRotate with rotation', function() {
         function openHandler() {
             viewer.removeHandler('open', openHandler);
@@ -257,6 +274,29 @@
             start();
         }
         viewer.addHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
+
+    asyncTest('getHomeBounds with margins and rotation', function() {
+        function openHandler() {
+            var viewport = viewer.viewport;
+            viewport.setRotation(45);
+            viewport.setMargins({
+                top: 100
+            });
+            Util.assertRectangleEquals(
+                viewport.getHomeBounds(),
+                new OpenSeadragon.Rect(
+                    0.375,
+                    -0.875,
+                    1.76776695,
+                    1.76776695,
+                    45),
+                0.00000001,
+                "Test getHomeBounds with margins and rotation");
+            start();
+        }
+        viewer.addOnceHandler('open', openHandler);
         viewer.open(DZI_PATH);
     });
 

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -236,6 +236,24 @@
         viewer.open(DZI_PATH);
     });
 
+    asyncTest('getHomeBounds with margins bigger than container', function() {
+        function openHandler() {
+            var viewport = viewer.viewport;
+            viewport.setMargins({
+                top: 300,
+                bottom: 300
+            });
+            Util.assertRectangleEquals(
+                viewport.getHomeBounds(),
+                new OpenSeadragon.Rect(-249.5, -249.5, 500, 500),
+                0.00000001,
+                "Test getHomeBounds with margins bigger than container");
+            start();
+        }
+        viewer.addOnceHandler('open', openHandler);
+        viewer.open(DZI_PATH);
+    });
+
     asyncTest('getHomeBoundsNoRotate with rotation', function() {
         function openHandler() {
             viewer.removeHandler('open', openHandler);


### PR DESCRIPTION
The issue in #1007 was actually due to a conversion error with margins + rotation.
I had to do a bigger refactoring than expected: I got rid of containerInnerSize and let getHomeBounds takes margins into account instead.

One side effect is that `getBounds` now includes margins but the previous behavior seems dangerous to me because margins are only relevant when at home.
