### PR TITLE
Compatibility with direct npm/yarn installation from Github forks/branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,12 @@ You can also get a report of the tests' code coverage:
 
 The report shows up at `coverage/html/index.html` viewable in a browser.
 
+### Installing from forked Github repo/branch
+
+This project is now compatible with direct installation of forked Github repos/branches via npm/yarn (possible because of the new [prepare](https://docs.npmjs.com/misc/scripts) command).  This enables quick testing of a bugfix or feature addition via a forked repo.  In order to do this:
+
+1. Install the Grunt command line runner (if you haven't already); on the command line, run `npm install -g grunt-cli` (or `yarn global add grunt-cli`)
+1. Remove any currently installed openseadragon package via `npm uninstall openseadragon` or `yarn remove openseadragon`
+1. Add the specific forked repo/branch by running `npm install git://github.com/username/openseadragon.git#branch-name` or `yarn add git://github.com/username/openseadragon.git#branch-name`. Make sure to replace username and branch-name with proper targets.
+
+During installation, the package should be correctly built via grunt and can then be used via `import Openseadragon from 'openseadragon'` or `var Openseadragon = require('openseadragon')` statements as if the official package were installed.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -194,8 +194,12 @@ module.exports = function(grunt) {
             target: sources
         },
         "git-describe": {
+            "options": {
+                failOnError: false
+            },
             build: {}
-        }
+        },
+        gitInfo: "unknown"
     });
 
     // ----------

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "scripts": {
     "test": "grunt test",
-    "prepublish": "grunt build"
+    "prepare": "grunt build"
   }
 }


### PR DESCRIPTION
This leverages the new `prepare` command that replaces the `prepublish` command.  This enables things to work as before for openseadragon publishing to the NPM registry, but adds support for installing from a Github fork of openseadragon.  When installed this way (via `npm install git://github.com/username/openseadragon.git#branch-name` or `yarn add git://github.com/username/openseadragon.git#branch-name`), the grunt build task will run after the project files have been fetched from Github and the package can be immediately used for testing.

In order to make it work with the least amount of modifications to the Grunt configuration, I simply added the `failOnError: false` setting for `git-describe` in the Gruntfile.  This way it just keeps on building instead aborting when it can't find the git info that doesn't exist.