### PR TITLE
Solves issue #1318 for transparent TiledImages

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -311,6 +311,10 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             this._updateViewport();
             this._midDraw = false;
         }
+        // Images with opacity 0 should not need to be drawn in future. this._needsDraw = false is set in this._updateViewport() for other images.
+        if (this.opacity === 0) {
+            this._needsDraw = false;
+        }
     },
 
     /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -312,7 +312,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             this._midDraw = false;
         }
         // Images with opacity 0 should not need to be drawn in future. this._needsDraw = false is set in this._updateViewport() for other images.
-        if (this.opacity === 0) {
+        else {
             this._needsDraw = false;
         }
     },


### PR DESCRIPTION
Solves issue #1318 . Transparent TiledImages need to set their _needsDraw to false in their draw function. _updateViewport(), which usually does this, is not called for transparent images. Otherwise, they will trigger world's draw function again and again.