### PR TITLE
Use the squared distance when comparing tiles.

### DIFF
--- a/src/point.js
+++ b/src/point.js
@@ -149,6 +149,18 @@ $.Point.prototype = {
     },
 
     /**
+     * Compute the squared distance between this point and another point.
+     * Useful for optimizing things like comparing distances.
+     * @function
+     * @param {OpenSeadragon.Point} point The point to compute the distance with.
+     * @returns {Number} The distance between the 2 points
+     */
+    squaredDistanceTo: function( point ) {
+        return Math.pow( this.x - point.x, 2 ) +
+            Math.pow( this.y - point.y, 2 );
+    },
+
+    /**
      * Apply a function to each coordinate of this point and return a new point.
      * @function
      * @param {function} func The function to apply to each coordinate.

--- a/src/point.js
+++ b/src/point.js
@@ -152,8 +152,8 @@ $.Point.prototype = {
      * Compute the squared distance between this point and another point.
      * Useful for optimizing things like comparing distances.
      * @function
-     * @param {OpenSeadragon.Point} point The point to compute the distance with.
-     * @returns {Number} The distance between the 2 points
+     * @param {OpenSeadragon.Point} point The point to compute the squared distance with.
+     * @returns {Number} The squared distance between the 2 points
      */
     squaredDistanceTo: function( point ) {
         return Math.pow( this.x - point.x, 2 ) +

--- a/src/tile.js
+++ b/src/tile.js
@@ -154,11 +154,12 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D) {
      */
     this.opacity    = null;
     /**
-     * The distance of this tile to the viewport center.
-     * @member {Number} distance
+     * The squared distance of this tile to the viewport center.
+     * Use for comparing tiles.
+     * @member {Number} squaredDistance
      * @memberof OpenSeadragon.Tile#
      */
-    this.distance   = null;
+    this.squaredDistance   = null;
     /**
      * The visibility score of this tile.
      * @member {Number} visibility

--- a/src/tile.js
+++ b/src/tile.js
@@ -156,6 +156,7 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D) {
     /**
      * The squared distance of this tile to the viewport center.
      * Use for comparing tiles.
+     * @private
      * @member {Number} squaredDistance
      * @memberof OpenSeadragon.Tile#
      */

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1295,12 +1295,12 @@ function positionTile( tile, overlap, viewport, viewportCenter, levelVisibility,
     boundsSize.x *= tiledImage._scaleSpring.current.value;
     boundsSize.y *= tiledImage._scaleSpring.current.value;
 
-    var positionC    = viewport.pixelFromPointNoRotate(boundsTL, true),
-        positionT    = viewport.pixelFromPointNoRotate(boundsTL, false),
-        sizeC        = viewport.deltaPixelsFromPointsNoRotate(boundsSize, true),
-        sizeT        = viewport.deltaPixelsFromPointsNoRotate(boundsSize, false),
-        tileCenter   = positionT.plus( sizeT.divide( 2 ) ),
-        tileDistance = viewportCenter.distanceTo( tileCenter );
+    var positionC = viewport.pixelFromPointNoRotate(boundsTL, true),
+        positionT = viewport.pixelFromPointNoRotate(boundsTL, false),
+        sizeC = viewport.deltaPixelsFromPointsNoRotate(boundsSize, true),
+        sizeT = viewport.deltaPixelsFromPointsNoRotate(boundsSize, false),
+        tileCenter = positionT.plus( sizeT.divide( 2 ) ),
+        tileSquaredDistance = viewportCenter.squaredDistanceTo( tileCenter );
 
     if ( !overlap ) {
         sizeC = sizeC.plus( new $.Point( 1, 1 ) );
@@ -1308,7 +1308,7 @@ function positionTile( tile, overlap, viewport, viewportCenter, levelVisibility,
 
     tile.position   = positionC;
     tile.size       = sizeC;
-    tile.distance   = tileDistance;
+    tile.squaredDistance   = tileSquaredDistance;
     tile.visibility = levelVisibility;
 }
 
@@ -1452,7 +1452,7 @@ function compareTiles( previousBest, tile ) {
     if ( tile.visibility > previousBest.visibility ) {
         return tile;
     } else if ( tile.visibility == previousBest.visibility ) {
-        if ( tile.distance < previousBest.distance ) {
+        if ( tile.squaredDistance < previousBest.squaredDistance ) {
             return tile;
         }
     }


### PR DESCRIPTION
This drops a Math.sqrt calculation from every tile iterated over while drawing, improving performance.

It's a pretty typical optimization in graphics. Not as optimal as eliminating the distance calculation entirely, but better than nothing.

