### PR TITLE
Fix image stuck to mouse when right-clicking and left-clicking simult…

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2881,7 +2881,7 @@
 
             // A primary mouse button may have been released while the non-primary button was down
             if (pointsList.contacts > 0 && pointsList.type === 'mouse') {
-                // Stop tracking the mouse
+                // Stop tracking the mouse; see https://github.com/openseadragon/openseadragon/pull/1223
                 pointsList.contacts--;
                 return true;
             }

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2879,6 +2879,12 @@
                 }
             }
 
+            // A primary mouse button may have been released while the non-primary button was down
+            if (pointsList.contacts > 0 && pointsList.type === 'mouse') {
+                // Stop tracking the mouse
+                pointsList.contacts--;
+                return true;
+            }
             return false;
         }
 


### PR DESCRIPTION
…aneously.

Mouseup and mousedown events are lost when two buttons are pressed at the same time. Pressing buttons in the order left-button down, right-button down (ignored), left-button up (ignored), right-button up was leaving drag state active.