### PR TITLE
No longer loading too many tiles

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -146,7 +146,8 @@ $.TiledImage = function( options ) {
         //internal state properties
         viewer:         null,
         tilesMatrix:    {},    // A '3d' dictionary [level][x][y] --> Tile.
-        coverage:       {},    // A '3d' dictionary [level][x][y] --> Boolean.
+        coverage:       {},    // A '3d' dictionary [level][x][y] --> Boolean; shows what areas have been drawn.
+        loadingCoverage: {},   // A '3d' dictionary [level][x][y] --> Boolean; shows what areas are loaded or are being loaded/blended.
         lastDrawn:      [],    // An unordered list of Tiles drawn last frame.
         lastResetTime:  0,     // Last time for which the tiledImage was reset.
         _midDraw:       false, // Is the tiledImage currently updating the viewport?
@@ -1122,6 +1123,7 @@ function updateLevel(tiledImage, haveDrawn, drawLevel, level, levelOpacity,
     }
 
     resetCoverage(tiledImage.coverage, level);
+    resetCoverage(tiledImage.loadingCoverage, level);
 
     //OK, a new drawing so do your calculations
     var cornerTiles = tiledImage._getCornerTiles(level, topLeftBound, bottomRightBound);
@@ -1216,6 +1218,9 @@ function updateTile( tiledImage, haveDrawn, drawLevel, x, y, level, levelOpacity
 
     setCoverage( tiledImage.coverage, level, x, y, false );
 
+    var loadingCoverage = tile.loaded || tile.loading || isCovered(tiledImage.loadingCoverage, level, x, y);
+    setCoverage(tiledImage.loadingCoverage, level, x, y, loadingCoverage);
+
     if ( !tile.exists ) {
         return best;
     }
@@ -1269,7 +1274,7 @@ function updateTile( tiledImage, haveDrawn, drawLevel, x, y, level, levelOpacity
     } else if ( tile.loading ) {
         // the tile is already in the download queue
         tiledImage._tilesLoading++;
-    } else {
+    } else if (!loadingCoverage) {
         best = compareTiles( best, tile );
     }
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1018,6 +1018,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
 
         // Load the new 'best' tile
         if (bestTile && !bestTile.context2D) {
+            $.console.log('loading tile, level: ' + bestTile.level + ', x: ' + bestTile.x + ', y: ' + bestTile.y);
             loadTile(this, bestTile, currentTime);
             this._needsDraw = true;
             this._setFullyLoaded(false);

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1054,7 +1054,6 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
 
         // Load the new 'best' tile
         if (bestTile && !bestTile.context2D) {
-            $.console.log('loading tile, level: ' + bestTile.level + ', x: ' + bestTile.x + ', y: ' + bestTile.y);
             loadTile(this, bestTile, currentTime);
             this._needsDraw = true;
             this._setFullyLoaded(false);

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -925,6 +925,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     _updateViewport: function() {
         this._needsDraw = false;
         this._tilesLoading = 0;
+        this.loadingCoverage = {};
 
         // Reset tile's internal drawn state
         while (this.lastDrawn.length > 0) {


### PR DESCRIPTION
Tracking tile loading separately from tile drawing for purposes of determining what to load next. Fixes #1020 