### PR TITLE
IE8 fix for tileSources type: 'image'

### DIFF
--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -72,6 +72,13 @@
         $.TileSource.apply(this, [options]);
 
     };
+    
+    /* IE8 fix for tileSources type: 'image' */
+    $.getNatural = function (DOMelement) {
+        var img = new Image();
+        img.src = DOMelement.src;
+        return { width: img.width, height: img.height };
+    };
 
     $.extend($.ImageTileSource.prototype, $.TileSource.prototype, /** @lends OpenSeadragon.ImageTileSource.prototype */{
         /**
@@ -114,8 +121,8 @@
             }
 
             $.addEvent(image, 'load', function () {
-                _this.width = image.naturalWidth;
-                _this.height = image.naturalHeight;
+                _this.width = $.getNatural(image).width;
+                _this.height = $.getNatural(image).height;
                 _this.aspectRatio = _this.width / _this.height;
                 _this.dimensions = new $.Point(_this.width, _this.height);
                 _this._tileWidth = _this.width;
@@ -202,8 +209,8 @@
         _buildLevels: function () {
             var levels = [{
                     url: this._image.src,
-                    width: this._image.naturalWidth,
-                    height: this._image.naturalHeight
+                    width: $.getNatural(this._image).width,
+                    height: $.getNatural(this._image).height
                 }];
 
             if (!this.buildPyramid || !$.supportsCanvas || !this.useCanvas) {

--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -72,13 +72,6 @@
         $.TileSource.apply(this, [options]);
 
     };
-    
-    /* IE8 fix for tileSources type: 'image' */
-    $.getNatural = function (DOMelement) {
-        var img = new Image();
-        img.src = DOMelement.src;
-        return { width: img.width, height: img.height };
-    };
 
     $.extend($.ImageTileSource.prototype, $.TileSource.prototype, /** @lends OpenSeadragon.ImageTileSource.prototype */{
         /**
@@ -121,8 +114,9 @@
             }
 
             $.addEvent(image, 'load', function () {
-                _this.width = $.getNatural(image).width;
-                _this.height = $.getNatural(image).height;
+                /* IE8 fix since it has no naturalWidth and naturalHeight */
+                _this.width = Object.prototype.hasOwnProperty.call(image, 'naturalWidth') ? image.naturalWidth : image.width;
+                _this.height = Object.prototype.hasOwnProperty.call(image, 'naturalHeight') ? image.naturalHeight : image.height;
                 _this.aspectRatio = _this.width / _this.height;
                 _this.dimensions = new $.Point(_this.width, _this.height);
                 _this._tileWidth = _this.width;
@@ -209,8 +203,9 @@
         _buildLevels: function () {
             var levels = [{
                     url: this._image.src,
-                    width: $.getNatural(this._image).width,
-                    height: $.getNatural(this._image).height
+                    /* IE8 fix since it has no naturalWidth and naturalHeight */
+                    width: Object.prototype.hasOwnProperty.call(this._image, 'naturalWidth') ? this._image.naturalWidth : this._image.width,
+                    height:  Object.prototype.hasOwnProperty.call(this._image, 'naturalHeight') ? this._image.naturalHeight : this._image.height
                 }];
 
             if (!this.buildPyramid || !$.supportsCanvas || !this.useCanvas) {
@@ -219,8 +214,10 @@
                 return levels;
             }
 
-            var currentWidth = this._image.naturalWidth;
-            var currentHeight = this._image.naturalHeight;
+            /* IE8 fix since it has no naturalWidth and naturalHeight */
+            var currentWidth = Object.prototype.hasOwnProperty.call(this._image, 'naturalWidth') ? this._image.naturalWidth : this._image.width;
+            var currentHeight = Object.prototype.hasOwnProperty.call(this._image, 'naturalHeight') ? this._image.naturalHeight : this._image.height;
+
 
             var bigCanvas = document.createElement("canvas");
             var bigContext = bigCanvas.getContext("2d");


### PR DESCRIPTION
Bug fix for IE8, that comes from [this issue](https://github.com/openseadragon/openseadragon/issues/1040).

Now this definithon should work:

```
OpenSeadragon({
    ...
    tileSources: {
        type: 'image',
        url:  '/example-images/grand-canyon-landscape-overlooking.jpg'
    }
    ...
});
```