### PR TITLE
Use TileSource.getClosestLevel to set TileCache release cutoff

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1468,8 +1468,7 @@ function onTileLoad( tiledImage, tile, time, image, errorMsg, tileRequest ) {
     }
 
     var finish = function() {
-        var cutoff = Math.ceil( Math.log(
-            tiledImage.source.getTileWidth(tile.level) ) / Math.log( 2 ) );
+        var cutoff = tiledImage.source.getClosestLevel();
         setTileLoaded(tiledImage, tile, image, cutoff, tileRequest);
     };
 


### PR DESCRIPTION
The current implementation of `TiledImage` sets the cutoff for releasing tiles from the cache to `log2(tileWidth)` which doesn't have much relevance to whether tiles should be released. This often means that tiles are never released from the cache, causing very high memory usage on large images. For example, in an image with 256x256 tiles `log2(256) = 8` any tiles in level 8 or below will never be released from the cache.

This PR uses `TileSource.getClosestLevel()` to set the cutoff, which means any levels where the entire image fits in a single tile will not be released from the cache. I imagine this was the original intention of this piece of code.