### PR TITLE
Add support for setting debug mode after the Viewer object has been constructed. #1221

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -861,6 +861,22 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     },
 
     /**
+     * Turns debugging mode on or off for this viewer.
+     *
+     * @function
+     * @param {Boolean} true to turn debug on, false to turn debug off.
+     */
+    setDebugMode: function(debugMode){
+
+        for (var i = 0; i < this.world.getItemCount(); i++) {
+            this.world.getItemAt(i).debugMode = debugMode;
+        }
+
+        this.debugMode = debugMode;
+        this.forceRedraw();
+    },
+
+    /**
      * @function
      * @return {Boolean}
      */

--- a/test/demo/setdebugmode.html
+++ b/test/demo/setdebugmode.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>OpenSeadragon Basic Demo</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+    <style type="text/css">
+        .openseadragon1 {
+            width: 800px;
+            height: 600px;
+        }
+    </style>
+</head>
+
+<body>
+    <div>
+        Turn debug mode on and off after viewer has been created.
+        <button onclick="debugModeOn()">Debug Mode On</button>
+        <button onclick="debugModeOff()">Debug Mode Off</button>
+    </div>
+    <div id="contentDiv" class="openseadragon1"></div>
+    <script type="text/javascript">
+
+        var viewer = OpenSeadragon({
+            // debugMode: true,
+            id: "contentDiv",
+            prefixUrl: "../../build/openseadragon/images/",
+            tileSources: "../data/testpattern.dzi",
+            showNavigator: true,
+            debugMode: true
+        });
+
+        function debugModeOn() {
+            viewer.setDebugMode(true);
+        }
+
+        function debugModeOff() {
+            viewer.setDebugMode(false);
+        }
+    </script>
+</body>
+
+</html>

--- a/test/modules/basic.js
+++ b/test/modules/basic.js
@@ -424,6 +424,40 @@
 
     } );
 
+
+    asyncTest('SetDebugMode', function() {
+        ok(viewer, 'Viewer exists');
+
+        var checkImageTilesDebugState = function (expectedState) {
+
+            for (var i = 0; i < viewer.world.getItemCount(); i++) {
+                if(viewer.world.getItemAt(i).debugMode != expectedState) {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        var openHandler = function(event) {
+            viewer.removeHandler('open', openHandler);
+
+            //Ensure we start with debug mode turned off
+            viewer.setDebugMode(false);
+            ok(checkImageTilesDebugState(false), "All image tiles have debug mode turned off.");
+            ok(!viewer.debugMode, "Viewer debug mode is turned off.");
+
+            //Turn debug mode on and check that the Viewer and all tiled images are in debug mode.
+            viewer.setDebugMode(true);
+            ok(checkImageTilesDebugState(true), "All image tiles have debug mode turned on.");
+            ok(viewer.debugMode, "Viewer debug mode is turned on.");
+
+            start();
+        };
+
+        viewer.addHandler('open', openHandler);
+        viewer.open('/test/data/testpattern.dzi');
+    });
+
     test('version object', function() {
         equal(typeof OpenSeadragon.version.versionStr, "string", "versionStr should be a string");
         ok(OpenSeadragon.version.major >= 0, "major should be a positive number");


### PR DESCRIPTION
This patch adds a setDebugMode function to the Viewer object. This enables scenarios such as toggling debug mode from a button in the UI.

