### PR TITLE
prevent unnecessary panBy on canvas-drag in viewer

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2573,11 +2573,11 @@ function onCanvasDrag( event ) {
         if( !this.panVertical ){
             event.delta.y = 0;
         }
-        if( event.delta.x !== 0 || event.delta.y !== 0){
+        if( event.delta.x !== 0 || event.delta.y !== 0 ){
             this.viewport.panBy( this.viewport.deltaPointsFromPixels( event.delta.negate() ), gestureSettings.flickEnabled );
-        }
-        if( this.constrainDuringPan ){
-            this.viewport.applyConstraints();
+            if( this.constrainDuringPan ){
+                this.viewport.applyConstraints();
+            }
         }
     }
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2573,7 +2573,9 @@ function onCanvasDrag( event ) {
         if( !this.panVertical ){
             event.delta.y = 0;
         }
-        this.viewport.panBy( this.viewport.deltaPointsFromPixels( event.delta.negate() ), gestureSettings.flickEnabled );
+        if( event.delta.x !== 0 || event.delta.y !== 0){
+            this.viewport.panBy( this.viewport.deltaPointsFromPixels( event.delta.negate() ), gestureSettings.flickEnabled );
+        }
         if( this.constrainDuringPan ){
             this.viewport.applyConstraints();
         }


### PR DESCRIPTION
In reference to my comments on #1149.
`event.delta.x` and `event.delta.y` will _both_ be set to zero if `panHorizontal` and `panVertical` are `false`. These values could also _both_ be zero if the drag passes them naturally, but would require no movement. If _either_ of these values are not zero, then the `panBy` should be applied.