### PR TITLE
Improved best first level calculation

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -978,7 +978,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             var targetZeroRatio = viewport.deltaPixelsFromPointsNoRotate(
                 this.source.getPixelRatio(
                     Math.max(
-                        this.source.getClosestLevel(viewport.containerSize) - 1,
+                        this.source.getClosestLevel(),
                         0
                     )
                 ),

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -320,21 +320,14 @@ $.TileSource.prototype = {
 
     /**
      * @function
-     * @param {Rect} rect
      */
-    getClosestLevel: function( rect ) {
+    getClosestLevel: function() {
         var i,
-            tilesPerSide,
             tiles;
 
-        for( i = this.minLevel; i < this.maxLevel; i++ ){
+        for( i = this.minLevel; i <= this.maxLevel; i++ ){
             tiles = this.getNumTiles( i );
-            tilesPerSide = new $.Point(
-              Math.floor( rect.x / this.getTileWidth(i) ),
-              Math.floor( rect.y / this.getTileHeight(i) )
-            );
-
-            if( tiles.x + 1 >= tilesPerSide.x && tiles.y + 1 >= tilesPerSide.y ){
+            if (tiles.x > 1 || tiles.y > 1) {
                 break;
             }
         }

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -320,18 +320,20 @@ $.TileSource.prototype = {
 
     /**
      * @function
+     * @returns {Number} The highest level in this tile source that can be contained in a single tile.
      */
     getClosestLevel: function() {
         var i,
             tiles;
 
-        for( i = this.minLevel; i <= this.maxLevel; i++ ){
-            tiles = this.getNumTiles( i );
+        for (i = this.minLevel + 1; i <= this.maxLevel; i++){
+            tiles = this.getNumTiles(i);
             if (tiles.x > 1 || tiles.y > 1) {
                 break;
             }
         }
-        return Math.max( 0, i - 1 );
+
+        return i - 1;
     },
 
     /**


### PR DESCRIPTION
Fixes #1197 

The issue hinges around the `levelVisibility` calculation that's based in part on `TileSource.getClosestLevel`. With 254px tiles, the response from getClosestLevel is reasonable, but with 500px tiles it just returns 0. 

I'm not actually sure why getClosestLevel compares against the container size. It seems to me the best thing to do is just find the highest level where the entire image can fit on a single tile, so I changed it to do that, and in my testing the results are good: regardless of the tile size or the viewer size, the first tile that's loaded is the largest single-tile level, and then higher level tiles are loaded to fill in the remainder. 

If you force the `defaultZoomLevel` to be something small, it will start with a lower level, since it doesn't need a tile as large as the largest single-tile level. If you force defaultZoomLevel to something big, it still starts with the largest single-tile level (unless you have `immediateRender` on), since we don't want to risk having holes. All seems good to me. 

Even though getClosestLevel is technically a [documented](http://openseadragon.github.io/docs/OpenSeadragon.TileSource.html#getClosestLevel) function, I'm not terribly concerned about changing it like this; it's not really a function people would use, and it still produces the same kind of value (even if the logic is different now), and ignoring the old argument isn't really a breaking change. Also note that this function is currently called in only one place. I suppose I could at least improve its documentation. 

That said, I'd love a second opinion... @avandecreme, what do you think? 

@rmcloughlin, can you verify that this fixes the issue you found?