### PR TITLE
count tiledImage._tilesLoading

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -146,6 +146,7 @@ $.TiledImage = function( options ) {
         _midDraw:       false, // Is the tiledImage currently updating the viewport?
         _needsDraw:     true,  // Does the tiledImage need to update the viewport again?
         _hasOpaqueTile: false,  // Do we have even one fully opaque tile?
+        _tilesLoading:  0,     // The number of pending tile requests.
         //configurable settings
         springStiffness:        $.DEFAULT_SETTINGS.springStiffness,
         animationTime:          $.DEFAULT_SETTINGS.animationTime,
@@ -898,6 +899,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     // private
     _updateViewport: function() {
         this._needsDraw = false;
+        this._tilesLoading = 0;
 
         // Reset tile's internal drawn state
         while (this.lastDrawn.length > 0) {
@@ -994,7 +996,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             this._needsDraw = true;
             this._setFullyLoaded(false);
         } else {
-            this._setFullyLoaded(true);
+            this._setFullyLoaded(this._tilesLoading === 0);
         }
     }
 });
@@ -1178,7 +1180,7 @@ function updateTile( tiledImage, drawLevel, haveDrawn, x, y, level, levelOpacity
         }
     } else if ( tile.loading ) {
         // the tile is already in the download queue
-        // thanks josh1093 for finally translating this typo
+        tiledImage._tilesLoading++;
     } else {
         best = compareTiles( best, tile );
     }


### PR DESCRIPTION
TL;DR: I've added a `tiledImage._tilesLoading` flag that tracks the requests for tiles that are still pending have not yet received data. This allows `tiledImage._fullyLoaded` to behave as expected.

The `tiledImage._fullyLoaded` term [pulled into master as request 837](https://github.com/openseadragon/openseadragon/pull/837) as well as the associated tiledImage event `'fully-loaded-change'` should allow the developer to design viewers that respond to the **completed loading of all tiles** for a current view in a `tiledImage`.

> TiledImage now has a getFullyLoaded() function that tells you whether all tiles necessary for this TiledImage to draw at the current view have been loaded. You can watch this status as well by listening to the fully-loaded-change event on the TiledImage.

-- @iangilman [2016-08-10](https://github.com/openseadragon/openseadragon/pull/837#issuecomment-238943723)

As the current master branch stands, the `tiledImage._fullLoaded` flag actually only informs the developer whether all tiles have _begun loading._ The changes here make `tiledImage._fullLoaded`, `tiledImage.getFullyLoaded`, and the `'fully-loaded-change'` event inform the developer whether all tiles have _finished loading._

Many thanks to Ian Gilman for walking me through the changes needed to make this happen.