### PR TITLE
Fix incorrect call to getTileWidth and getTileHeight in getTileAtPoint

### DIFF
--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -353,8 +353,8 @@ $.TileSource.prototype = {
         var pixelX = point.x * widthScaled;
         var pixelY = point.y * widthScaled;
 
-        var x = Math.floor(pixelX / this.getTileWidth());
-        var y = Math.floor(pixelY / this.getTileHeight());
+        var x = Math.floor(pixelX / this.getTileWidth(level));
+        var y = Math.floor(pixelY / this.getTileHeight(level));
 
         return new $.Point(x, y);
     },


### PR DESCRIPTION
`TileSource.getTileAtPoint` incorrectly calls `TileSource.getTileWidth` and `TileSource.getTileHeight` without the `level` parameter. This won't matter if all levels have a uniform tile size, but it will cause major problems otherwise.