### PR TITLE
fix for #1209 (Reference strip using "thumbs")

### DIFF
--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -50,6 +50,7 @@
      * @extends OpenSeadragon.TileSource
      * @param {Object} options Options object.
      * @param {String} options.url URL of the image
+     * @param {String} options.referenceStripThumbnailUrl URL of the dedicated thumbnail image
      * @param {Boolean} [options.buildPyramid=true] If set to true (default), a
      * pyramid will be built internally to provide a better downsampling.
      * @param {String|Boolean} [options.crossOriginPolicy=false] Valid values are

--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -50,7 +50,6 @@
      * @extends OpenSeadragon.TileSource
      * @param {Object} options Options object.
      * @param {String} options.url URL of the image
-     * @param {String} options.referenceStripThumbnailUrl URL of the dedicated thumbnail image
      * @param {Boolean} [options.buildPyramid=true] If set to true (default), a
      * pyramid will be built internally to provide a better downsampling.
      * @param {String|Boolean} [options.crossOriginPolicy=false] Valid values are

--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -428,9 +428,19 @@ function loadPanels( strip, viewerSize, scroll ) {
     for ( i = activePanelsStart; i < activePanelsEnd && i < strip.panels.length; i++ ) {
         element = strip.panels[i];
         if ( !element.activePanel ) {
+            var miniTileSource;
+            var originalTileSource = strip.viewer.tileSources[i];
+            if (originalTileSource.referenceStripThumbnailUrl) {
+                miniTileSource = {
+                    type: 'image',
+                    url: originalTileSource.referenceStripThumbnailUrl
+                };
+            } else {
+                miniTileSource = originalTileSource;
+            }
             miniViewer = new $.Viewer( {
                 id:                     element.id,
-                tileSources:            [strip.viewer.tileSources[i]],
+                tileSources:            [miniTileSource],
                 element:                element,
                 navigatorSizeRatio:     strip.sizeRatio,
                 showNavigator:          false,

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -60,6 +60,8 @@
  *      the extending classes implementation of 'configure'.
  * @param {String} [options.url]
  *      The URL for the data necessary for this TileSource.
+ * @param {String} [options.referenceStripThumbnailUrl]
+ *      The URL for the thumbnail image to be used by the reference strip
  * @param {Function} [options.success]
  *      A function to be called upon successful creation.
  * @param {Boolean} [options.ajaxWithCredentials]


### PR DESCRIPTION
Took the option name (`referenceStripThumbnailUrl`) like you suggested and added it to doc appropriately.

Btw. in the end I ditched the cloning approach as it was not needed when we're not changing the original tileSource.