### PR TITLE
Update legacytilesource.js

### DIFF
--- a/src/legacytilesource.js
+++ b/src/legacytilesource.js
@@ -204,12 +204,7 @@ function filterFiles( files ){
         file = files[ i ];
         if( file.height &&
             file.width &&
-            file.url && (
-                file.url.toLowerCase().match(/^.*\.(png|jpg|jpeg|gif)(?:\?.*)?$/) || (
-                    file.mimetype &&
-                    file.mimetype.toLowerCase().match(/^.*\/(png|jpg|jpeg|gif)$/)
-                )
-            ) ){
+            file.url ){
             //This is sufficient to serve as a level
             filtered.push({
                 url: file.url,


### PR DESCRIPTION
Remove check for filetype based on uri or mimetype strings (maybe the filetype is not known before actually downloading the resource).

(Please bear with me, this is my first PR. I'm only starting with git/github.)