### PR TITLE
Fix #1013

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -947,6 +947,7 @@ function updateViewport( tiledImage ) {
     // Load the new 'best' tile
     if (best && !best.context2D) {
         loadTile( tiledImage, best, currentTime );
+        tiledImage._needsDraw = true;
         tiledImage._setFullyLoaded(false);
     } else {
         tiledImage._setFullyLoaded(true);


### PR DESCRIPTION
tiledImage. _needsDraw flag was only being set to true once the tile had been loaded which effectively made the initial tile loading sequential