### PR TITLE
Clamp device pixel ratio to a minimum of 1 for calculating pixelDensi…

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -880,7 +880,7 @@ function OpenSeadragon( options ){
                                     context.msBackingStorePixelRatio ||
                                     context.oBackingStorePixelRatio ||
                                     context.backingStorePixelRatio || 1;
-            return devicePixelRatio / backingStoreRatio;
+            return Math.max(devicePixelRatio, 1) / backingStoreRatio;
         } else {
             return 1;
         }


### PR DESCRIPTION
…tyRatio.

A lower value can cause tile drawing issues.