### PR TITLE
Enable configuration of ImageJob timeout

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -45,6 +45,7 @@
  * @param {String} [options.crossOriginPolicy] - CORS policy to use for downloads
  * @param {Function} [options.callback] - Called once image has been downloaded.
  * @param {Function} [options.abort] - Called when this image job is aborted.
+ * @param {Number} [options.timeout] - The max number of milliseconds that this image job may take to complete.
  */
 function ImageJob (options) {
 
@@ -171,11 +172,13 @@ ImageJob.prototype = {
  * You generally won't have to interact with the ImageLoader directly.
  * @param {Object} options - Options for this ImageLoader.
  * @param {Number} [options.jobLimit] - The number of concurrent image requests. See imageLoaderLimit in {@link OpenSeadragon.Options} for details.
+ * @param {Number} [options.timeout] - The max number of milliseconds that an image job may take to complete.
  */
 $.ImageLoader = function(options) {
 
     $.extend(true, this, {
         jobLimit:       $.DEFAULT_SETTINGS.imageLoaderLimit,
+        timeout:        $.DEFAULT_SETTINGS.timeout,
         jobQueue:       [],
         jobsInProgress: 0
     }, options);
@@ -210,7 +213,8 @@ $.ImageLoader.prototype = {
                 crossOriginPolicy: options.crossOriginPolicy,
                 ajaxWithCredentials: options.ajaxWithCredentials,
                 callback: complete,
-                abort: options.abort
+                abort: options.abort,
+                timeout: this.timeout
             },
             newJob = new ImageJob(jobOptions);
 

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -411,6 +411,7 @@
   *     The max number of images we should keep in memory (per drawer).
   *
   * @property {Number} [timeout=30000]
+  *     The max number of milliseconds that an image job may take to complete.
   *
   * @property {Boolean} [useCanvas=true]
   *     Set to false to not use an HTML canvas element for image rendering even if canvas is supported.

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -370,7 +370,8 @@ $.Viewer = function( options ) {
 
     // Create the image loader
     this.imageLoader = new $.ImageLoader({
-        jobLimit: this.imageLoaderLimit
+        jobLimit: this.imageLoaderLimit,
+        timeout: options.timeout
     });
 
     // Create the tile cache

--- a/test/coverage.html
+++ b/test/coverage.html
@@ -81,6 +81,7 @@
     <script src="/test/modules/spring.js"></script>
     <script src="/test/modules/rectangle.js"></script>
     <script src="/test/modules/ajax-tiles.js"></script>
+    <script src="/test/modules/imageloader.js"></script>
     <!-- The navigator tests are the slowest (for now; hopefully they can be sped up)
     so we put them last. -->
     <script src="/test/modules/navigator.js"></script>

--- a/test/modules/imageloader.js
+++ b/test/modules/imageloader.js
@@ -1,0 +1,88 @@
+/* global module, asyncTest, $, ok, equal, notEqual, start, test, Util, testLog */
+
+(function() {
+    var viewer,
+        baseOptions = {
+            id:            'example',
+            prefixUrl:     '/build/openseadragon/images/',
+            springStiffness: 100 // Faster animation = faster tests
+        };
+
+    module('ImageLoader', {
+        setup: function () {
+            var example = $('<div id="example"></div>').appendTo("#qunit-fixture");
+
+            testLog.reset();
+        },
+        teardown: function () {
+            if (viewer && viewer.close) {
+                viewer.close();
+            }
+
+            viewer = null;
+        }
+    });
+
+    // ----------
+
+    test('Default timeout', function() {
+        var actual,
+            expected = OpenSeadragon.DEFAULT_SETTINGS.timeout,
+            message,
+            options = OpenSeadragon.extend(true, baseOptions, {
+                imageLoaderLimit: 1
+            }), 
+            viewer = OpenSeadragon(options),
+            imageLoader = viewer.imageLoader;
+
+        message = 'ImageLoader timeout should be set to the default value of ' + expected + ' when none is specified';
+        actual = imageLoader.timeout;
+        equal(actual, expected, message); 
+
+        // Manually seize the ImageLoader
+        imageLoader.jobsInProgress = imageLoader.jobLimit;
+        imageLoader.addJob({
+            src: 'test',
+            loadWithAjax: false,
+            crossOriginPolicy: 'test',
+            ajaxWithCredentials: false,
+            abort: function() {}
+        });
+
+        message = 'ImageJob should inherit the ImageLoader timeout value';
+        actual = imageLoader.jobQueue.shift().timeout;
+        equal(actual, expected, message); 
+    });
+
+    // ----------
+            
+    test('Configure timeout', function() {
+        var actual,
+            expected = 123456,
+            message,
+            options = OpenSeadragon.extend(true, baseOptions, {
+                imageLoaderLimit: 1,
+                timeout: expected
+            }),
+            viewer = OpenSeadragon(options),
+            imageLoader = viewer.imageLoader;
+
+        message = 'ImageLoader timeout should be configurable';
+        actual = imageLoader.timeout;
+        equal(actual, expected, message); 
+
+        imageLoader.jobsInProgress = imageLoader.jobLimit;
+        imageLoader.addJob({
+            src: 'test',
+            loadWithAjax: false,
+            crossOriginPolicy: 'test',
+            ajaxWithCredentials: false,
+            abort: function() {}
+        });
+
+        message = 'ImageJob should inherit the ImageLoader timeout value';
+        actual = imageLoader.jobQueue.shift().timeout;
+        equal(actual, expected, message); 
+    });
+
+})();

--- a/test/test.html
+++ b/test/test.html
@@ -43,6 +43,7 @@
     <script src="/test/modules/spring.js"></script>
     <script src="/test/modules/rectangle.js"></script>
     <script src="/test/modules/ajax-tiles.js"></script>
+    <script src="/test/modules/imageloader.js"></script>
     <!-- The navigator tests are the slowest (for now; hopefully they can be sped up)
     so we put them last. -->
     <script src="/test/modules/navigator.js"></script>


### PR DESCRIPTION
The [`timeout`](https://github.com/openseadragon/openseadragon/blob/b08efcf169756171ca4b06ac84e9ac777cb3efe6/src/openseadragon.js#L413) property is not currently configurable through the top-level API.

Basically I did what is outlined by [this comment](https://github.com/openseadragon/openseadragon/issues/913#issuecomment-213513469) (also tangentially related to https://github.com/openseadragon/openseadragon/issues/880, as I had problem  similar to what is outlined there).

I am not sure where tests should go for this fix. I added a new file called `configuration.js` with some TODOs, but there may be a place that is better suited.