### PR TITLE
Navigator can pan outside boundary

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -405,6 +405,9 @@ function onCanvasDrag( event ) {
                 event.delta
             )
         );
+        if( this.viewer.constrainDuringPan ){
+            this.viewer.viewport.applyConstraints();
+        }
     }
 }
 


### PR DESCRIPTION
Fix navigator doesn't get constrained although viewer have `constrainDuringPan` options set `true`