### PR TITLE
Skip version tests when running coverage. Fixes #1226

### DIFF
--- a/test/coverage.html
+++ b/test/coverage.html
@@ -10,6 +10,11 @@
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
+
+    <script>
+        var isCoverageTest = true;
+    </script>
+
     <script src="/node_modules/qunitjs/qunit/qunit.js"></script>
     <script src="/test/lib/jquery-1.9.1.min.js"></script>
     <script src="/test/lib/jquery-ui-1.10.2/js/jquery-ui-1.10.2.min.js"></script>

--- a/test/modules/basic.js
+++ b/test/modules/basic.js
@@ -458,11 +458,13 @@
         viewer.open('/test/data/testpattern.dzi');
     });
 
-    test('version object', function() {
-        equal(typeof OpenSeadragon.version.versionStr, "string", "versionStr should be a string");
-        ok(OpenSeadragon.version.major >= 0, "major should be a positive number");
-        ok(OpenSeadragon.version.minor >= 0, "minor should be a positive number");
-        ok(OpenSeadragon.version.revision >= 0, "revision should be a positive number");
-    });
-
+    //Version numbers are injected by the build process, so skip version tests if we are only running code coverage
+    if(!window.isCoverageTest ){
+        test('version object', function() {
+            equal(typeof OpenSeadragon.version.versionStr, "string", "versionStr should be a string");
+            ok(OpenSeadragon.version.major >= 0, "major should be a positive number");
+            ok(OpenSeadragon.version.minor >= 0, "minor should be a positive number");
+            ok(OpenSeadragon.version.revision >= 0, "revision should be a positive number");
+        });
+    }
 })();


### PR DESCRIPTION
These changes prevent version tests from running when code coverage is being executed. Version numbers are injected by the build process so these tests currently fail when running code coverage only.