### PR TITLE
add loop for re-trying failed tiles (max 3 times)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach",
+            "type": "chrome",
+            "request": "attach",
+            "port": 9222,
+            "url": "http://localhost:8000/test/demo/basic.html",
+            "webRoot": "${workspaceFolder}"
+        },
+    ]
+}

--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -259,7 +259,7 @@
      */
     function completeJob(loader, job, callback) {
 
-        if (job.errorMsg != '' && job.image === null && job.tries < 3) {
+        if (job.errorMsg != '' && job.image === null && job.tries < 1 + loader.tileRetryMax) {
             loader.failedTiles.push(job);
         }
 
@@ -273,13 +273,13 @@
             loader.jobsInProgress++;
         }
 
-        if (loader.refetchFailedTiles && loader.jobQueue.length === 0) {
+        if (loader.tileRetryMax > 0 && loader.jobQueue.length === 0) {
             //SAME AS ABOVE => REFACTOR
             if ((!loader.jobLimit || loader.jobsInProgress < loader.jobLimit) && loader.failedTiles.length > 0) {
                 nextJob = loader.failedTiles.shift();
                 setTimeout(function () {
                     nextJob.start();
-                }, 2500);
+                }, loader.tileRetryDelay);
                 loader.jobsInProgress++;
             }
         }

--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -32,237 +32,252 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-(function($){
-
-/**
- * @private
- * @class ImageJob
- * @classdesc Handles downloading of a single image.
- * @param {Object} options - Options for this ImageJob.
- * @param {String} [options.src] - URL of image to download.
- * @param {String} [options.loadWithAjax] - Whether to load this image with AJAX.
- * @param {String} [options.ajaxHeaders] - Headers to add to the image request if using AJAX.
- * @param {String} [options.crossOriginPolicy] - CORS policy to use for downloads
- * @param {Function} [options.callback] - Called once image has been downloaded.
- * @param {Function} [options.abort] - Called when this image job is aborted.
- * @param {Number} [options.timeout] - The max number of milliseconds that this image job may take to complete.
- */
-function ImageJob (options) {
-
-    $.extend(true, this, {
-        timeout: $.DEFAULT_SETTINGS.timeout,
-        jobId: null
-    }, options);
+(function ($) {
 
     /**
-     * Image object which will contain downloaded image.
-     * @member {Image} image
-     * @memberof OpenSeadragon.ImageJob#
-     */
-    this.image = null;
-}
-
-ImageJob.prototype = {
-    errorMsg: null,
-
-    /**
-     * Starts the image job.
-     * @method
-     */
-    start: function(){
-        var self = this;
-        var selfAbort = this.abort;
-
-        this.image = new Image();
-
-        this.image.onload = function(){
-            self.finish(true);
-        };
-        this.image.onabort = this.image.onerror = function() {
-            self.errorMsg = "Image load aborted";
-            self.finish(false);
-        };
-
-        this.jobId = window.setTimeout(function(){
-            self.errorMsg = "Image load exceeded timeout";
-            self.finish(false);
-        }, this.timeout);
-
-        // Load the tile with an AJAX request if the loadWithAjax option is
-        // set. Otherwise load the image by setting the source proprety of the image object.
-        if (this.loadWithAjax) {
-            this.request = $.makeAjaxRequest({
-                url: this.src,
-                withCredentials: this.ajaxWithCredentials,
-                headers: this.ajaxHeaders,
-                responseType: "arraybuffer",
-                success: function(request) {
-                    var blb;
-                    // Make the raw data into a blob.
-                    // BlobBuilder fallback adapted from
-                    // http://stackoverflow.com/questions/15293694/blob-constructor-browser-compatibility
-                    try {
-                        blb = new window.Blob([request.response]);
-                    } catch (e) {
-                        var BlobBuilder = (
-                            window.BlobBuilder ||
-                            window.WebKitBlobBuilder ||
-                            window.MozBlobBuilder ||
-                            window.MSBlobBuilder
-                        );
-                        if (e.name === 'TypeError' && BlobBuilder) {
-                            var bb = new BlobBuilder();
-                            bb.append(request.response);
-                            blb = bb.getBlob();
-                        }
-                    }
-                    // If the blob is empty for some reason consider the image load a failure.
-                    if (blb.size === 0) {
-                        self.errorMsg = "Empty image response.";
-                        self.finish(false);
-                    }
-                    // Create a URL for the blob data and make it the source of the image object.
-                    // This will still trigger Image.onload to indicate a successful tile load.
-                    var url = (window.URL || window.webkitURL).createObjectURL(blb);
-                    self.image.src = url;
-                },
-                error: function(request) {
-                    self.errorMsg = "Image load aborted - XHR error";
-                    self.finish(false);
-                }
-            });
-
-            // Provide a function to properly abort the request.
-            this.abort = function() {
-                self.request.abort();
-
-                // Call the existing abort function if available
-                if (typeof selfAbort === "function") {
-                    selfAbort();
-                }
-            };
-        } else {
-            if (this.crossOriginPolicy !== false) {
-                this.image.crossOrigin = this.crossOriginPolicy;
-            }
-
-            this.image.src = this.src;
-        }
-    },
-
-    finish: function(successful) {
-        this.image.onload = this.image.onerror = this.image.onabort = null;
-        if (!successful) {
-            this.image = null;
-        }
-
-        if (this.jobId) {
-            window.clearTimeout(this.jobId);
-        }
-
-        this.callback(this);
-    }
-
-};
-
-/**
- * @class ImageLoader
- * @memberof OpenSeadragon
- * @classdesc Handles downloading of a set of images using asynchronous queue pattern.
- * You generally won't have to interact with the ImageLoader directly.
- * @param {Object} options - Options for this ImageLoader.
- * @param {Number} [options.jobLimit] - The number of concurrent image requests. See imageLoaderLimit in {@link OpenSeadragon.Options} for details.
- * @param {Number} [options.timeout] - The max number of milliseconds that an image job may take to complete.
- */
-$.ImageLoader = function(options) {
-
-    $.extend(true, this, {
-        jobLimit:       $.DEFAULT_SETTINGS.imageLoaderLimit,
-        timeout:        $.DEFAULT_SETTINGS.timeout,
-        jobQueue:       [],
-        jobsInProgress: 0
-    }, options);
-
-};
-
-/** @lends OpenSeadragon.ImageLoader.prototype */
-$.ImageLoader.prototype = {
-
-    /**
-     * Add an unloaded image to the loader queue.
-     * @method
-     * @param {Object} options - Options for this job.
+     * @private
+     * @class ImageJob
+     * @classdesc Handles downloading of a single image.
+     * @param {Object} options - Options for this ImageJob.
      * @param {String} [options.src] - URL of image to download.
      * @param {String} [options.loadWithAjax] - Whether to load this image with AJAX.
      * @param {String} [options.ajaxHeaders] - Headers to add to the image request if using AJAX.
-     * @param {String|Boolean} [options.crossOriginPolicy] - CORS policy to use for downloads
-     * @param {Boolean} [options.ajaxWithCredentials] - Whether to set withCredentials on AJAX
-     * requests.
+     * @param {String} [options.crossOriginPolicy] - CORS policy to use for downloads
      * @param {Function} [options.callback] - Called once image has been downloaded.
      * @param {Function} [options.abort] - Called when this image job is aborted.
+     * @param {Number} [options.timeout] - The max number of milliseconds that this image job may take to complete.
+     * @param {Number} [options.tries] - Actual number of the current try.
      */
-    addJob: function(options) {
-        var _this = this,
-            complete = function(job) {
-                completeJob(_this, job, options.callback);
-            },
-            jobOptions = {
-                src: options.src,
-                loadWithAjax: options.loadWithAjax,
-                ajaxHeaders: options.loadWithAjax ? options.ajaxHeaders : null,
-                crossOriginPolicy: options.crossOriginPolicy,
-                ajaxWithCredentials: options.ajaxWithCredentials,
-                callback: complete,
-                abort: options.abort,
-                timeout: this.timeout
-            },
-            newJob = new ImageJob(jobOptions);
+    function ImageJob(options) {
 
-        if ( !this.jobLimit || this.jobsInProgress < this.jobLimit ) {
-            newJob.start();
-            this.jobsInProgress++;
+        $.extend(true, this, {
+            timeout: $.DEFAULT_SETTINGS.timeout,
+            jobId: null,
+            tries: 0
+        }, options);
+
+        /**
+         * Image object which will contain downloaded image.
+         * @member {Image} image
+         * @memberof OpenSeadragon.ImageJob#
+         */
+        this.image = null;
+    }
+
+    ImageJob.prototype = {
+        errorMsg: null,
+
+        /**
+         * Starts the image job.
+         * @method
+         */
+        start: function () {
+            this.tries++;
+
+            var self = this;
+            var selfAbort = this.abort;
+
+            this.image = new Image();
+
+            this.image.onload = function () {
+                self.finish(true);
+            };
+            this.image.onabort = this.image.onerror = function () {
+                self.errorMsg = "Image load aborted";
+                self.finish(false);
+            };
+
+            this.jobId = window.setTimeout(function () {
+                self.errorMsg = "Image load exceeded timeout";
+                self.finish(false);
+            }, this.timeout);
+
+            // Load the tile with an AJAX request if the loadWithAjax option is
+            // set. Otherwise load the image by setting the source proprety of the image object.
+            if (this.loadWithAjax) {
+                this.request = $.makeAjaxRequest({
+                    url: this.src,
+                    withCredentials: this.ajaxWithCredentials,
+                    headers: this.ajaxHeaders,
+                    responseType: "arraybuffer",
+                    success: function (request) {
+                        var blb;
+                        // Make the raw data into a blob.
+                        // BlobBuilder fallback adapted from
+                        // http://stackoverflow.com/questions/15293694/blob-constructor-browser-compatibility
+                        try {
+                            blb = new window.Blob([request.response]);
+                        } catch (e) {
+                            var BlobBuilder = (
+                                window.BlobBuilder ||
+                                window.WebKitBlobBuilder ||
+                                window.MozBlobBuilder ||
+                                window.MSBlobBuilder
+                            );
+                            if (e.name === 'TypeError' && BlobBuilder) {
+                                var bb = new BlobBuilder();
+                                bb.append(request.response);
+                                blb = bb.getBlob();
+                            }
+                        }
+                        // If the blob is empty for some reason consider the image load a failure.
+                        if (blb.size === 0) {
+                            self.errorMsg = "Empty image response.";
+                            self.finish(false);
+                        }
+                        // Create a URL for the blob data and make it the source of the image object.
+                        // This will still trigger Image.onload to indicate a successful tile load.
+                        var url = (window.URL || window.webkitURL).createObjectURL(blb);
+                        self.image.src = url;
+                    },
+                    error: function (request) {
+                        self.errorMsg = "Image load aborted - XHR error";
+                        self.finish(false);
+                    }
+                });
+
+                // Provide a function to properly abort the request.
+                this.abort = function () {
+                    self.request.abort();
+
+                    // Call the existing abort function if available
+                    if (typeof selfAbort === "function") {
+                        selfAbort();
+                    }
+                };
+            } else {
+                if (this.crossOriginPolicy !== false) {
+                    this.image.crossOrigin = this.crossOriginPolicy;
+                }
+
+                this.image.src = this.src;
+            }
+        },
+
+        finish: function (successful) {
+            this.image.onload = this.image.onerror = this.image.onabort = null;
+            if (!successful) {
+                this.image = null;
+            }
+
+            if (this.jobId) {
+                window.clearTimeout(this.jobId);
+            }
+
+            this.callback(this);
         }
-        else {
-            this.jobQueue.push( newJob );
-        }
-    },
+
+    };
 
     /**
-     * Clear any unstarted image loading jobs from the queue.
-     * @method
+     * @class ImageLoader
+     * @memberof OpenSeadragon
+     * @classdesc Handles downloading of a set of images using asynchronous queue pattern.
+     * You generally won't have to interact with the ImageLoader directly.
+     * @param {Object} options - Options for this ImageLoader.
+     * @param {Number} [options.jobLimit] - The number of concurrent image requests. See imageLoaderLimit in {@link OpenSeadragon.Options} for details.
+     * @param {Number} [options.timeout] - The max number of milliseconds that an image job may take to complete.
      */
-    clear: function() {
-        for( var i = 0; i < this.jobQueue.length; i++ ) {
-            var job = this.jobQueue[i];
-            if ( typeof job.abort === "function" ) {
-                job.abort();
+    $.ImageLoader = function (options) {
+
+        $.extend(true, this, {
+            jobLimit: $.DEFAULT_SETTINGS.imageLoaderLimit,
+            timeout: $.DEFAULT_SETTINGS.timeout,
+            jobQueue: [],
+            jobsInProgress: 0
+        }, options);
+
+    };
+
+    /** @lends OpenSeadragon.ImageLoader.prototype */
+    $.ImageLoader.prototype = {
+
+        /**
+         * Add an unloaded image to the loader queue.
+         * @method
+         * @param {Object} options - Options for this job.
+         * @param {String} [options.src] - URL of image to download.
+         * @param {String} [options.loadWithAjax] - Whether to load this image with AJAX.
+         * @param {String} [options.ajaxHeaders] - Headers to add to the image request if using AJAX.
+         * @param {String|Boolean} [options.crossOriginPolicy] - CORS policy to use for downloads
+         * @param {Boolean} [options.ajaxWithCredentials] - Whether to set withCredentials on AJAX
+         * requests.
+         * @param {Function} [options.callback] - Called once image has been downloaded.
+         * @param {Function} [options.abort] - Called when this image job is aborted.
+         */
+        addJob: function (options) {
+            var _this = this,
+                complete = function (job) {
+                    completeJob(_this, job, options.callback);
+                },
+                jobOptions = {
+                    src: options.src,
+                    loadWithAjax: options.loadWithAjax,
+                    ajaxHeaders: options.loadWithAjax ? options.ajaxHeaders : null,
+                    crossOriginPolicy: options.crossOriginPolicy,
+                    ajaxWithCredentials: options.ajaxWithCredentials,
+                    callback: complete,
+                    abort: options.abort,
+                    timeout: this.timeout
+                },
+                newJob = new ImageJob(jobOptions);
+
+            if (!this.jobLimit || this.jobsInProgress < this.jobLimit) {
+                newJob.start();
+                this.jobsInProgress++;
             }
+            else {
+                this.jobQueue.push(newJob);
+            }
+        },
+
+        /**
+         * Clear any unstarted image loading jobs from the queue.
+         * @method
+         */
+        clear: function () {
+            for (var i = 0; i < this.jobQueue.length; i++) {
+                var job = this.jobQueue[i];
+                if (typeof job.abort === "function") {
+                    job.abort();
+                }
+            }
+
+            this.jobQueue = [];
+        }
+    };
+
+    /**
+     * Cleans up ImageJob once completed. Restarts job after 2.5 seconds
+     * if it failed loading but max three times.
+     * @method
+     * @private
+     * @param loader - ImageLoader used to start job.
+     * @param job - The ImageJob that has completed.
+     * @param callback - Called once cleanup is finished.
+     */
+    function completeJob(loader, job, callback) {
+
+        if (job.errorMsg != '' && job.image === null && job.tries < 3) {
+            // Restart job with delay of 2500ms
+            setTimeout(function () {
+                job.start();
+            }, 2500);
+
+            return false;
         }
 
-        this.jobQueue = [];
+        var nextJob;
+
+        loader.jobsInProgress--;
+
+        if ((!loader.jobLimit || loader.jobsInProgress < loader.jobLimit) && loader.jobQueue.length > 0) {
+            nextJob = loader.jobQueue.shift();
+            nextJob.start();
+            loader.jobsInProgress++;
+        }
+
+        callback(job.image, job.errorMsg, job.request);
     }
-};
-
-/**
- * Cleans up ImageJob once completed.
- * @method
- * @private
- * @param loader - ImageLoader used to start job.
- * @param job - The ImageJob that has completed.
- * @param callback - Called once cleanup is finished.
- */
-function completeJob(loader, job, callback) {
-    var nextJob;
-
-    loader.jobsInProgress--;
-
-    if ((!loader.jobLimit || loader.jobsInProgress < loader.jobLimit) && loader.jobQueue.length > 0) {
-        nextJob = loader.jobQueue.shift();
-        nextJob.start();
-        loader.jobsInProgress++;
-    }
-
-    callback(job.image, job.errorMsg, job.request);
-}
 
 }(OpenSeadragon));

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -93,550 +93,550 @@
 
 // Typedefs
 
- /**
-  * All required and optional settings for instantiating a new instance of an OpenSeadragon image viewer.
-  *
-  * @typedef {Object} Options
-  * @memberof OpenSeadragon
-  *
-  * @property {String} id
-  *     Id of the element to append the viewer's container element to. If not provided, the 'element' property must be provided.
-  *     If both the element and id properties are specified, the viewer is appended to the element provided in the element property.
-  *
-  * @property {Element} element
-  *     The element to append the viewer's container element to. If not provided, the 'id' property must be provided.
-  *     If both the element and id properties are specified, the viewer is appended to the element provided in the element property.
-  *
-  * @property {Array|String|Function|Object} [tileSources=null]
-  *     Tile source(s) to open initially. This is a complex parameter; see
-  *     {@link OpenSeadragon.Viewer#open} for details.
-  *
-  * @property {Number} [tabIndex=0]
-  *     Tabbing order index to assign to the viewer element. Positive values are selected in increasing order. When tabIndex is 0
-  *     source order is used. A negative value omits the viewer from the tabbing order.
-  *
-  * @property {Array} overlays Array of objects defining permanent overlays of
-  *     the viewer. The overlays added via this option and later removed with
-  *     {@link OpenSeadragon.Viewer#removeOverlay} will be added back when a new
-  *     image is opened.
-  *     To add overlays which can be definitively removed, one must use
-  *     {@link OpenSeadragon.Viewer#addOverlay}
-  *     If displaying a sequence of images, the overlays can be associated
-  *     with a specific page by passing the overlays array to the page's
-  *     tile source configuration.
-  *     Expected properties:
-  *     * x, y, (or px, py for pixel coordinates) to define the location.
-  *     * width, height in point if using x,y or in pixels if using px,py. If width
-  *       and height are specified, the overlay size is adjusted when zooming,
-  *       otherwise the size stays the size of the content (or the size defined by CSS).
-  *     * className to associate a class to the overlay
-  *     * id to set the overlay element. If an element with this id already exists,
-  *       it is reused, otherwise it is created. If not specified, a new element is
-  *       created.
-  *     * placement a string to define the relative position to the viewport.
-  *       Only used if no width and height are specified. Default: 'TOP_LEFT'.
-  *       See {@link OpenSeadragon.Placement} for possible values.
-  *
-  * @property {String} [xmlPath=null]
-  *     <strong>DEPRECATED</strong>. A relative path to load a DZI file from the server.
-  *     Prefer the newer Options.tileSources.
-  *
-  * @property {String} [prefixUrl='/images/']
-  *     Prepends the prefixUrl to navImages paths, which is very useful
-  *     since the default paths are rarely useful for production
-  *     environments.
-  *
-  * @property {OpenSeadragon.NavImages} [navImages]
-  *     An object with a property for each button or other built-in navigation
-  *     control, eg the current 'zoomIn', 'zoomOut', 'home', and 'fullpage'.
-  *     Each of those in turn provides an image path for each state of the button
-  *     or navigation control, eg 'REST', 'GROUP', 'HOVER', 'PRESS'. Finally the
-  *     image paths, by default assume there is a folder on the servers root path
-  *     called '/images', eg '/images/zoomin_rest.png'.  If you need to adjust
-  *     these paths, prefer setting the option.prefixUrl rather than overriding
-  *     every image path directly through this setting.
-  *
-  * @property {Boolean} [debugMode=false]
-  *     TODO: provide an in-screen panel providing event detail feedback.
-  *
-  * @property {String} [debugGridColor=['#437AB2', '#1B9E77', '#D95F02', '#7570B3', '#E7298A', '#66A61E', '#E6AB02', '#A6761D', '#666666']]
-  *     The colors of grids in debug mode. Each tiled image's grid uses a consecutive color.
-  *     If there are more tiled images than provided colors, the color vector is recycled.
-  *
-  * @property {Number} [blendTime=0]
-  *     Specifies the duration of animation as higher or lower level tiles are
-  *     replacing the existing tile.
-  *
-  * @property {Boolean} [alwaysBlend=false]
-  *     Forces the tile to always blend.  By default the tiles skip blending
-  *     when the blendTime is surpassed and the current animation frame would
-  *     not complete the blend.
-  *
-  * @property {Boolean} [autoHideControls=true]
-  *     If the user stops interacting with the viewport, fade the navigation
-  *     controls.  Useful for presentation since the controls are by default
-  *     floated on top of the image the user is viewing.
-  *
-  * @property {Boolean} [immediateRender=false]
-  *     Render the best closest level first, ignoring the lowering levels which
-  *     provide the effect of very blurry to sharp. It is recommended to change
-  *     setting to true for mobile devices.
-  *
-  * @property {Number} [defaultZoomLevel=0]
-  *     Zoom level to use when image is first opened or the home button is clicked.
-  *     If 0, adjusts to fit viewer.
-  *
-  * @property {Number} [opacity=1]
-  *     Default proportional opacity of the tiled images (1=opaque, 0=hidden)
-  *     Hidden images do not draw and only load when preloading is allowed.
-  *
-  * @property {Boolean} [preload=false]
-  *     Default switch for loading hidden images (true loads, false blocks)
-  *
-  * @property {String} [compositeOperation=null]
-  *     Valid values are 'source-over', 'source-atop', 'source-in', 'source-out',
-  *     'destination-over', 'destination-atop', 'destination-in',
-  *     'destination-out', 'lighter', 'copy' or 'xor'
-  *
-  * @property {String|CanvasGradient|CanvasPattern|Function} [placeholderFillStyle=null]
-  *     Draws a colored rectangle behind the tile if it is not loaded yet.
-  *     You can pass a CSS color value like "#FF8800".
-  *     When passing a function the tiledImage and canvas context are available as argument which is useful when you draw a gradient or pattern.
-  *
-  * @property {Number} [degrees=0]
-  *     Initial rotation.
-  *
-  * @property {Number} [minZoomLevel=null]
-  *
-  * @property {Number} [maxZoomLevel=null]
-  *
-  * @property {Boolean} [homeFillsViewer=false]
-  *     Make the 'home' button fill the viewer and clip the image, instead
-  *     of fitting the image to the viewer and letterboxing.
-  *
-  * @property {Boolean} [panHorizontal=true]
-  *     Allow horizontal pan.
-  *
-  * @property {Boolean} [panVertical=true]
-  *     Allow vertical pan.
-  *
-  * @property {Boolean} [constrainDuringPan=false]
-  *
-  * @property {Boolean} [wrapHorizontal=false]
-  *     Set to true to force the image to wrap horizontally within the viewport.
-  *     Useful for maps or images representing the surface of a sphere or cylinder.
-  *
-  * @property {Boolean} [wrapVertical=false]
-  *     Set to true to force the image to wrap vertically within the viewport.
-  *     Useful for maps or images representing the surface of a sphere or cylinder.
-  *
-  * @property {Number} [minZoomImageRatio=0.9]
-  *     The minimum percentage ( expressed as a number between 0 and 1 ) of
-  *     the viewport height or width at which the zoom out will be constrained.
-  *     Setting it to 0, for example will allow you to zoom out infinity.
-  *
-  * @property {Number} [maxZoomPixelRatio=1.1]
-  *     The maximum ratio to allow a zoom-in to affect the highest level pixel
-  *     ratio. This can be set to Infinity to allow 'infinite' zooming into the
-  *     image though it is less effective visually if the HTML5 Canvas is not
-  *     availble on the viewing device.
-  *
-  * @property {Number} [smoothTileEdgesMinZoom=1.1]
-  *     A zoom percentage ( where 1 is 100% ) of the highest resolution level.
-  *     When zoomed in beyond this value alternative compositing will be used to
-  *     smooth out the edges between tiles. This will have a performance impact.
-  *     Can be set to Infinity to turn it off.
-  *     Note: This setting is ignored on iOS devices due to a known bug (See {@link https://github.com/openseadragon/openseadragon/issues/952})
-  *
-  * @property {Boolean} [iOSDevice=?]
-  *     True if running on an iOS device, false otherwise.
-  *     Used to disable certain features that behave differently on iOS devices.
-  *
-  * @property {Boolean} [autoResize=true]
-  *     Set to false to prevent polling for viewer size changes. Useful for providing custom resize behavior.
-  *
-  * @property {Boolean} [preserveImageSizeOnResize=false]
-  *     Set to true to have the image size preserved when the viewer is resized. This requires autoResize=true (default).
-  *
-  * @property {Number} [minScrollDeltaTime=50]
-  *     Number of milliseconds between canvas-scroll events. This value helps normalize the rate of canvas-scroll
-  *     events between different devices, causing the faster devices to slow down enough to make the zoom control
-  *     more manageable.
-  *
-  * @property {Number} [pixelsPerWheelLine=40]
-  *     For pixel-resolution scrolling devices, the number of pixels equal to one scroll line.
-  *
-  * @property {Number} [pixelsPerArrowPress=40]
-  *     The number of pixels viewport moves when an arrow key is pressed.
-  *
-  * @property {Number} [visibilityRatio=0.5]
-  *     The percentage ( as a number from 0 to 1 ) of the source image which
-  *     must be kept within the viewport.  If the image is dragged beyond that
-  *     limit, it will 'bounce' back until the minimum visibility ratio is
-  *     achieved.  Setting this to 0 and wrapHorizontal ( or wrapVertical ) to
-  *     true will provide the effect of an infinitely scrolling viewport.
-  *
-  * @property {Object} [viewportMargins={}]
-  *     Pushes the "home" region in from the sides by the specified amounts.
-  *     Possible subproperties (Numbers, in screen coordinates): left, top, right, bottom.
-  *
-  * @property {Number} [imageLoaderLimit=0]
-  *     The maximum number of image requests to make concurrently. By default
-  *     it is set to 0 allowing the browser to make the maximum number of
-  *     image requests in parallel as allowed by the browsers policy.
-  *
-  * @property {Number} [clickTimeThreshold=300]
-  *      The number of milliseconds within which a pointer down-up event combination
-  *      will be treated as a click gesture.
-  *
-  * @property {Number} [clickDistThreshold=5]
-  *      The maximum distance allowed between a pointer down event and a pointer up event
-  *      to be treated as a click gesture.
-  *
-  * @property {Number} [dblClickTimeThreshold=300]
-  *      The number of milliseconds within which two pointer down-up event combinations
-  *      will be treated as a double-click gesture.
-  *
-  * @property {Number} [dblClickDistThreshold=20]
-  *      The maximum distance allowed between two pointer click events
-  *      to be treated as a double-click gesture.
-  *
-  * @property {Number} [springStiffness=6.5]
-  *
-  * @property {Number} [animationTime=1.2]
-  *     Specifies the animation duration per each {@link OpenSeadragon.Spring}
-  *     which occur when the image is dragged or zoomed.
-  *
-  * @property {OpenSeadragon.GestureSettings} [gestureSettingsMouse]
-  *     Settings for gestures generated by a mouse pointer device. (See {@link OpenSeadragon.GestureSettings})
-  * @property {Boolean} [gestureSettingsMouse.scrollToZoom=true] - Zoom on scroll gesture
-  * @property {Boolean} [gestureSettingsMouse.clickToZoom=true] - Zoom on click gesture
-  * @property {Boolean} [gestureSettingsMouse.dblClickToZoom=false] - Zoom on double-click gesture. Note: If set to true
-  *     then clickToZoom should be set to false to prevent multiple zooms.
-  * @property {Boolean} [gestureSettingsMouse.pinchToZoom=false] - Zoom on pinch gesture
-  * @property {Boolean} [gestureSettingsMouse.flickEnabled=false] - Enable flick gesture
-  * @property {Number} [gestureSettingsMouse.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
-  * @property {Number} [gestureSettingsMouse.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
-  * @property {Boolean} [gestureSettingsMouse.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
-  *
-  * @property {OpenSeadragon.GestureSettings} [gestureSettingsTouch]
-  *     Settings for gestures generated by a touch pointer device. (See {@link OpenSeadragon.GestureSettings})
-  * @property {Boolean} [gestureSettingsTouch.scrollToZoom=false] - Zoom on scroll gesture
-  * @property {Boolean} [gestureSettingsTouch.clickToZoom=false] - Zoom on click gesture
-  * @property {Boolean} [gestureSettingsTouch.dblClickToZoom=true] - Zoom on double-click gesture. Note: If set to true
-  *     then clickToZoom should be set to false to prevent multiple zooms.
-  * @property {Boolean} [gestureSettingsTouch.pinchToZoom=true] - Zoom on pinch gesture
-  * @property {Boolean} [gestureSettingsTouch.flickEnabled=true] - Enable flick gesture
-  * @property {Number} [gestureSettingsTouch.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
-  * @property {Number} [gestureSettingsTouch.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
-  * @property {Boolean} [gestureSettingsTouch.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
-  *
-  * @property {OpenSeadragon.GestureSettings} [gestureSettingsPen]
-  *     Settings for gestures generated by a pen pointer device. (See {@link OpenSeadragon.GestureSettings})
-  * @property {Boolean} [gestureSettingsPen.scrollToZoom=false] - Zoom on scroll gesture
-  * @property {Boolean} [gestureSettingsPen.clickToZoom=true] - Zoom on click gesture
-  * @property {Boolean} [gestureSettingsPen.dblClickToZoom=false] - Zoom on double-click gesture. Note: If set to true
-  *     then clickToZoom should be set to false to prevent multiple zooms.
-  * @property {Boolean} [gestureSettingsPen.pinchToZoom=false] - Zoom on pinch gesture
-  * @property {Boolean} [gestureSettingsPen.flickEnabled=false] - Enable flick gesture
-  * @property {Number} [gestureSettingsPen.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
-  * @property {Number} [gestureSettingsPen.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
-  * @property {Boolean} [gestureSettingsPen.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
-  *
-  * @property {OpenSeadragon.GestureSettings} [gestureSettingsUnknown]
-  *     Settings for gestures generated by unknown pointer devices. (See {@link OpenSeadragon.GestureSettings})
-  * @property {Boolean} [gestureSettingsUnknown.scrollToZoom=true] - Zoom on scroll gesture
-  * @property {Boolean} [gestureSettingsUnknown.clickToZoom=false] - Zoom on click gesture
-  * @property {Boolean} [gestureSettingsUnknown.dblClickToZoom=true] - Zoom on double-click gesture. Note: If set to true
-  *     then clickToZoom should be set to false to prevent multiple zooms.
-  * @property {Boolean} [gestureSettingsUnknown.pinchToZoom=true] - Zoom on pinch gesture
-  * @property {Boolean} [gestureSettingsUnknown.flickEnabled=true] - Enable flick gesture
-  * @property {Number} [gestureSettingsUnknown.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
-  * @property {Number} [gestureSettingsUnknown.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
-  * @property {Boolean} [gestureSettingsUnknown.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
-  *
-  * @property {Number} [zoomPerClick=2.0]
-  *     The "zoom distance" per mouse click or touch tap. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the click-to-zoom feature (also see gestureSettings[Mouse|Touch|Pen].clickToZoom/dblClickToZoom).</em>
-  *
-  * @property {Number} [zoomPerScroll=1.2]
-  *     The "zoom distance" per mouse scroll or touch pinch. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the mouse-wheel zoom feature (also see gestureSettings[Mouse|Touch|Pen].scrollToZoom}).</em>
-  *
-  * @property {Number} [zoomPerSecond=1.0]
-  *     The number of seconds to animate a single zoom event over.
-  *
-  * @property {Boolean} [showNavigator=false]
-  *     Set to true to make the navigator minimap appear.
-  *
-  * @property {String} [navigatorId=navigator-GENERATED DATE]
-  *     The ID of a div to hold the navigator minimap.
-  *     If an ID is specified, the navigatorPosition, navigatorSizeRatio, navigatorMaintainSizeRatio, navigator[Top|Left|Height|Width] and navigatorAutoFade options will be ignored.
-  *     If an ID is not specified, a div element will be generated and placed on top of the main image.
-  *
-  * @property {String} [navigatorPosition='TOP_RIGHT']
-  *     Valid values are 'TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_LEFT', 'BOTTOM_RIGHT', or 'ABSOLUTE'.<br>
-  *     If 'ABSOLUTE' is specified, then navigator[Top|Left|Height|Width] determines the size and position of the navigator minimap in the viewer, and navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.<br>
-  *     For 'TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_LEFT', and 'BOTTOM_RIGHT', the navigatorSizeRatio or navigator[Height|Width] values determine the size of the navigator minimap.
-  *
-  * @property {Number} [navigatorSizeRatio=0.2]
-  *     Ratio of navigator size to viewer size. Ignored if navigator[Height|Width] are specified.
-  *
-  * @property {Boolean} [navigatorMaintainSizeRatio=false]
-  *     If true, the navigator minimap is resized (using navigatorSizeRatio) when the viewer size changes.
-  *
-  * @property {Number|String} [navigatorTop=null]
-  *     Specifies the location of the navigator minimap (see navigatorPosition).
-  *
-  * @property {Number|String} [navigatorLeft=null]
-  *     Specifies the location of the navigator minimap (see navigatorPosition).
-  *
-  * @property {Number|String} [navigatorHeight=null]
-  *     Specifies the size of the navigator minimap (see navigatorPosition).
-  *     If specified, navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.
-  *
-  * @property {Number|String} [navigatorWidth=null]
-  *     Specifies the size of the navigator minimap (see navigatorPosition).
-  *     If specified, navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.
-  *
-  * @property {Boolean} [navigatorAutoResize=true]
-  *     Set to false to prevent polling for navigator size changes. Useful for providing custom resize behavior.
-  *     Setting to false can also improve performance when the navigator is configured to a fixed size.
-  *
-  * @property {Boolean} [navigatorAutoFade=true]
-  *     If the user stops interacting with the viewport, fade the navigator minimap.
-  *     Setting to false will make the navigator minimap always visible.
-  *
-  * @property {Boolean} [navigatorRotate=true]
-  *     If true, the navigator will be rotated together with the viewer.
-  *
-  * @property {Number} [controlsFadeDelay=2000]
-  *     The number of milliseconds to wait once the user has stopped interacting
-  *     with the interface before begining to fade the controls. Assumes
-  *     showNavigationControl and autoHideControls are both true.
-  *
-  * @property {Number} [controlsFadeLength=1500]
-  *     The number of milliseconds to animate the controls fading out.
-  *
-  * @property {Number} [maxImageCacheCount=200]
-  *     The max number of images we should keep in memory (per drawer).
-  *
-  * @property {Number} [timeout=30000]
-  *     The max number of milliseconds that an image job may take to complete.
-  *
-  * @property {Boolean} [useCanvas=true]
-  *     Set to false to not use an HTML canvas element for image rendering even if canvas is supported.
-  *
-  * @property {Number} [minPixelRatio=0.5]
-  *     The higher the minPixelRatio, the lower the quality of the image that
-  *     is considered sufficient to stop rendering a given zoom level.  For
-  *     example, if you are targeting mobile devices with less bandwith you may
-  *     try setting this to 1.5 or higher.
-  *
-  * @property {Boolean} [mouseNavEnabled=true]
-  *     Is the user able to interact with the image via mouse or touch. Default
-  *     interactions include draging the image in a plane, and zooming in toward
-  *     and away from the image.
-  *
-  * @property {Boolean} [showNavigationControl=true]
-  *     Set to false to prevent the appearance of the default navigation controls.<br>
-  *     Note that if set to false, the customs buttons set by the options
-  *     zoomInButton, zoomOutButton etc, are rendered inactive.
-  *
-  * @property {OpenSeadragon.ControlAnchor} [navigationControlAnchor=TOP_LEFT]
-  *     Placement of the default navigation controls.
-  *     To set the placement of the sequence controls, see the
-  *     sequenceControlAnchor option.
-  *
-  * @property {Boolean} [showZoomControl=true]
-  *     If true then + and - buttons to zoom in and out are displayed.<br>
-  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
-  *     this setting when set to false.
-  *
-  * @property {Boolean} [showHomeControl=true]
-  *     If true then the 'Go home' button is displayed to go back to the original
-  *     zoom and pan.<br>
-  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
-  *     this setting when set to false.
-  *
-  * @property {Boolean} [showFullPageControl=true]
-  *     If true then the 'Toggle full page' button is displayed to switch
-  *     between full page and normal mode.<br>
-  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
-  *     this setting when set to false.
-  *
-  * @property {Boolean} [showRotationControl=false]
-  *     If true then the rotate left/right controls will be displayed as part of the
-  *     standard controls. This is also subject to the browser support for rotate
-  *     (e.g. viewer.drawer.canRotate()).<br>
-  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
-  *     this setting when set to false.
-  *
-  * @property {Boolean} [showSequenceControl=true]
-  *     If sequenceMode is true, then provide buttons for navigating forward and
-  *     backward through the images.
-  *
-  * @property {OpenSeadragon.ControlAnchor} [sequenceControlAnchor=TOP_LEFT]
-  *     Placement of the default sequence controls.
-  *
-  * @property {Boolean} [navPrevNextWrap=false]
-  *     If true then the 'previous' button will wrap to the last image when
-  *     viewing the first image and the 'next' button will wrap to the first
-  *     image when viewing the last image.
-  *
-  * @property {String} zoomInButton
-  *     Set the id of the custom 'Zoom in' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {String} zoomOutButton
-  *     Set the id of the custom 'Zoom out' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {String} homeButton
-  *     Set the id of the custom 'Go home' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {String} fullPageButton
-  *     Set the id of the custom 'Toggle full page' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {String} rotateLeftButton
-  *     Set the id of the custom 'Rotate left' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {String} rotateRightButton
-  *     Set the id of the custom 'Rotate right' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {String} previousButton
-  *     Set the id of the custom 'Previous page' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {String} nextButton
-  *     Set the id of the custom 'Next page' button to use.
-  *     This is useful to have a custom button anywhere in the web page.<br>
-  *     To only change the button images, consider using
-  *     {@link OpenSeadragon.Options.navImages}
-  *
-  * @property {Boolean} [sequenceMode=false]
-  *     Set to true to have the viewer treat your tilesources as a sequence of images to
-  *     be opened one at a time rather than all at once.
-  *
-  * @property {Number} [initialPage=0]
-  *     If sequenceMode is true, display this page initially.
-  *
-  * @property {Boolean} [preserveViewport=false]
-  *     If sequenceMode is true, then normally navigating through each image resets the
-  *     viewport to 'home' position.  If preserveViewport is set to true, then the viewport
-  *     position is preserved when navigating between images in the sequence.
-  *
-  * @property {Boolean} [preserveOverlays=false]
-  *     If sequenceMode is true, then normally navigating through each image
-  *     resets the overlays.
-  *     If preserveOverlays is set to true, then the overlays added with {@link OpenSeadragon.Viewer#addOverlay}
-  *     are preserved when navigating between images in the sequence.
-  *     Note: setting preserveOverlays overrides any overlays specified in the global
-  *     "overlays" option for the Viewer. It's also not compatible with specifying
-  *     per-tileSource overlays via the options, as those overlays will persist
-  *     even after the tileSource is closed.
-  *
-  * @property {Boolean} [showReferenceStrip=false]
-  *     If sequenceMode is true, then display a scrolling strip of image thumbnails for
-  *     navigating through the images.
-  *
-  * @property {String} [referenceStripScroll='horizontal']
-  *
-  * @property {Element} [referenceStripElement=null]
-  *
-  * @property {Number} [referenceStripHeight=null]
-  *
-  * @property {Number} [referenceStripWidth=null]
-  *
-  * @property {String} [referenceStripPosition='BOTTOM_LEFT']
-  *
-  * @property {Number} [referenceStripSizeRatio=0.2]
-  *
-  * @property {Boolean} [collectionMode=false]
-  *     Set to true to have the viewer arrange your TiledImages in a grid or line.
-  *
-  * @property {Number} [collectionRows=3]
-  *     If collectionMode is true, specifies how many rows the grid should have. Use 1 to make a line.
-  *     If collectionLayout is 'vertical', specifies how many columns instead.
-  *
-  * @property {Number} [collectionColumns=0]
-  *     If collectionMode is true, specifies how many columns the grid should have. Use 1 to make a line.
-  *     If collectionLayout is 'vertical', specifies how many rows instead. Ignored if collectionRows is not set to a falsy value.
-  *
-  * @property {String} [collectionLayout='horizontal']
-  *     If collectionMode is true, specifies whether to arrange vertically or horizontally.
-  *
-  * @property {Number} [collectionTileSize=800]
-  *     If collectionMode is true, specifies the size, in viewport coordinates, for each TiledImage to fit into.
-  *     The TiledImage will be centered within a square of the specified size.
-  *
-  * @property {Number} [collectionTileMargin=80]
-  *     If collectionMode is true, specifies the margin, in viewport coordinates, between each TiledImage.
-  *
-  * @property {String|Boolean} [crossOriginPolicy=false]
-  *     Valid values are 'Anonymous', 'use-credentials', and false. If false, canvas requests will
-  *     not use CORS, and the canvas will be tainted.
-  *
-  * @property {Boolean} [ajaxWithCredentials=false]
-  *     Whether to set the withCredentials XHR flag for AJAX requests.
-  *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
-  *
-  * @property {Boolean} [loadTilesWithAjax=false]
-  *     Whether to load tile data using AJAX requests.
-  *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
-  *
-  * @property {Object} [ajaxHeaders={}]
-  *     A set of headers to include when making AJAX requests for tile sources or tiles.
-  *
-  */
+/**
+ * All required and optional settings for instantiating a new instance of an OpenSeadragon image viewer.
+ *
+ * @typedef {Object} Options
+ * @memberof OpenSeadragon
+ *
+ * @property {String} id
+ *     Id of the element to append the viewer's container element to. If not provided, the 'element' property must be provided.
+ *     If both the element and id properties are specified, the viewer is appended to the element provided in the element property.
+ *
+ * @property {Element} element
+ *     The element to append the viewer's container element to. If not provided, the 'id' property must be provided.
+ *     If both the element and id properties are specified, the viewer is appended to the element provided in the element property.
+ *
+ * @property {Array|String|Function|Object} [tileSources=null]
+ *     Tile source(s) to open initially. This is a complex parameter; see
+ *     {@link OpenSeadragon.Viewer#open} for details.
+ *
+ * @property {Number} [tabIndex=0]
+ *     Tabbing order index to assign to the viewer element. Positive values are selected in increasing order. When tabIndex is 0
+ *     source order is used. A negative value omits the viewer from the tabbing order.
+ *
+ * @property {Array} overlays Array of objects defining permanent overlays of
+ *     the viewer. The overlays added via this option and later removed with
+ *     {@link OpenSeadragon.Viewer#removeOverlay} will be added back when a new
+ *     image is opened.
+ *     To add overlays which can be definitively removed, one must use
+ *     {@link OpenSeadragon.Viewer#addOverlay}
+ *     If displaying a sequence of images, the overlays can be associated
+ *     with a specific page by passing the overlays array to the page's
+ *     tile source configuration.
+ *     Expected properties:
+ *     * x, y, (or px, py for pixel coordinates) to define the location.
+ *     * width, height in point if using x,y or in pixels if using px,py. If width
+ *       and height are specified, the overlay size is adjusted when zooming,
+ *       otherwise the size stays the size of the content (or the size defined by CSS).
+ *     * className to associate a class to the overlay
+ *     * id to set the overlay element. If an element with this id already exists,
+ *       it is reused, otherwise it is created. If not specified, a new element is
+ *       created.
+ *     * placement a string to define the relative position to the viewport.
+ *       Only used if no width and height are specified. Default: 'TOP_LEFT'.
+ *       See {@link OpenSeadragon.Placement} for possible values.
+ *
+ * @property {String} [xmlPath=null]
+ *     <strong>DEPRECATED</strong>. A relative path to load a DZI file from the server.
+ *     Prefer the newer Options.tileSources.
+ *
+ * @property {String} [prefixUrl='/images/']
+ *     Prepends the prefixUrl to navImages paths, which is very useful
+ *     since the default paths are rarely useful for production
+ *     environments.
+ *
+ * @property {OpenSeadragon.NavImages} [navImages]
+ *     An object with a property for each button or other built-in navigation
+ *     control, eg the current 'zoomIn', 'zoomOut', 'home', and 'fullpage'.
+ *     Each of those in turn provides an image path for each state of the button
+ *     or navigation control, eg 'REST', 'GROUP', 'HOVER', 'PRESS'. Finally the
+ *     image paths, by default assume there is a folder on the servers root path
+ *     called '/images', eg '/images/zoomin_rest.png'.  If you need to adjust
+ *     these paths, prefer setting the option.prefixUrl rather than overriding
+ *     every image path directly through this setting.
+ *
+ * @property {Boolean} [debugMode=false]
+ *     TODO: provide an in-screen panel providing event detail feedback.
+ *
+ * @property {String} [debugGridColor=['#437AB2', '#1B9E77', '#D95F02', '#7570B3', '#E7298A', '#66A61E', '#E6AB02', '#A6761D', '#666666']]
+ *     The colors of grids in debug mode. Each tiled image's grid uses a consecutive color.
+ *     If there are more tiled images than provided colors, the color vector is recycled.
+ *
+ * @property {Number} [blendTime=0]
+ *     Specifies the duration of animation as higher or lower level tiles are
+ *     replacing the existing tile.
+ *
+ * @property {Boolean} [alwaysBlend=false]
+ *     Forces the tile to always blend.  By default the tiles skip blending
+ *     when the blendTime is surpassed and the current animation frame would
+ *     not complete the blend.
+ *
+ * @property {Boolean} [autoHideControls=true]
+ *     If the user stops interacting with the viewport, fade the navigation
+ *     controls.  Useful for presentation since the controls are by default
+ *     floated on top of the image the user is viewing.
+ *
+ * @property {Boolean} [immediateRender=false]
+ *     Render the best closest level first, ignoring the lowering levels which
+ *     provide the effect of very blurry to sharp. It is recommended to change
+ *     setting to true for mobile devices.
+ *
+ * @property {Number} [defaultZoomLevel=0]
+ *     Zoom level to use when image is first opened or the home button is clicked.
+ *     If 0, adjusts to fit viewer.
+ *
+ * @property {Number} [opacity=1]
+ *     Default proportional opacity of the tiled images (1=opaque, 0=hidden)
+ *     Hidden images do not draw and only load when preloading is allowed.
+ *
+ * @property {Boolean} [preload=false]
+ *     Default switch for loading hidden images (true loads, false blocks)
+ *
+ * @property {String} [compositeOperation=null]
+ *     Valid values are 'source-over', 'source-atop', 'source-in', 'source-out',
+ *     'destination-over', 'destination-atop', 'destination-in',
+ *     'destination-out', 'lighter', 'copy' or 'xor'
+ *
+ * @property {String|CanvasGradient|CanvasPattern|Function} [placeholderFillStyle=null]
+ *     Draws a colored rectangle behind the tile if it is not loaded yet.
+ *     You can pass a CSS color value like "#FF8800".
+ *     When passing a function the tiledImage and canvas context are available as argument which is useful when you draw a gradient or pattern.
+ *
+ * @property {Number} [degrees=0]
+ *     Initial rotation.
+ *
+ * @property {Number} [minZoomLevel=null]
+ *
+ * @property {Number} [maxZoomLevel=null]
+ *
+ * @property {Boolean} [homeFillsViewer=false]
+ *     Make the 'home' button fill the viewer and clip the image, instead
+ *     of fitting the image to the viewer and letterboxing.
+ *
+ * @property {Boolean} [panHorizontal=true]
+ *     Allow horizontal pan.
+ *
+ * @property {Boolean} [panVertical=true]
+ *     Allow vertical pan.
+ *
+ * @property {Boolean} [constrainDuringPan=false]
+ *
+ * @property {Boolean} [wrapHorizontal=false]
+ *     Set to true to force the image to wrap horizontally within the viewport.
+ *     Useful for maps or images representing the surface of a sphere or cylinder.
+ *
+ * @property {Boolean} [wrapVertical=false]
+ *     Set to true to force the image to wrap vertically within the viewport.
+ *     Useful for maps or images representing the surface of a sphere or cylinder.
+ *
+ * @property {Number} [minZoomImageRatio=0.9]
+ *     The minimum percentage ( expressed as a number between 0 and 1 ) of
+ *     the viewport height or width at which the zoom out will be constrained.
+ *     Setting it to 0, for example will allow you to zoom out infinity.
+ *
+ * @property {Number} [maxZoomPixelRatio=1.1]
+ *     The maximum ratio to allow a zoom-in to affect the highest level pixel
+ *     ratio. This can be set to Infinity to allow 'infinite' zooming into the
+ *     image though it is less effective visually if the HTML5 Canvas is not
+ *     availble on the viewing device.
+ *
+ * @property {Number} [smoothTileEdgesMinZoom=1.1]
+ *     A zoom percentage ( where 1 is 100% ) of the highest resolution level.
+ *     When zoomed in beyond this value alternative compositing will be used to
+ *     smooth out the edges between tiles. This will have a performance impact.
+ *     Can be set to Infinity to turn it off.
+ *     Note: This setting is ignored on iOS devices due to a known bug (See {@link https://github.com/openseadragon/openseadragon/issues/952})
+ *
+ * @property {Boolean} [iOSDevice=?]
+ *     True if running on an iOS device, false otherwise.
+ *     Used to disable certain features that behave differently on iOS devices.
+ *
+ * @property {Boolean} [autoResize=true]
+ *     Set to false to prevent polling for viewer size changes. Useful for providing custom resize behavior.
+ *
+ * @property {Boolean} [preserveImageSizeOnResize=false]
+ *     Set to true to have the image size preserved when the viewer is resized. This requires autoResize=true (default).
+ *
+ * @property {Number} [minScrollDeltaTime=50]
+ *     Number of milliseconds between canvas-scroll events. This value helps normalize the rate of canvas-scroll
+ *     events between different devices, causing the faster devices to slow down enough to make the zoom control
+ *     more manageable.
+ *
+ * @property {Number} [pixelsPerWheelLine=40]
+ *     For pixel-resolution scrolling devices, the number of pixels equal to one scroll line.
+ *
+ * @property {Number} [pixelsPerArrowPress=40]
+ *     The number of pixels viewport moves when an arrow key is pressed.
+ *
+ * @property {Number} [visibilityRatio=0.5]
+ *     The percentage ( as a number from 0 to 1 ) of the source image which
+ *     must be kept within the viewport.  If the image is dragged beyond that
+ *     limit, it will 'bounce' back until the minimum visibility ratio is
+ *     achieved.  Setting this to 0 and wrapHorizontal ( or wrapVertical ) to
+ *     true will provide the effect of an infinitely scrolling viewport.
+ *
+ * @property {Object} [viewportMargins={}]
+ *     Pushes the "home" region in from the sides by the specified amounts.
+ *     Possible subproperties (Numbers, in screen coordinates): left, top, right, bottom.
+ *
+ * @property {Number} [imageLoaderLimit=0]
+ *     The maximum number of image requests to make concurrently. By default
+ *     it is set to 0 allowing the browser to make the maximum number of
+ *     image requests in parallel as allowed by the browsers policy.
+ *
+ * @property {Number} [clickTimeThreshold=300]
+ *      The number of milliseconds within which a pointer down-up event combination
+ *      will be treated as a click gesture.
+ *
+ * @property {Number} [clickDistThreshold=5]
+ *      The maximum distance allowed between a pointer down event and a pointer up event
+ *      to be treated as a click gesture.
+ *
+ * @property {Number} [dblClickTimeThreshold=300]
+ *      The number of milliseconds within which two pointer down-up event combinations
+ *      will be treated as a double-click gesture.
+ *
+ * @property {Number} [dblClickDistThreshold=20]
+ *      The maximum distance allowed between two pointer click events
+ *      to be treated as a double-click gesture.
+ *
+ * @property {Number} [springStiffness=6.5]
+ *
+ * @property {Number} [animationTime=1.2]
+ *     Specifies the animation duration per each {@link OpenSeadragon.Spring}
+ *     which occur when the image is dragged or zoomed.
+ *
+ * @property {OpenSeadragon.GestureSettings} [gestureSettingsMouse]
+ *     Settings for gestures generated by a mouse pointer device. (See {@link OpenSeadragon.GestureSettings})
+ * @property {Boolean} [gestureSettingsMouse.scrollToZoom=true] - Zoom on scroll gesture
+ * @property {Boolean} [gestureSettingsMouse.clickToZoom=true] - Zoom on click gesture
+ * @property {Boolean} [gestureSettingsMouse.dblClickToZoom=false] - Zoom on double-click gesture. Note: If set to true
+ *     then clickToZoom should be set to false to prevent multiple zooms.
+ * @property {Boolean} [gestureSettingsMouse.pinchToZoom=false] - Zoom on pinch gesture
+ * @property {Boolean} [gestureSettingsMouse.flickEnabled=false] - Enable flick gesture
+ * @property {Number} [gestureSettingsMouse.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+ * @property {Number} [gestureSettingsMouse.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+ * @property {Boolean} [gestureSettingsMouse.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+ *
+ * @property {OpenSeadragon.GestureSettings} [gestureSettingsTouch]
+ *     Settings for gestures generated by a touch pointer device. (See {@link OpenSeadragon.GestureSettings})
+ * @property {Boolean} [gestureSettingsTouch.scrollToZoom=false] - Zoom on scroll gesture
+ * @property {Boolean} [gestureSettingsTouch.clickToZoom=false] - Zoom on click gesture
+ * @property {Boolean} [gestureSettingsTouch.dblClickToZoom=true] - Zoom on double-click gesture. Note: If set to true
+ *     then clickToZoom should be set to false to prevent multiple zooms.
+ * @property {Boolean} [gestureSettingsTouch.pinchToZoom=true] - Zoom on pinch gesture
+ * @property {Boolean} [gestureSettingsTouch.flickEnabled=true] - Enable flick gesture
+ * @property {Number} [gestureSettingsTouch.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+ * @property {Number} [gestureSettingsTouch.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+ * @property {Boolean} [gestureSettingsTouch.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+ *
+ * @property {OpenSeadragon.GestureSettings} [gestureSettingsPen]
+ *     Settings for gestures generated by a pen pointer device. (See {@link OpenSeadragon.GestureSettings})
+ * @property {Boolean} [gestureSettingsPen.scrollToZoom=false] - Zoom on scroll gesture
+ * @property {Boolean} [gestureSettingsPen.clickToZoom=true] - Zoom on click gesture
+ * @property {Boolean} [gestureSettingsPen.dblClickToZoom=false] - Zoom on double-click gesture. Note: If set to true
+ *     then clickToZoom should be set to false to prevent multiple zooms.
+ * @property {Boolean} [gestureSettingsPen.pinchToZoom=false] - Zoom on pinch gesture
+ * @property {Boolean} [gestureSettingsPen.flickEnabled=false] - Enable flick gesture
+ * @property {Number} [gestureSettingsPen.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+ * @property {Number} [gestureSettingsPen.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+ * @property {Boolean} [gestureSettingsPen.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+ *
+ * @property {OpenSeadragon.GestureSettings} [gestureSettingsUnknown]
+ *     Settings for gestures generated by unknown pointer devices. (See {@link OpenSeadragon.GestureSettings})
+ * @property {Boolean} [gestureSettingsUnknown.scrollToZoom=true] - Zoom on scroll gesture
+ * @property {Boolean} [gestureSettingsUnknown.clickToZoom=false] - Zoom on click gesture
+ * @property {Boolean} [gestureSettingsUnknown.dblClickToZoom=true] - Zoom on double-click gesture. Note: If set to true
+ *     then clickToZoom should be set to false to prevent multiple zooms.
+ * @property {Boolean} [gestureSettingsUnknown.pinchToZoom=true] - Zoom on pinch gesture
+ * @property {Boolean} [gestureSettingsUnknown.flickEnabled=true] - Enable flick gesture
+ * @property {Number} [gestureSettingsUnknown.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+ * @property {Number} [gestureSettingsUnknown.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+ * @property {Boolean} [gestureSettingsUnknown.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+ *
+ * @property {Number} [zoomPerClick=2.0]
+ *     The "zoom distance" per mouse click or touch tap. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the click-to-zoom feature (also see gestureSettings[Mouse|Touch|Pen].clickToZoom/dblClickToZoom).</em>
+ *
+ * @property {Number} [zoomPerScroll=1.2]
+ *     The "zoom distance" per mouse scroll or touch pinch. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the mouse-wheel zoom feature (also see gestureSettings[Mouse|Touch|Pen].scrollToZoom}).</em>
+ *
+ * @property {Number} [zoomPerSecond=1.0]
+ *     The number of seconds to animate a single zoom event over.
+ *
+ * @property {Boolean} [showNavigator=false]
+ *     Set to true to make the navigator minimap appear.
+ *
+ * @property {String} [navigatorId=navigator-GENERATED DATE]
+ *     The ID of a div to hold the navigator minimap.
+ *     If an ID is specified, the navigatorPosition, navigatorSizeRatio, navigatorMaintainSizeRatio, navigator[Top|Left|Height|Width] and navigatorAutoFade options will be ignored.
+ *     If an ID is not specified, a div element will be generated and placed on top of the main image.
+ *
+ * @property {String} [navigatorPosition='TOP_RIGHT']
+ *     Valid values are 'TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_LEFT', 'BOTTOM_RIGHT', or 'ABSOLUTE'.<br>
+ *     If 'ABSOLUTE' is specified, then navigator[Top|Left|Height|Width] determines the size and position of the navigator minimap in the viewer, and navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.<br>
+ *     For 'TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_LEFT', and 'BOTTOM_RIGHT', the navigatorSizeRatio or navigator[Height|Width] values determine the size of the navigator minimap.
+ *
+ * @property {Number} [navigatorSizeRatio=0.2]
+ *     Ratio of navigator size to viewer size. Ignored if navigator[Height|Width] are specified.
+ *
+ * @property {Boolean} [navigatorMaintainSizeRatio=false]
+ *     If true, the navigator minimap is resized (using navigatorSizeRatio) when the viewer size changes.
+ *
+ * @property {Number|String} [navigatorTop=null]
+ *     Specifies the location of the navigator minimap (see navigatorPosition).
+ *
+ * @property {Number|String} [navigatorLeft=null]
+ *     Specifies the location of the navigator minimap (see navigatorPosition).
+ *
+ * @property {Number|String} [navigatorHeight=null]
+ *     Specifies the size of the navigator minimap (see navigatorPosition).
+ *     If specified, navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.
+ *
+ * @property {Number|String} [navigatorWidth=null]
+ *     Specifies the size of the navigator minimap (see navigatorPosition).
+ *     If specified, navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.
+ *
+ * @property {Boolean} [navigatorAutoResize=true]
+ *     Set to false to prevent polling for navigator size changes. Useful for providing custom resize behavior.
+ *     Setting to false can also improve performance when the navigator is configured to a fixed size.
+ *
+ * @property {Boolean} [navigatorAutoFade=true]
+ *     If the user stops interacting with the viewport, fade the navigator minimap.
+ *     Setting to false will make the navigator minimap always visible.
+ *
+ * @property {Boolean} [navigatorRotate=true]
+ *     If true, the navigator will be rotated together with the viewer.
+ *
+ * @property {Number} [controlsFadeDelay=2000]
+ *     The number of milliseconds to wait once the user has stopped interacting
+ *     with the interface before begining to fade the controls. Assumes
+ *     showNavigationControl and autoHideControls are both true.
+ *
+ * @property {Number} [controlsFadeLength=1500]
+ *     The number of milliseconds to animate the controls fading out.
+ *
+ * @property {Number} [maxImageCacheCount=200]
+ *     The max number of images we should keep in memory (per drawer).
+ *
+ * @property {Number} [timeout=30000]
+ *     The max number of milliseconds that an image job may take to complete.
+ *
+ * @property {Boolean} [useCanvas=true]
+ *     Set to false to not use an HTML canvas element for image rendering even if canvas is supported.
+ *
+ * @property {Number} [minPixelRatio=0.5]
+ *     The higher the minPixelRatio, the lower the quality of the image that
+ *     is considered sufficient to stop rendering a given zoom level.  For
+ *     example, if you are targeting mobile devices with less bandwith you may
+ *     try setting this to 1.5 or higher.
+ *
+ * @property {Boolean} [mouseNavEnabled=true]
+ *     Is the user able to interact with the image via mouse or touch. Default
+ *     interactions include draging the image in a plane, and zooming in toward
+ *     and away from the image.
+ *
+ * @property {Boolean} [showNavigationControl=true]
+ *     Set to false to prevent the appearance of the default navigation controls.<br>
+ *     Note that if set to false, the customs buttons set by the options
+ *     zoomInButton, zoomOutButton etc, are rendered inactive.
+ *
+ * @property {OpenSeadragon.ControlAnchor} [navigationControlAnchor=TOP_LEFT]
+ *     Placement of the default navigation controls.
+ *     To set the placement of the sequence controls, see the
+ *     sequenceControlAnchor option.
+ *
+ * @property {Boolean} [showZoomControl=true]
+ *     If true then + and - buttons to zoom in and out are displayed.<br>
+ *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+ *     this setting when set to false.
+ *
+ * @property {Boolean} [showHomeControl=true]
+ *     If true then the 'Go home' button is displayed to go back to the original
+ *     zoom and pan.<br>
+ *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+ *     this setting when set to false.
+ *
+ * @property {Boolean} [showFullPageControl=true]
+ *     If true then the 'Toggle full page' button is displayed to switch
+ *     between full page and normal mode.<br>
+ *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+ *     this setting when set to false.
+ *
+ * @property {Boolean} [showRotationControl=false]
+ *     If true then the rotate left/right controls will be displayed as part of the
+ *     standard controls. This is also subject to the browser support for rotate
+ *     (e.g. viewer.drawer.canRotate()).<br>
+ *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+ *     this setting when set to false.
+ *
+ * @property {Boolean} [showSequenceControl=true]
+ *     If sequenceMode is true, then provide buttons for navigating forward and
+ *     backward through the images.
+ *
+ * @property {OpenSeadragon.ControlAnchor} [sequenceControlAnchor=TOP_LEFT]
+ *     Placement of the default sequence controls.
+ *
+ * @property {Boolean} [navPrevNextWrap=false]
+ *     If true then the 'previous' button will wrap to the last image when
+ *     viewing the first image and the 'next' button will wrap to the first
+ *     image when viewing the last image.
+ *
+ * @property {String} zoomInButton
+ *     Set the id of the custom 'Zoom in' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {String} zoomOutButton
+ *     Set the id of the custom 'Zoom out' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {String} homeButton
+ *     Set the id of the custom 'Go home' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {String} fullPageButton
+ *     Set the id of the custom 'Toggle full page' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {String} rotateLeftButton
+ *     Set the id of the custom 'Rotate left' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {String} rotateRightButton
+ *     Set the id of the custom 'Rotate right' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {String} previousButton
+ *     Set the id of the custom 'Previous page' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {String} nextButton
+ *     Set the id of the custom 'Next page' button to use.
+ *     This is useful to have a custom button anywhere in the web page.<br>
+ *     To only change the button images, consider using
+ *     {@link OpenSeadragon.Options.navImages}
+ *
+ * @property {Boolean} [sequenceMode=false]
+ *     Set to true to have the viewer treat your tilesources as a sequence of images to
+ *     be opened one at a time rather than all at once.
+ *
+ * @property {Number} [initialPage=0]
+ *     If sequenceMode is true, display this page initially.
+ *
+ * @property {Boolean} [preserveViewport=false]
+ *     If sequenceMode is true, then normally navigating through each image resets the
+ *     viewport to 'home' position.  If preserveViewport is set to true, then the viewport
+ *     position is preserved when navigating between images in the sequence.
+ *
+ * @property {Boolean} [preserveOverlays=false]
+ *     If sequenceMode is true, then normally navigating through each image
+ *     resets the overlays.
+ *     If preserveOverlays is set to true, then the overlays added with {@link OpenSeadragon.Viewer#addOverlay}
+ *     are preserved when navigating between images in the sequence.
+ *     Note: setting preserveOverlays overrides any overlays specified in the global
+ *     "overlays" option for the Viewer. It's also not compatible with specifying
+ *     per-tileSource overlays via the options, as those overlays will persist
+ *     even after the tileSource is closed.
+ *
+ * @property {Boolean} [showReferenceStrip=false]
+ *     If sequenceMode is true, then display a scrolling strip of image thumbnails for
+ *     navigating through the images.
+ *
+ * @property {String} [referenceStripScroll='horizontal']
+ *
+ * @property {Element} [referenceStripElement=null]
+ *
+ * @property {Number} [referenceStripHeight=null]
+ *
+ * @property {Number} [referenceStripWidth=null]
+ *
+ * @property {String} [referenceStripPosition='BOTTOM_LEFT']
+ *
+ * @property {Number} [referenceStripSizeRatio=0.2]
+ *
+ * @property {Boolean} [collectionMode=false]
+ *     Set to true to have the viewer arrange your TiledImages in a grid or line.
+ *
+ * @property {Number} [collectionRows=3]
+ *     If collectionMode is true, specifies how many rows the grid should have. Use 1 to make a line.
+ *     If collectionLayout is 'vertical', specifies how many columns instead.
+ *
+ * @property {Number} [collectionColumns=0]
+ *     If collectionMode is true, specifies how many columns the grid should have. Use 1 to make a line.
+ *     If collectionLayout is 'vertical', specifies how many rows instead. Ignored if collectionRows is not set to a falsy value.
+ *
+ * @property {String} [collectionLayout='horizontal']
+ *     If collectionMode is true, specifies whether to arrange vertically or horizontally.
+ *
+ * @property {Number} [collectionTileSize=800]
+ *     If collectionMode is true, specifies the size, in viewport coordinates, for each TiledImage to fit into.
+ *     The TiledImage will be centered within a square of the specified size.
+ *
+ * @property {Number} [collectionTileMargin=80]
+ *     If collectionMode is true, specifies the margin, in viewport coordinates, between each TiledImage.
+ *
+ * @property {String|Boolean} [crossOriginPolicy=false]
+ *     Valid values are 'Anonymous', 'use-credentials', and false. If false, canvas requests will
+ *     not use CORS, and the canvas will be tainted.
+ *
+ * @property {Boolean} [ajaxWithCredentials=false]
+ *     Whether to set the withCredentials XHR flag for AJAX requests.
+ *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
+ *
+ * @property {Boolean} [loadTilesWithAjax=false]
+ *     Whether to load tile data using AJAX requests.
+ *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
+ *
+ * @property {Object} [ajaxHeaders={}]
+ *     A set of headers to include when making AJAX requests for tile sources or tiles.
+ *
+ */
 
- /**
-  * Settings for gestures generated by a pointer device.
-  *
-  * @typedef {Object} GestureSettings
-  * @memberof OpenSeadragon
-  *
-  * @property {Boolean} scrollToZoom
-  *     Set to false to disable zooming on scroll gestures.
-  *
-  * @property {Boolean} clickToZoom
-  *     Set to false to disable zooming on click gestures.
-  *
-  * @property {Boolean} dblClickToZoom
-  *     Set to false to disable zooming on double-click gestures. Note: If set to true
-  *     then clickToZoom should be set to false to prevent multiple zooms.
-  *
-  * @property {Boolean} pinchToZoom
-  *     Set to false to disable zooming on pinch gestures.
-  *
-  * @property {Boolean} flickEnabled
-  *     Set to false to disable the kinetic panning effect (flick) at the end of a drag gesture.
-  *
-  * @property {Number} flickMinSpeed
-  *     If flickEnabled is true, the minimum speed (in pixels-per-second) required to cause the kinetic panning effect (flick) at the end of a drag gesture.
-  *
-  * @property {Number} flickMomentum
-  *     If flickEnabled is true, a constant multiplied by the velocity to determine the distance of the kinetic panning effect (flick) at the end of a drag gesture.
-  *     A larger value will make the flick feel "lighter", while a smaller value will make the flick feel "heavier".
-  *     Note: springStiffness and animationTime also affect the "spring" used to stop the flick animation.
-  *
-  */
+/**
+ * Settings for gestures generated by a pointer device.
+ *
+ * @typedef {Object} GestureSettings
+ * @memberof OpenSeadragon
+ *
+ * @property {Boolean} scrollToZoom
+ *     Set to false to disable zooming on scroll gestures.
+ *
+ * @property {Boolean} clickToZoom
+ *     Set to false to disable zooming on click gestures.
+ *
+ * @property {Boolean} dblClickToZoom
+ *     Set to false to disable zooming on double-click gestures. Note: If set to true
+ *     then clickToZoom should be set to false to prevent multiple zooms.
+ *
+ * @property {Boolean} pinchToZoom
+ *     Set to false to disable zooming on pinch gestures.
+ *
+ * @property {Boolean} flickEnabled
+ *     Set to false to disable the kinetic panning effect (flick) at the end of a drag gesture.
+ *
+ * @property {Number} flickMinSpeed
+ *     If flickEnabled is true, the minimum speed (in pixels-per-second) required to cause the kinetic panning effect (flick) at the end of a drag gesture.
+ *
+ * @property {Number} flickMomentum
+ *     If flickEnabled is true, a constant multiplied by the velocity to determine the distance of the kinetic panning effect (flick) at the end of a drag gesture.
+ *     A larger value will make the flick feel "lighter", while a smaller value will make the flick feel "heavier".
+ *     Note: springStiffness and animationTime also affect the "spring" used to stop the flick animation.
+ *
+ */
 
 /**
   * The names for the image resources used for the image navigation buttons.
@@ -695,11 +695,11 @@
   */
 
 
-function OpenSeadragon( options ){
-    return new OpenSeadragon.Viewer( options );
+function OpenSeadragon(options) {
+    return new OpenSeadragon.Viewer(options);
 }
 
-(function( $ ){
+(function ($) {
 
 
     /**
@@ -726,18 +726,18 @@ function OpenSeadragon( options ){
      * @private
      */
     var class2type = {
-            '[object Boolean]':     'boolean',
-            '[object Number]':      'number',
-            '[object String]':      'string',
-            '[object Function]':    'function',
-            '[object Array]':       'array',
-            '[object Date]':        'date',
-            '[object RegExp]':      'regexp',
-            '[object Object]':      'object'
-        },
+        '[object Boolean]': 'boolean',
+        '[object Number]': 'number',
+        '[object String]': 'string',
+        '[object Function]': 'function',
+        '[object Array]': 'array',
+        '[object Date]': 'date',
+        '[object RegExp]': 'regexp',
+        '[object Object]': 'object'
+    },
         // Save a reference to some core methods
-        toString    = Object.prototype.toString,
-        hasOwn      = Object.prototype.hasOwnProperty;
+        toString = Object.prototype.toString,
+        hasOwn = Object.prototype.hasOwnProperty;
 
     /**
      * Taken from jQuery 1.6.1
@@ -745,7 +745,7 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      * @see {@link http://www.jquery.com/ jQuery}
      */
-    $.isFunction = function( obj ) {
+    $.isFunction = function (obj) {
         return $.type(obj) === "function";
     };
 
@@ -756,7 +756,7 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      * @see {@link http://www.jquery.com/ jQuery}
      */
-    $.isArray = Array.isArray || function( obj ) {
+    $.isArray = Array.isArray || function (obj) {
         return $.type(obj) === "array";
     };
 
@@ -768,7 +768,7 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      * @see {@link http://www.jquery.com/ jQuery}
      */
-    $.isWindow = function( obj ) {
+    $.isWindow = function (obj) {
         return obj && typeof obj === "object" && "setInterval" in obj;
     };
 
@@ -779,10 +779,10 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      * @see {@link http://www.jquery.com/ jQuery}
      */
-    $.type = function( obj ) {
-        return ( obj === null ) || ( obj === undefined ) ?
-            String( obj ) :
-            class2type[ toString.call(obj) ] || "object";
+    $.type = function (obj) {
+        return (obj === null) || (obj === undefined) ?
+            String(obj) :
+            class2type[toString.call(obj)] || "object";
     };
 
 
@@ -792,18 +792,18 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      * @see {@link http://www.jquery.com/ jQuery}
      */
-    $.isPlainObject = function( obj ) {
+    $.isPlainObject = function (obj) {
         // Must be an Object.
         // Because of IE, we also have to check the presence of the constructor property.
         // Make sure that DOM nodes and window objects don't pass through, as well
-        if ( !obj || OpenSeadragon.type(obj) !== "object" || obj.nodeType || $.isWindow( obj ) ) {
+        if (!obj || OpenSeadragon.type(obj) !== "object" || obj.nodeType || $.isWindow(obj)) {
             return false;
         }
 
         // Not own constructor property must be Object
-        if ( obj.constructor &&
+        if (obj.constructor &&
             !hasOwn.call(obj, "constructor") &&
-            !hasOwn.call(obj.constructor.prototype, "isPrototypeOf") ) {
+            !hasOwn.call(obj.constructor.prototype, "isPrototypeOf")) {
             return false;
         }
 
@@ -811,11 +811,11 @@ function OpenSeadragon( options ){
         // if last one is own, then all properties are own.
 
         var lastKey;
-        for (var key in obj ) {
+        for (var key in obj) {
             lastKey = key;
         }
 
-        return lastKey === undefined || hasOwn.call( obj, lastKey );
+        return lastKey === undefined || hasOwn.call(obj, lastKey);
     };
 
 
@@ -825,8 +825,8 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      * @see {@link http://www.jquery.com/ jQuery}
      */
-    $.isEmptyObject = function( obj ) {
-        for ( var name in obj ) {
+    $.isEmptyObject = function (obj) {
+        for (var name in obj) {
             return false;
         }
         return true;
@@ -837,11 +837,11 @@ function OpenSeadragon( options ){
      * @param {Object} obj The object to freeze.
      * @return {Object} obj The frozen object.
      */
-    $.freezeObject = function(obj) {
+    $.freezeObject = function (obj) {
         if (Object.freeze) {
             $.freezeObject = Object.freeze;
         } else {
-            $.freezeObject = function(obj) {
+            $.freezeObject = function (obj) {
                 return obj;
             };
         }
@@ -854,9 +854,9 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      */
     $.supportsCanvas = (function () {
-        var canvasElement = document.createElement( 'canvas' );
-        return !!( $.isFunction( canvasElement.getContext ) &&
-                    canvasElement.getContext( '2d' ) );
+        var canvasElement = document.createElement('canvas');
+        return !!($.isFunction(canvasElement.getContext) &&
+            canvasElement.getContext('2d'));
     }());
 
     /**
@@ -864,7 +864,7 @@ function OpenSeadragon( options ){
      * @argument {Canvas} canvas The canvas to test.
      * @returns {Boolean} True if the canvas is tainted.
      */
-    $.isCanvasTainted = function(canvas) {
+    $.isCanvasTainted = function (canvas) {
         var isTainted = false;
         try {
             // We test if the canvas is tainted by retrieving data from it.
@@ -883,21 +883,21 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      */
     $.pixelDensityRatio = (function () {
-        if ( $.supportsCanvas ) {
+        if ($.supportsCanvas) {
             var context = document.createElement('canvas').getContext('2d');
             var devicePixelRatio = window.devicePixelRatio || 1;
             var backingStoreRatio = context.webkitBackingStorePixelRatio ||
-                                    context.mozBackingStorePixelRatio ||
-                                    context.msBackingStorePixelRatio ||
-                                    context.oBackingStorePixelRatio ||
-                                    context.backingStorePixelRatio || 1;
+                context.mozBackingStorePixelRatio ||
+                context.msBackingStorePixelRatio ||
+                context.oBackingStorePixelRatio ||
+                context.backingStorePixelRatio || 1;
             return Math.max(devicePixelRatio, 1) / backingStoreRatio;
         } else {
             return 1;
         }
     }());
 
-}( OpenSeadragon ));
+}(OpenSeadragon));
 
 /**
  *  This closure defines all static methods available to the OpenSeadragon
@@ -911,7 +911,7 @@ function OpenSeadragon( options ){
  *  Some static methods have also been refactored from the original OpenSeadragon
  *  project.
  */
-(function( $ ){
+(function ($) {
 
     /**
      * Taken from jQuery 1.6.1
@@ -919,67 +919,67 @@ function OpenSeadragon( options ){
      * @memberof OpenSeadragon
      * @see {@link http://www.jquery.com/ jQuery}
      */
-    $.extend = function() {
+    $.extend = function () {
         var options,
             name,
             src,
             copy,
             copyIsArray,
             clone,
-            target  = arguments[ 0 ] || {},
-            length  = arguments.length,
-            deep    = false,
-            i       = 1;
+            target = arguments[0] || {},
+            length = arguments.length,
+            deep = false,
+            i = 1;
 
         // Handle a deep copy situation
-        if ( typeof target === "boolean" ) {
-            deep    = target;
-            target  = arguments[ 1 ] || {};
+        if (typeof target === "boolean") {
+            deep = target;
+            target = arguments[1] || {};
             // skip the boolean and the target
             i = 2;
         }
 
         // Handle case when target is a string or something (possible in deep copy)
-        if ( typeof target !== "object" && !OpenSeadragon.isFunction( target ) ) {
+        if (typeof target !== "object" && !OpenSeadragon.isFunction(target)) {
             target = {};
         }
 
         // extend jQuery itself if only one argument is passed
-        if ( length === i ) {
+        if (length === i) {
             target = this;
             --i;
         }
 
-        for ( ; i < length; i++ ) {
+        for (; i < length; i++) {
             // Only deal with non-null/undefined values
-            options = arguments[ i ];
-            if ( options !== null || options !== undefined ) {
+            options = arguments[i];
+            if (options !== null || options !== undefined) {
                 // Extend the base object
-                for ( name in options ) {
-                    src = target[ name ];
-                    copy = options[ name ];
+                for (name in options) {
+                    src = target[name];
+                    copy = options[name];
 
                     // Prevent never-ending loop
-                    if ( target === copy ) {
+                    if (target === copy) {
                         continue;
                     }
 
                     // Recurse if we're merging plain objects or arrays
-                    if ( deep && copy && ( OpenSeadragon.isPlainObject( copy ) || ( copyIsArray = OpenSeadragon.isArray( copy ) ) ) ) {
-                        if ( copyIsArray ) {
+                    if (deep && copy && (OpenSeadragon.isPlainObject(copy) || (copyIsArray = OpenSeadragon.isArray(copy)))) {
+                        if (copyIsArray) {
                             copyIsArray = false;
-                            clone = src && OpenSeadragon.isArray( src ) ? src : [];
+                            clone = src && OpenSeadragon.isArray(src) ? src : [];
 
                         } else {
-                            clone = src && OpenSeadragon.isPlainObject( src ) ? src : {};
+                            clone = src && OpenSeadragon.isPlainObject(src) ? src : {};
                         }
 
                         // Never move original objects, clone them
-                        target[ name ] = OpenSeadragon.extend( deep, clone, copy );
+                        target[name] = OpenSeadragon.extend(deep, clone, copy);
 
-                    // Don't bring in undefined values
-                    } else if ( copy !== undefined ) {
-                        target[ name ] = copy;
+                        // Don't bring in undefined values
+                    } else if (copy !== undefined) {
+                        target[name] = copy;
                     }
                 }
             }
@@ -998,11 +998,11 @@ function OpenSeadragon( options ){
             return false;
         }
         return userAgent.indexOf('iPhone') !== -1 ||
-               userAgent.indexOf('iPad') !== -1 ||
-               userAgent.indexOf('iPod') !== -1;
+            userAgent.indexOf('iPad') !== -1 ||
+            userAgent.indexOf('iPod') !== -1;
     };
 
-    $.extend( $, /** @lends OpenSeadragon */{
+    $.extend($, /** @lends OpenSeadragon */{
         /**
          * The default values for the optional settings documented at {@link OpenSeadragon.Options}.
          * @static
@@ -1010,36 +1010,36 @@ function OpenSeadragon( options ){
          */
         DEFAULT_SETTINGS: {
             //DATA SOURCE DETAILS
-            xmlPath:                null,
-            tileSources:            null,
-            tileHost:               null,
-            initialPage:            0,
-            crossOriginPolicy:      false,
-            ajaxWithCredentials:    false,
-            loadTilesWithAjax:      false,
-            ajaxHeaders:            {},
+            xmlPath: null,
+            tileSources: null,
+            tileHost: null,
+            initialPage: 0,
+            crossOriginPolicy: false,
+            ajaxWithCredentials: false,
+            loadTilesWithAjax: false,
+            ajaxHeaders: {},
 
             //PAN AND ZOOM SETTINGS AND CONSTRAINTS
-            panHorizontal:          true,
-            panVertical:            true,
-            constrainDuringPan:     false,
-            wrapHorizontal:         false,
-            wrapVertical:           false,
-            visibilityRatio:        0.5, //-> how much of the viewer can be negative space
-            minPixelRatio:          0.5, //->closer to 0 draws tiles meant for a higher zoom at this zoom
-            defaultZoomLevel:       0,
-            minZoomLevel:           null,
-            maxZoomLevel:           null,
-            homeFillsViewer:        false,
+            panHorizontal: true,
+            panVertical: true,
+            constrainDuringPan: false,
+            wrapHorizontal: false,
+            wrapVertical: false,
+            visibilityRatio: 0.5, //-> how much of the viewer can be negative space
+            minPixelRatio: 0.5, //->closer to 0 draws tiles meant for a higher zoom at this zoom
+            defaultZoomLevel: 0,
+            minZoomLevel: null,
+            maxZoomLevel: null,
+            homeFillsViewer: false,
 
             //UI RESPONSIVENESS AND FEEL
-            clickTimeThreshold:     300,
-            clickDistThreshold:     5,
-            dblClickTimeThreshold:  300,
-            dblClickDistThreshold:  20,
-            springStiffness:        6.5,
-            animationTime:          1.2,
-            gestureSettingsMouse:   {
+            clickTimeThreshold: 300,
+            clickDistThreshold: 5,
+            dblClickTimeThreshold: 300,
+            dblClickDistThreshold: 20,
+            springStiffness: 6.5,
+            animationTime: 1.2,
+            gestureSettingsMouse: {
                 scrollToZoom: true,
                 clickToZoom: true,
                 dblClickToZoom: false,
@@ -1049,7 +1049,7 @@ function OpenSeadragon( options ){
                 flickMomentum: 0.25,
                 pinchRotate: false
             },
-            gestureSettingsTouch:   {
+            gestureSettingsTouch: {
                 scrollToZoom: false,
                 clickToZoom: false,
                 dblClickToZoom: true,
@@ -1059,7 +1059,7 @@ function OpenSeadragon( options ){
                 flickMomentum: 0.25,
                 pinchRotate: false
             },
-            gestureSettingsPen:     {
+            gestureSettingsPen: {
                 scrollToZoom: false,
                 clickToZoom: true,
                 dblClickToZoom: false,
@@ -1079,141 +1079,142 @@ function OpenSeadragon( options ){
                 flickMomentum: 0.25,
                 pinchRotate: false
             },
-            zoomPerClick:           2,
-            zoomPerScroll:          1.2,
-            zoomPerSecond:          1.0,
-            blendTime:              0,
-            alwaysBlend:            false,
-            autoHideControls:       true,
-            immediateRender:        false,
-            minZoomImageRatio:      0.9, //-> closer to 0 allows zoom out to infinity
-            maxZoomPixelRatio:      1.1, //-> higher allows 'over zoom' into pixels
+            zoomPerClick: 2,
+            zoomPerScroll: 1.2,
+            zoomPerSecond: 1.0,
+            blendTime: 0,
+            alwaysBlend: false,
+            autoHideControls: true,
+            immediateRender: false,
+            minZoomImageRatio: 0.9, //-> closer to 0 allows zoom out to infinity
+            maxZoomPixelRatio: 1.1, //-> higher allows 'over zoom' into pixels
             smoothTileEdgesMinZoom: 1.1, //-> higher than maxZoomPixelRatio disables it
-            iOSDevice:              isIOSDevice(),
-            pixelsPerWheelLine:     40,
-            pixelsPerArrowPress:    40,
-            autoResize:             true,
+            iOSDevice: isIOSDevice(),
+            pixelsPerWheelLine: 40,
+            pixelsPerArrowPress: 40,
+            autoResize: true,
             preserveImageSizeOnResize: false, // requires autoResize=true
-            minScrollDeltaTime:     50,
+            minScrollDeltaTime: 50,
 
             //DEFAULT CONTROL SETTINGS
-            showSequenceControl:     true,  //SEQUENCE
-            sequenceControlAnchor:   null,  //SEQUENCE
-            preserveViewport:        false, //SEQUENCE
-            preserveOverlays:        false, //SEQUENCE
-            navPrevNextWrap:         false, //SEQUENCE
-            showNavigationControl:   true,  //ZOOM/HOME/FULL/ROTATION
+            showSequenceControl: true,  //SEQUENCE
+            sequenceControlAnchor: null,  //SEQUENCE
+            preserveViewport: false, //SEQUENCE
+            preserveOverlays: false, //SEQUENCE
+            navPrevNextWrap: false, //SEQUENCE
+            showNavigationControl: true,  //ZOOM/HOME/FULL/ROTATION
             navigationControlAnchor: null,  //ZOOM/HOME/FULL/ROTATION
-            showZoomControl:         true,  //ZOOM
-            showHomeControl:         true,  //HOME
-            showFullPageControl:     true,  //FULL
-            showRotationControl:     false, //ROTATION
-            controlsFadeDelay:       2000,  //ZOOM/HOME/FULL/SEQUENCE
-            controlsFadeLength:      1500,  //ZOOM/HOME/FULL/SEQUENCE
-            mouseNavEnabled:         true,  //GENERAL MOUSE INTERACTIVITY
+            showZoomControl: true,  //ZOOM
+            showHomeControl: true,  //HOME
+            showFullPageControl: true,  //FULL
+            showRotationControl: false, //ROTATION
+            controlsFadeDelay: 2000,  //ZOOM/HOME/FULL/SEQUENCE
+            controlsFadeLength: 1500,  //ZOOM/HOME/FULL/SEQUENCE
+            mouseNavEnabled: true,  //GENERAL MOUSE INTERACTIVITY
 
             //VIEWPORT NAVIGATOR SETTINGS
-            showNavigator:              false,
-            navigatorId:                null,
-            navigatorPosition:          null,
-            navigatorSizeRatio:         0.2,
+            showNavigator: false,
+            navigatorId: null,
+            navigatorPosition: null,
+            navigatorSizeRatio: 0.2,
             navigatorMaintainSizeRatio: false,
-            navigatorTop:               null,
-            navigatorLeft:              null,
-            navigatorHeight:            null,
-            navigatorWidth:             null,
-            navigatorAutoResize:        true,
-            navigatorAutoFade:          true,
-            navigatorRotate:            true,
+            navigatorTop: null,
+            navigatorLeft: null,
+            navigatorHeight: null,
+            navigatorWidth: null,
+            navigatorAutoResize: true,
+            navigatorAutoFade: true,
+            navigatorRotate: true,
 
             // INITIAL ROTATION
-            degrees:                    0,
+            degrees: 0,
 
             // APPEARANCE
-            opacity:                    1,
-            preload:                    false,
-            compositeOperation:         null,
-            placeholderFillStyle:       null,
+            opacity: 1,
+            preload: false,
+            compositeOperation: null,
+            placeholderFillStyle: null,
 
             //REFERENCE STRIP SETTINGS
-            showReferenceStrip:          false,
-            referenceStripScroll:       'horizontal',
-            referenceStripElement:       null,
-            referenceStripHeight:        null,
-            referenceStripWidth:         null,
-            referenceStripPosition:      'BOTTOM_LEFT',
-            referenceStripSizeRatio:     0.2,
+            showReferenceStrip: false,
+            referenceStripScroll: 'horizontal',
+            referenceStripElement: null,
+            referenceStripHeight: null,
+            referenceStripWidth: null,
+            referenceStripPosition: 'BOTTOM_LEFT',
+            referenceStripSizeRatio: 0.2,
 
             //COLLECTION VISUALIZATION SETTINGS
-            collectionRows:         3, //or columns depending on layout
-            collectionColumns:      0, //columns in horizontal layout, rows in vertical layout
-            collectionLayout:       'horizontal', //vertical
-            collectionMode:         false,
-            collectionTileSize:     800,
-            collectionTileMargin:   80,
+            collectionRows: 3, //or columns depending on layout
+            collectionColumns: 0, //columns in horizontal layout, rows in vertical layout
+            collectionLayout: 'horizontal', //vertical
+            collectionMode: false,
+            collectionTileSize: 800,
+            collectionTileMargin: 80,
 
             //PERFORMANCE SETTINGS
-            imageLoaderLimit:       0,
-            maxImageCacheCount:     200,
-            timeout:                30000,
-            useCanvas:              true,  // Use canvas element for drawing if available
+            imageLoaderLimit: 0,
+            maxImageCacheCount: 200,
+            timeout: 30000,
+            useCanvas: true,  // Use canvas element for drawing if available
+            refetchFailedTiles: false,
 
             //INTERFACE RESOURCE SETTINGS
-            prefixUrl:              "/images/",
+            prefixUrl: "/images/",
             navImages: {
                 zoomIn: {
-                    REST:   'zoomin_rest.png',
-                    GROUP:  'zoomin_grouphover.png',
-                    HOVER:  'zoomin_hover.png',
-                    DOWN:   'zoomin_pressed.png'
+                    REST: 'zoomin_rest.png',
+                    GROUP: 'zoomin_grouphover.png',
+                    HOVER: 'zoomin_hover.png',
+                    DOWN: 'zoomin_pressed.png'
                 },
                 zoomOut: {
-                    REST:   'zoomout_rest.png',
-                    GROUP:  'zoomout_grouphover.png',
-                    HOVER:  'zoomout_hover.png',
-                    DOWN:   'zoomout_pressed.png'
+                    REST: 'zoomout_rest.png',
+                    GROUP: 'zoomout_grouphover.png',
+                    HOVER: 'zoomout_hover.png',
+                    DOWN: 'zoomout_pressed.png'
                 },
                 home: {
-                    REST:   'home_rest.png',
-                    GROUP:  'home_grouphover.png',
-                    HOVER:  'home_hover.png',
-                    DOWN:   'home_pressed.png'
+                    REST: 'home_rest.png',
+                    GROUP: 'home_grouphover.png',
+                    HOVER: 'home_hover.png',
+                    DOWN: 'home_pressed.png'
                 },
                 fullpage: {
-                    REST:   'fullpage_rest.png',
-                    GROUP:  'fullpage_grouphover.png',
-                    HOVER:  'fullpage_hover.png',
-                    DOWN:   'fullpage_pressed.png'
+                    REST: 'fullpage_rest.png',
+                    GROUP: 'fullpage_grouphover.png',
+                    HOVER: 'fullpage_hover.png',
+                    DOWN: 'fullpage_pressed.png'
                 },
                 rotateleft: {
-                    REST:   'rotateleft_rest.png',
-                    GROUP:  'rotateleft_grouphover.png',
-                    HOVER:  'rotateleft_hover.png',
-                    DOWN:   'rotateleft_pressed.png'
+                    REST: 'rotateleft_rest.png',
+                    GROUP: 'rotateleft_grouphover.png',
+                    HOVER: 'rotateleft_hover.png',
+                    DOWN: 'rotateleft_pressed.png'
                 },
                 rotateright: {
-                    REST:   'rotateright_rest.png',
-                    GROUP:  'rotateright_grouphover.png',
-                    HOVER:  'rotateright_hover.png',
-                    DOWN:   'rotateright_pressed.png'
+                    REST: 'rotateright_rest.png',
+                    GROUP: 'rotateright_grouphover.png',
+                    HOVER: 'rotateright_hover.png',
+                    DOWN: 'rotateright_pressed.png'
                 },
                 previous: {
-                    REST:   'previous_rest.png',
-                    GROUP:  'previous_grouphover.png',
-                    HOVER:  'previous_hover.png',
-                    DOWN:   'previous_pressed.png'
+                    REST: 'previous_rest.png',
+                    GROUP: 'previous_grouphover.png',
+                    HOVER: 'previous_hover.png',
+                    DOWN: 'previous_pressed.png'
                 },
                 next: {
-                    REST:   'next_rest.png',
-                    GROUP:  'next_grouphover.png',
-                    HOVER:  'next_hover.png',
-                    DOWN:   'next_pressed.png'
+                    REST: 'next_rest.png',
+                    GROUP: 'next_grouphover.png',
+                    HOVER: 'next_hover.png',
+                    DOWN: 'next_pressed.png'
                 }
             },
 
             //DEVELOPER SETTINGS
-            debugMode:              false,
-            debugGridColor:         ['#437AB2', '#1B9E77', '#D95F02', '#7570B3', '#E7298A', '#66A61E', '#E6AB02', '#A6761D', '#666666']
+            debugMode: false,
+            debugGridColor: ['#437AB2', '#1B9E77', '#D95F02', '#7570B3', '#E7298A', '#66A61E', '#E6AB02', '#A6761D', '#666666']
         },
 
 
@@ -1233,13 +1234,13 @@ function OpenSeadragon( options ){
          * @param {Function} method
          * @returns {Function}
          */
-        delegate: function( object, method ) {
-            return function(){
+        delegate: function (object, method) {
+            return function () {
                 var args = arguments;
-                if ( args === undefined ){
+                if (args === undefined) {
                     args = [];
                 }
-                return method.apply( object, args );
+                return method.apply(object, args);
             };
         },
 
@@ -1256,12 +1257,12 @@ function OpenSeadragon( options ){
          * @property {Number} OPERA
          */
         BROWSERS: {
-            UNKNOWN:    0,
-            IE:         1,
-            FIREFOX:    2,
-            SAFARI:     3,
-            CHROME:     4,
-            OPERA:      5
+            UNKNOWN: 0,
+            IE: 1,
+            FIREFOX: 2,
+            SAFARI: 3,
+            CHROME: 4,
+            OPERA: 5
         },
 
 
@@ -1271,9 +1272,9 @@ function OpenSeadragon( options ){
          * @param {String|Element} element Accepts an id or element.
          * @returns {Element} The element with the given id, null, or the element itself.
          */
-        getElement: function( element ) {
-            if ( typeof ( element ) == "string" ) {
-                element = document.getElementById( element );
+        getElement: function (element) {
+            if (typeof (element) == "string") {
+                element = document.getElementById(element);
             }
             return element;
         },
@@ -1285,27 +1286,27 @@ function OpenSeadragon( options ){
          * @param {Element|String} element - the elemenet we want the position for.
          * @returns {OpenSeadragon.Point} - the position of the upper left corner of the element.
          */
-        getElementPosition: function( element ) {
+        getElementPosition: function (element) {
             var result = new $.Point(),
                 isFixed,
                 offsetParent;
 
-            element      = $.getElement( element );
-            isFixed      = $.getElementStyle( element ).position == "fixed";
-            offsetParent = getOffsetParent( element, isFixed );
+            element = $.getElement(element);
+            isFixed = $.getElementStyle(element).position == "fixed";
+            offsetParent = getOffsetParent(element, isFixed);
 
-            while ( offsetParent ) {
+            while (offsetParent) {
 
                 result.x += element.offsetLeft;
                 result.y += element.offsetTop;
 
-                if ( isFixed ) {
-                    result = result.plus( $.getPageScroll() );
+                if (isFixed) {
+                    result = result.plus($.getPageScroll());
                 }
 
                 element = offsetParent;
-                isFixed = $.getElementStyle( element ).position == "fixed";
-                offsetParent = getOffsetParent( element, isFixed );
+                isFixed = $.getElementStyle(element).position == "fixed";
+                offsetParent = getOffsetParent(element, isFixed);
             }
 
             return result;
@@ -1318,33 +1319,33 @@ function OpenSeadragon( options ){
          * @param {Element|String} element - the element we want the position for.
          * @returns {OpenSeadragon.Point} - the position of the upper left corner of the element adjusted for current page and/or element scroll.
          */
-        getElementOffset: function( element ) {
-            element = $.getElement( element );
+        getElementOffset: function (element) {
+            element = $.getElement(element);
 
             var doc = element && element.ownerDocument,
                 docElement,
                 win,
                 boundingRect = { top: 0, left: 0 };
 
-            if ( !doc ) {
+            if (!doc) {
                 return new $.Point();
             }
 
             docElement = doc.documentElement;
 
-            if ( typeof element.getBoundingClientRect !== typeof undefined ) {
+            if (typeof element.getBoundingClientRect !== typeof undefined) {
                 boundingRect = element.getBoundingClientRect();
             }
 
-            win = ( doc == doc.window ) ?
+            win = (doc == doc.window) ?
                 doc :
-                ( doc.nodeType === 9 ) ?
+                (doc.nodeType === 9) ?
                     doc.defaultView || doc.parentWindow :
                     false;
 
             return new $.Point(
-                boundingRect.left + ( win.pageXOffset || docElement.scrollLeft ) - ( docElement.clientLeft || 0 ),
-                boundingRect.top + ( win.pageYOffset || docElement.scrollTop ) - ( docElement.clientTop || 0 )
+                boundingRect.left + (win.pageXOffset || docElement.scrollLeft) - (docElement.clientLeft || 0),
+                boundingRect.top + (win.pageYOffset || docElement.scrollTop) - (docElement.clientTop || 0)
             );
         },
 
@@ -1355,8 +1356,8 @@ function OpenSeadragon( options ){
          * @param {Element|String} element
          * @returns {OpenSeadragon.Point}
          */
-        getElementSize: function( element ) {
-            element = $.getElement( element );
+        getElementSize: function (element) {
+            element = $.getElement(element);
 
             return new $.Point(
                 element.clientWidth,
@@ -1373,14 +1374,14 @@ function OpenSeadragon( options ){
          */
         getElementStyle:
             document.documentElement.currentStyle ?
-            function( element ) {
-                element = $.getElement( element );
-                return element.currentStyle;
-            } :
-            function( element ) {
-                element = $.getElement( element );
-                return window.getComputedStyle( element, "" );
-            },
+                function (element) {
+                    element = $.getElement(element);
+                    return element.currentStyle;
+                } :
+                function (element) {
+                    element = $.getElement(element);
+                    return window.getComputedStyle(element, "");
+                },
 
         /**
          * Returns the property with the correct vendor prefix appended.
@@ -1388,10 +1389,10 @@ function OpenSeadragon( options ){
          * @returns {String} the property with the correct prefix or null if not
          * supported.
          */
-        getCssPropertyWithVendorPrefix: function(property) {
+        getCssPropertyWithVendorPrefix: function (property) {
             var memo = {};
 
-            $.getCssPropertyWithVendorPrefix = function(property) {
+            $.getCssPropertyWithVendorPrefix = function (property) {
                 if (memo[property] !== undefined) {
                     return memo[property];
                 }
@@ -1422,7 +1423,7 @@ function OpenSeadragon( options ){
          * @param {String} string
          * @returns {String} The string with the first letter capitalized
          */
-        capitalizeFirstLetter: function(string) {
+        capitalizeFirstLetter: function (string) {
             return string.charAt(0).toUpperCase() + string.slice(1);
         },
 
@@ -1433,7 +1434,7 @@ function OpenSeadragon( options ){
          * @param {Number} modulo the modulo
          * @returns {Number} the result of the modulo of number
          */
-        positiveModulo: function(number, modulo) {
+        positiveModulo: function (number, modulo) {
             var result = number % modulo;
             if (result < 0) {
                 result += modulo;
@@ -1448,10 +1449,10 @@ function OpenSeadragon( options ){
          * @param {OpenSeadragon.Point} point
          * @returns {Boolean}
          */
-        pointInElement: function( element, point ) {
-            element = $.getElement( element );
-            var offset = $.getElementOffset( element ),
-                size = $.getElementSize( element );
+        pointInElement: function (element, point) {
+            element = $.getElement(element);
+            var offset = $.getElementOffset(element),
+                size = $.getElementSize(element);
             return point.x >= offset.x && point.x < offset.x + size.x && point.y < offset.y + size.y && point.y >= offset.y;
         },
 
@@ -1465,17 +1466,17 @@ function OpenSeadragon( options ){
          * @deprecated For internal use only
          * @private
          */
-        getEvent: function( event ) {
-            if( event ){
-                $.getEvent = function( event ) {
+        getEvent: function (event) {
+            if (event) {
+                $.getEvent = function (event) {
                     return event;
                 };
             } else {
-                $.getEvent = function() {
+                $.getEvent = function () {
                     return window.event;
                 };
             }
-            return $.getEvent( event );
+            return $.getEvent(event);
         },
 
 
@@ -1485,23 +1486,23 @@ function OpenSeadragon( options ){
          * @param {Event} [event]
          * @returns {OpenSeadragon.Point}
          */
-        getMousePosition: function( event ) {
+        getMousePosition: function (event) {
 
-            if ( typeof( event.pageX ) == "number" ) {
-                $.getMousePosition = function( event ){
+            if (typeof (event.pageX) == "number") {
+                $.getMousePosition = function (event) {
                     var result = new $.Point();
 
-                    event = $.getEvent( event );
+                    event = $.getEvent(event);
                     result.x = event.pageX;
                     result.y = event.pageY;
 
                     return result;
                 };
-            } else if ( typeof( event.clientX ) == "number" ) {
-                $.getMousePosition = function( event ){
+            } else if (typeof (event.clientX) == "number") {
+                $.getMousePosition = function (event) {
                     var result = new $.Point();
 
-                    event = $.getEvent( event );
+                    event = $.getEvent(event);
                     result.x =
                         event.clientX +
                         document.body.scrollLeft +
@@ -1519,7 +1520,7 @@ function OpenSeadragon( options ){
                 );
             }
 
-            return $.getMousePosition( event );
+            return $.getMousePosition(event);
         },
 
 
@@ -1528,26 +1529,26 @@ function OpenSeadragon( options ){
          * @function
          * @returns {OpenSeadragon.Point}
          */
-        getPageScroll: function() {
-            var docElement  = document.documentElement || {},
-                body        = document.body || {};
+        getPageScroll: function () {
+            var docElement = document.documentElement || {},
+                body = document.body || {};
 
-            if ( typeof( window.pageXOffset ) == "number" ) {
-                $.getPageScroll = function(){
+            if (typeof (window.pageXOffset) == "number") {
+                $.getPageScroll = function () {
                     return new $.Point(
                         window.pageXOffset,
                         window.pageYOffset
                     );
                 };
-            } else if ( body.scrollLeft || body.scrollTop ) {
-                $.getPageScroll = function(){
+            } else if (body.scrollLeft || body.scrollTop) {
+                $.getPageScroll = function () {
                     return new $.Point(
                         document.body.scrollLeft,
                         document.body.scrollTop
                     );
                 };
-            } else if ( docElement.scrollLeft || docElement.scrollTop ) {
-                $.getPageScroll = function(){
+            } else if (docElement.scrollLeft || docElement.scrollTop) {
+                $.getPageScroll = function () {
                     return new $.Point(
                         document.documentElement.scrollLeft,
                         document.documentElement.scrollTop
@@ -1566,15 +1567,15 @@ function OpenSeadragon( options ){
          * @function
          * @returns {OpenSeadragon.Point}
          */
-        setPageScroll: function( scroll ) {
-            if ( typeof ( window.scrollTo ) !== "undefined" ) {
-                $.setPageScroll = function( scroll ) {
-                    window.scrollTo( scroll.x, scroll.y );
+        setPageScroll: function (scroll) {
+            if (typeof (window.scrollTo) !== "undefined") {
+                $.setPageScroll = function (scroll) {
+                    window.scrollTo(scroll.x, scroll.y);
                 };
             } else {
                 var originalScroll = $.getPageScroll();
-                if ( originalScroll.x === scroll.x &&
-                    originalScroll.y === scroll.y ) {
+                if (originalScroll.x === scroll.x &&
+                    originalScroll.y === scroll.y) {
                     // We are already correctly positioned and there
                     // is no way to detect the correct method.
                     return;
@@ -1583,9 +1584,9 @@ function OpenSeadragon( options ){
                 document.body.scrollLeft = scroll.x;
                 document.body.scrollTop = scroll.y;
                 var currentScroll = $.getPageScroll();
-                if ( currentScroll.x !== originalScroll.x &&
-                    currentScroll.y !== originalScroll.y ) {
-                    $.setPageScroll = function( scroll ) {
+                if (currentScroll.x !== originalScroll.x &&
+                    currentScroll.y !== originalScroll.y) {
+                    $.setPageScroll = function (scroll) {
                         document.body.scrollLeft = scroll.x;
                         document.body.scrollTop = scroll.y;
                     };
@@ -1595,9 +1596,9 @@ function OpenSeadragon( options ){
                 document.documentElement.scrollLeft = scroll.x;
                 document.documentElement.scrollTop = scroll.y;
                 currentScroll = $.getPageScroll();
-                if ( currentScroll.x !== originalScroll.x &&
-                    currentScroll.y !== originalScroll.y ) {
-                    $.setPageScroll = function( scroll ) {
+                if (currentScroll.x !== originalScroll.x &&
+                    currentScroll.y !== originalScroll.y) {
+                    $.setPageScroll = function (scroll) {
                         document.documentElement.scrollLeft = scroll.x;
                         document.documentElement.scrollTop = scroll.y;
                     };
@@ -1605,11 +1606,11 @@ function OpenSeadragon( options ){
                 }
 
                 // We can't find anything working, so we do nothing.
-                $.setPageScroll = function( scroll ) {
+                $.setPageScroll = function (scroll) {
                 };
             }
 
-            return $.setPageScroll( scroll );
+            return $.setPageScroll(scroll);
         },
 
         /**
@@ -1617,26 +1618,26 @@ function OpenSeadragon( options ){
          * @function
          * @returns {OpenSeadragon.Point}
          */
-        getWindowSize: function() {
+        getWindowSize: function () {
             var docElement = document.documentElement || {},
-                body    = document.body || {};
+                body = document.body || {};
 
-            if ( typeof( window.innerWidth ) == 'number' ) {
-                $.getWindowSize = function(){
+            if (typeof (window.innerWidth) == 'number') {
+                $.getWindowSize = function () {
                     return new $.Point(
                         window.innerWidth,
                         window.innerHeight
                     );
                 };
-            } else if ( docElement.clientWidth || docElement.clientHeight ) {
-                $.getWindowSize = function(){
+            } else if (docElement.clientWidth || docElement.clientHeight) {
+                $.getWindowSize = function () {
                     return new $.Point(
                         document.documentElement.clientWidth,
                         document.documentElement.clientHeight
                     );
                 };
-            } else if ( body.clientWidth || body.clientHeight ) {
-                $.getWindowSize = function(){
+            } else if (body.clientWidth || body.clientHeight) {
+                $.getWindowSize = function () {
                     return new $.Point(
                         document.body.clientWidth,
                         document.body.clientHeight
@@ -1657,9 +1658,9 @@ function OpenSeadragon( options ){
          * @param {Element|String} element
          * @returns {Element} outermost wrapper element
          */
-        makeCenteredNode: function( element ) {
+        makeCenteredNode: function (element) {
             // Convert a possible ID to an actual HTMLElement
-            element = $.getElement( element );
+            element = $.getElement(element);
 
             /*
                 CSS tables require you to have a display:table/row/cell hierarchy so we need to create
@@ -1667,9 +1668,9 @@ function OpenSeadragon( options ){
              */
 
             var wrappers = [
-                $.makeNeutralElement( 'div' ),
-                $.makeNeutralElement( 'div' ),
-                $.makeNeutralElement( 'div' )
+                $.makeNeutralElement('div'),
+                $.makeNeutralElement('div'),
+                $.makeNeutralElement('div')
             ];
 
             // It feels like we should be able to pass style dicts to makeNeutralElement:
@@ -1704,15 +1705,15 @@ function OpenSeadragon( options ){
          * @param {String} tagName
          * @returns {Element}
          */
-        makeNeutralElement: function( tagName ) {
-            var element = document.createElement( tagName ),
-                style   = element.style;
+        makeNeutralElement: function (tagName) {
+            var element = document.createElement(tagName),
+                style = element.style;
 
             style.background = "transparent none";
-            style.border     = "none";
-            style.margin     = "0px";
-            style.padding    = "0px";
-            style.position   = "static";
+            style.border = "none";
+            style.margin = "0px";
+            style.padding = "0px";
+            style.position = "static";
 
             return element;
         },
@@ -1722,11 +1723,11 @@ function OpenSeadragon( options ){
          * Returns the current milliseconds, using Date.now() if available
          * @function
          */
-        now: function( ) {
+        now: function () {
             if (Date.now) {
                 $.now = Date.now;
             } else {
-                $.now = function() {
+                $.now = function () {
                     return new Date().getTime();
                 };
             }
@@ -1743,27 +1744,27 @@ function OpenSeadragon( options ){
          * @param {String} src
          * @returns {Element}
          */
-        makeTransparentImage: function( src ) {
+        makeTransparentImage: function (src) {
 
-            $.makeTransparentImage = function( src ){
-                var img = $.makeNeutralElement( "img" );
+            $.makeTransparentImage = function (src) {
+                var img = $.makeNeutralElement("img");
 
                 img.src = src;
 
                 return img;
             };
 
-            if ( $.Browser.vendor == $.BROWSERS.IE && $.Browser.version < 7 ) {
+            if ($.Browser.vendor == $.BROWSERS.IE && $.Browser.version < 7) {
 
-                $.makeTransparentImage = function( src ){
-                    var img     = $.makeNeutralElement( "img" ),
+                $.makeTransparentImage = function (src) {
+                    var img = $.makeNeutralElement("img"),
                         element = null;
 
                     element = $.makeNeutralElement("span");
                     element.style.display = "inline-block";
 
-                    img.onload = function() {
-                        element.style.width  = element.style.width || img.width + "px";
+                    img.onload = function () {
+                        element.style.width = element.style.width || img.width + "px";
                         element.style.height = element.style.height || img.height + "px";
 
                         img.onload = null;
@@ -1781,7 +1782,7 @@ function OpenSeadragon( options ){
 
             }
 
-            return $.makeTransparentImage( src );
+            return $.makeTransparentImage(src);
         },
 
 
@@ -1792,23 +1793,23 @@ function OpenSeadragon( options ){
          * @param {Number} opacity
          * @param {Boolean} [usesAlpha]
          */
-        setElementOpacity: function( element, opacity, usesAlpha ) {
+        setElementOpacity: function (element, opacity, usesAlpha) {
 
             var ieOpacity,
                 ieFilter;
 
-            element = $.getElement( element );
+            element = $.getElement(element);
 
-            if ( usesAlpha && !$.Browser.alpha ) {
-                opacity = Math.round( opacity );
+            if (usesAlpha && !$.Browser.alpha) {
+                opacity = Math.round(opacity);
             }
 
-            if ( $.Browser.opacity ) {
+            if ($.Browser.opacity) {
                 element.style.opacity = opacity < 1 ? opacity : "";
             } else {
-                if ( opacity < 1 ) {
-                    ieOpacity = Math.round( 100 * opacity );
-                    ieFilter  = "alpha(opacity=" + ieOpacity + ")";
+                if (opacity < 1) {
+                    ieOpacity = Math.round(100 * opacity);
+                    ieFilter = "alpha(opacity=" + ieOpacity + ")";
                     element.style.filter = ieFilter;
                 } else {
                     element.style.filter = "";
@@ -1822,11 +1823,11 @@ function OpenSeadragon( options ){
          * @function
          * @param {Element|String} element
          */
-        setElementTouchActionNone: function( element ) {
-            element = $.getElement( element );
-            if ( typeof element.style.touchAction !== 'undefined' ) {
+        setElementTouchActionNone: function (element) {
+            element = $.getElement(element);
+            if (typeof element.style.touchAction !== 'undefined') {
                 element.style.touchAction = 'none';
-            } else if ( typeof element.style.msTouchAction !== 'undefined' ) {
+            } else if (typeof element.style.msTouchAction !== 'undefined') {
                 element.style.msTouchAction = 'none';
             }
         },
@@ -1838,13 +1839,13 @@ function OpenSeadragon( options ){
          * @param {Element|String} element
          * @param {String} className
          */
-        addClass: function( element, className ) {
-            element = $.getElement( element );
+        addClass: function (element, className) {
+            element = $.getElement(element);
 
             if (!element.className) {
                 element.className = className;
-            } else if ( ( ' ' + element.className + ' ' ).
-                indexOf( ' ' + className + ' ' ) === -1 ) {
+            } else if ((' ' + element.className + ' ').
+                indexOf(' ' + className + ' ') === -1) {
                 element.className += ' ' + className;
             }
         },
@@ -1862,38 +1863,38 @@ function OpenSeadragon( options ){
          * @param {Number} [fromIndex=0] Index to start research.
          * @returns {Number} The index of the element in the array.
          */
-        indexOf: function( array, searchElement, fromIndex ) {
-            if ( Array.prototype.indexOf ) {
-                this.indexOf = function( array, searchElement, fromIndex ) {
-                    return array.indexOf( searchElement, fromIndex );
+        indexOf: function (array, searchElement, fromIndex) {
+            if (Array.prototype.indexOf) {
+                this.indexOf = function (array, searchElement, fromIndex) {
+                    return array.indexOf(searchElement, fromIndex);
                 };
             } else {
-                this.indexOf = function( array, searchElement, fromIndex ) {
+                this.indexOf = function (array, searchElement, fromIndex) {
                     var i,
-                        pivot = ( fromIndex ) ? fromIndex : 0,
+                        pivot = (fromIndex) ? fromIndex : 0,
                         length;
-                    if ( !array ) {
-                        throw new TypeError( );
+                    if (!array) {
+                        throw new TypeError();
                     }
 
                     length = array.length;
-                    if ( length === 0 || pivot >= length ) {
+                    if (length === 0 || pivot >= length) {
                         return -1;
                     }
 
-                    if ( pivot < 0 ) {
-                        pivot = length - Math.abs( pivot );
+                    if (pivot < 0) {
+                        pivot = length - Math.abs(pivot);
                     }
 
-                    for ( i = pivot; i < length; i++ ) {
-                        if ( array[i] === searchElement ) {
+                    for (i = pivot; i < length; i++) {
+                        if (array[i] === searchElement) {
                             return i;
                         }
                     }
                     return -1;
                 };
             }
-            return this.indexOf( array, searchElement, fromIndex );
+            return this.indexOf(array, searchElement, fromIndex);
         },
 
         /**
@@ -1902,16 +1903,16 @@ function OpenSeadragon( options ){
          * @param {Element|String} element
          * @param {String} className
          */
-        removeClass: function( element, className ) {
+        removeClass: function (element, className) {
             var oldClasses,
                 newClasses = [],
                 i;
 
-            element = $.getElement( element );
-            oldClasses = element.className.split( /\s+/ );
-            for ( i = 0; i < oldClasses.length; i++ ) {
-                if ( oldClasses[ i ] && oldClasses[ i ] !== className ) {
-                    newClasses.push( oldClasses[ i ] );
+            element = $.getElement(element);
+            oldClasses = element.className.split(/\s+/);
+            for (i = 0; i < oldClasses.length; i++) {
+                if (oldClasses[i] && oldClasses[i] !== className) {
+                    newClasses.push(oldClasses[i]);
                 }
             }
             element.className = newClasses.join(' ');
@@ -1927,18 +1928,18 @@ function OpenSeadragon( options ){
          * @param {Boolean} [useCapture]
          */
         addEvent: (function () {
-            if ( window.addEventListener ) {
-                return function ( element, eventName, handler, useCapture ) {
-                    element = $.getElement( element );
-                    element.addEventListener( eventName, handler, useCapture );
+            if (window.addEventListener) {
+                return function (element, eventName, handler, useCapture) {
+                    element = $.getElement(element);
+                    element.addEventListener(eventName, handler, useCapture);
                 };
-            } else if ( window.attachEvent ) {
-                return function ( element, eventName, handler, useCapture ) {
-                    element = $.getElement( element );
-                    element.attachEvent( 'on' + eventName, handler );
+            } else if (window.attachEvent) {
+                return function (element, eventName, handler, useCapture) {
+                    element = $.getElement(element);
+                    element.attachEvent('on' + eventName, handler);
                 };
             } else {
-                throw new Error( "No known event model." );
+                throw new Error("No known event model.");
             }
         }()),
 
@@ -1953,18 +1954,18 @@ function OpenSeadragon( options ){
          * @param {Boolean} [useCapture]
          */
         removeEvent: (function () {
-            if ( window.removeEventListener ) {
-                return function ( element, eventName, handler, useCapture ) {
-                    element = $.getElement( element );
-                    element.removeEventListener( eventName, handler, useCapture );
+            if (window.removeEventListener) {
+                return function (element, eventName, handler, useCapture) {
+                    element = $.getElement(element);
+                    element.removeEventListener(eventName, handler, useCapture);
                 };
-            } else if ( window.detachEvent ) {
-                return function( element, eventName, handler, useCapture ) {
-                    element = $.getElement( element );
-                    element.detachEvent( 'on' + eventName, handler );
+            } else if (window.detachEvent) {
+                return function (element, eventName, handler, useCapture) {
+                    element = $.getElement(element);
+                    element.detachEvent('on' + eventName, handler);
                 };
             } else {
-                throw new Error( "No known event model." );
+                throw new Error("No known event model.");
             }
         }()),
 
@@ -1975,24 +1976,24 @@ function OpenSeadragon( options ){
          * @function
          * @param {Event} [event]
          */
-        cancelEvent: function( event ) {
-            event = $.getEvent( event );
+        cancelEvent: function (event) {
+            event = $.getEvent(event);
 
-            if ( event.preventDefault ) {
-                $.cancelEvent = function( event ){
+            if (event.preventDefault) {
+                $.cancelEvent = function (event) {
                     // W3C for preventing default
                     event.preventDefault();
                 };
             } else {
-                $.cancelEvent = function( event ){
-                    event = $.getEvent( event );
+                $.cancelEvent = function (event) {
+                    event = $.getEvent(event);
                     // legacy for preventing default
                     event.cancel = true;
                     // IE for preventing default
                     event.returnValue = false;
                 };
             }
-            $.cancelEvent( event );
+            $.cancelEvent(event);
         },
 
 
@@ -2001,24 +2002,24 @@ function OpenSeadragon( options ){
          * @function
          * @param {Event} [event]
          */
-        stopEvent: function( event ) {
-            event = $.getEvent( event );
+        stopEvent: function (event) {
+            event = $.getEvent(event);
 
-            if ( event.stopPropagation ) {
+            if (event.stopPropagation) {
                 // W3C for stopping propagation
-                $.stopEvent = function( event ){
+                $.stopEvent = function (event) {
                     event.stopPropagation();
                 };
             } else {
                 // IE for stopping propagation
-                $.stopEvent = function( event ){
-                    event = $.getEvent( event );
+                $.stopEvent = function (event) {
+                    event = $.getEvent(event);
                     event.cancelBubble = true;
                 };
 
             }
 
-            $.stopEvent( event );
+            $.stopEvent(event);
         },
 
 
@@ -2036,24 +2037,24 @@ function OpenSeadragon( options ){
          *  created callback
          * @returns {Function}
          */
-        createCallback: function( object, method ) {
+        createCallback: function (object, method) {
             //TODO: This pattern is painful to use and debug.  It's much cleaner
             //      to use pinning plus anonymous functions.  Get rid of this
             //      pattern!
             var initialArgs = [],
                 i;
-            for ( i = 2; i < arguments.length; i++ ) {
-                initialArgs.push( arguments[ i ] );
+            for (i = 2; i < arguments.length; i++) {
+                initialArgs.push(arguments[i]);
             }
 
-            return function() {
-                var args = initialArgs.concat( [] ),
+            return function () {
+                var args = initialArgs.concat([]),
                     i;
-                for ( i = 0; i < arguments.length; i++ ) {
-                    args.push( arguments[ i ] );
+                for (i = 0; i < arguments.length; i++) {
+                    args.push(arguments[i]);
                 }
 
-                return method.apply( object, args );
+                return method.apply(object, args);
             };
         },
 
@@ -2064,9 +2065,9 @@ function OpenSeadragon( options ){
          * @param {String} key
          * @returns {String} The value of the url parameter or null if no param matches.
          */
-        getUrlParameter: function( key ) {
+        getUrlParameter: function (key) {
             // eslint-disable-next-line no-use-before-define
-            var value = URLPARAMS[ key ];
+            var value = URLPARAMS[key];
             return value ? value : null;
         },
 
@@ -2078,9 +2079,9 @@ function OpenSeadragon( options ){
          * @param {String} url The url to retrieve the protocol from.
          * @return {String} The protocol (http:, https:, file:, ftp: ...)
          */
-        getUrlProtocol: function( url ) {
+        getUrlProtocol: function (url) {
             var match = url.match(/^([a-z]+:)\/\//i);
-            if ( match === null ) {
+            if (match === null) {
                 // Relative URL, retrive the protocol from window.location
                 return window.location.protocol;
             }
@@ -2094,39 +2095,39 @@ function OpenSeadragon( options ){
          * compatible if possible (but may raise a warning in the browser).
          * @returns {XMLHttpRequest}
          */
-        createAjaxRequest: function( local ) {
+        createAjaxRequest: function (local) {
             // IE11 does not support window.ActiveXObject so we just try to
             // create one to see if it is supported.
             // See: http://msdn.microsoft.com/en-us/library/ie/dn423948%28v=vs.85%29.aspx
             var supportActiveX;
             try {
                 /* global ActiveXObject:true */
-                supportActiveX = !!new ActiveXObject( "Microsoft.XMLHTTP" );
-            } catch( e ) {
+                supportActiveX = !!new ActiveXObject("Microsoft.XMLHTTP");
+            } catch (e) {
                 supportActiveX = false;
             }
 
-            if ( supportActiveX ) {
-                if ( window.XMLHttpRequest ) {
-                    $.createAjaxRequest = function( local ) {
-                        if ( local ) {
-                            return new ActiveXObject( "Microsoft.XMLHTTP" );
+            if (supportActiveX) {
+                if (window.XMLHttpRequest) {
+                    $.createAjaxRequest = function (local) {
+                        if (local) {
+                            return new ActiveXObject("Microsoft.XMLHTTP");
                         }
                         return new XMLHttpRequest();
                     };
                 } else {
-                    $.createAjaxRequest = function() {
-                        return new ActiveXObject( "Microsoft.XMLHTTP" );
+                    $.createAjaxRequest = function () {
+                        return new ActiveXObject("Microsoft.XMLHTTP");
                     };
                 }
-            } else if ( window.XMLHttpRequest ) {
-                $.createAjaxRequest = function() {
+            } else if (window.XMLHttpRequest) {
+                $.createAjaxRequest = function () {
                     return new XMLHttpRequest();
                 };
             } else {
-                throw new Error( "Browser doesn't support XMLHttpRequest." );
+                throw new Error("Browser doesn't support XMLHttpRequest.");
             }
-            return $.createAjaxRequest( local );
+            return $.createAjaxRequest(local);
         },
 
         /**
@@ -2141,14 +2142,14 @@ function OpenSeadragon( options ){
          * @throws {Error}
          * @returns {XMLHttpRequest}
          */
-        makeAjaxRequest: function( url, onSuccess, onError ) {
+        makeAjaxRequest: function (url, onSuccess, onError) {
             var withCredentials;
             var headers;
             var responseType;
 
             // Note that our preferred API is that you pass in a single object; the named
             // arguments are for legacy support.
-            if( $.isPlainObject( url ) ){
+            if ($.isPlainObject(url)) {
                 onSuccess = url.success;
                 onError = url.error;
                 withCredentials = url.withCredentials;
@@ -2157,37 +2158,37 @@ function OpenSeadragon( options ){
                 url = url.url;
             }
 
-            var protocol = $.getUrlProtocol( url );
-            var request = $.createAjaxRequest( protocol === "file:" );
+            var protocol = $.getUrlProtocol(url);
+            var request = $.createAjaxRequest(protocol === "file:");
 
-            if ( !$.isFunction( onSuccess ) ) {
-                throw new Error( "makeAjaxRequest requires a success callback" );
+            if (!$.isFunction(onSuccess)) {
+                throw new Error("makeAjaxRequest requires a success callback");
             }
 
-            request.onreadystatechange = function() {
+            request.onreadystatechange = function () {
                 // 4 = DONE (https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Properties)
-                if ( request.readyState == 4 ) {
-                    request.onreadystatechange = function(){};
+                if (request.readyState == 4) {
+                    request.onreadystatechange = function () { };
 
                     // With protocols other than http/https, a successful request status is in
                     // the 200's on Firefox and 0 on other browsers
-                    if ( (request.status >= 200 && request.status < 300) ||
-                        ( request.status === 0 &&
-                          protocol !== "http:" &&
-                          protocol !== "https:" )) {
-                        onSuccess( request );
+                    if ((request.status >= 200 && request.status < 300) ||
+                        (request.status === 0 &&
+                            protocol !== "http:" &&
+                            protocol !== "https:")) {
+                        onSuccess(request);
                     } else {
-                        $.console.log( "AJAX request returned %d: %s", request.status, url );
+                        $.console.log("AJAX request returned %d: %s", request.status, url);
 
-                        if ( $.isFunction( onError ) ) {
-                            onError( request );
+                        if ($.isFunction(onError)) {
+                            onError(request);
                         }
                     }
                 }
             };
 
             try {
-                request.open( "GET", url, true );
+                request.open("GET", url, true);
 
                 if (responseType) {
                     request.responseType = responseType;
@@ -2221,19 +2222,19 @@ function OpenSeadragon( options ){
                     error messages are localized.
                 */
                 var oldIE = $.Browser.vendor == $.BROWSERS.IE && $.Browser.version < 10;
-                if ( oldIE && typeof( e.number ) != "undefined" && e.number == -2147024891 ) {
+                if (oldIE && typeof (e.number) != "undefined" && e.number == -2147024891) {
                     msg += "\nSee http://msdn.microsoft.com/en-us/library/ms537505(v=vs.85).aspx#xdomain";
                 }
 
-                $.console.log( "%s while making AJAX request: %s", e.name, msg );
+                $.console.log("%s while making AJAX request: %s", e.name, msg);
 
-                request.onreadystatechange = function(){};
+                request.onreadystatechange = function () { };
 
                 if (window.XDomainRequest) { // IE9 or IE8 might as well try to use XDomainRequest
                     var xdr = new XDomainRequest();
                     if (xdr) {
                         xdr.onload = function (e) {
-                            if ( $.isFunction( onSuccess ) ) {
+                            if ($.isFunction(onSuccess)) {
                                 onSuccess({ // Faking an xhr object
                                     responseText: xdr.responseText,
                                     status: 200, // XDomainRequest doesn't support status codes, so we just fake one! :/
@@ -2254,14 +2255,14 @@ function OpenSeadragon( options ){
                             xdr.open('GET', url);
                             xdr.send();
                         } catch (e2) {
-                            if ( $.isFunction( onError ) ) {
-                                onError( request, e );
+                            if ($.isFunction(onError)) {
+                                onError(request, e);
                             }
                         }
                     }
                 } else {
-                    if ( $.isFunction( onError ) ) {
-                        onError( request, e );
+                    if ($.isFunction(onError)) {
+                        onError(request, e);
                     }
                 }
             }
@@ -2280,62 +2281,62 @@ function OpenSeadragon( options ){
          * @param {String} [options.callbackName=] The name of the callback to
          *      request the jsonp provider with.
          */
-        jsonp: function( options ){
+        jsonp: function (options) {
             var script,
-                url     = options.url,
-                head    = document.head ||
-                    document.getElementsByTagName( "head" )[ 0 ] ||
+                url = options.url,
+                head = document.head ||
+                    document.getElementsByTagName("head")[0] ||
                     document.documentElement,
                 jsonpCallback = options.callbackName || 'openseadragon' + $.now(),
-                previous      = window[ jsonpCallback ],
-                replace       = "$1" + jsonpCallback + "$2",
+                previous = window[jsonpCallback],
+                replace = "$1" + jsonpCallback + "$2",
                 callbackParam = options.param || 'callback',
-                callback      = options.callback;
+                callback = options.callback;
 
-            url = url.replace( /(\=)\?(&|$)|\?\?/i, replace );
+            url = url.replace(/(\=)\?(&|$)|\?\?/i, replace);
             // Add callback manually
-            url += (/\?/.test( url ) ? "&" : "?") + callbackParam + "=" + jsonpCallback;
+            url += (/\?/.test(url) ? "&" : "?") + callbackParam + "=" + jsonpCallback;
 
             // Install callback
-            window[ jsonpCallback ] = function( response ) {
-                if ( !previous ){
-                    try{
-                        delete window[ jsonpCallback ];
-                    }catch(e){
+            window[jsonpCallback] = function (response) {
+                if (!previous) {
+                    try {
+                        delete window[jsonpCallback];
+                    } catch (e) {
                         //swallow
                     }
                 } else {
-                    window[ jsonpCallback ] = previous;
+                    window[jsonpCallback] = previous;
                 }
-                if( callback && $.isFunction( callback ) ){
-                    callback( response );
+                if (callback && $.isFunction(callback)) {
+                    callback(response);
                 }
             };
 
-            script = document.createElement( "script" );
+            script = document.createElement("script");
 
             //TODO: having an issue with async info requests
-            if( undefined !== options.async || false !== options.async ){
+            if (undefined !== options.async || false !== options.async) {
                 script.async = "async";
             }
 
-            if ( options.scriptCharset ) {
+            if (options.scriptCharset) {
                 script.charset = options.scriptCharset;
             }
 
             script.src = url;
 
             // Attach handlers for all browsers
-            script.onload = script.onreadystatechange = function( _, isAbort ) {
+            script.onload = script.onreadystatechange = function (_, isAbort) {
 
-                if ( isAbort || !script.readyState || /loaded|complete/.test( script.readyState ) ) {
+                if (isAbort || !script.readyState || /loaded|complete/.test(script.readyState)) {
 
                     // Handle memory leak in IE
                     script.onload = script.onreadystatechange = null;
 
                     // Remove the script
-                    if ( head && script.parentNode ) {
-                        head.removeChild( script );
+                    if (head && script.parentNode) {
+                        head.removeChild(script);
                     }
 
                     // Dereference the script
@@ -2344,7 +2345,7 @@ function OpenSeadragon( options ){
             };
             // Use insertBefore instead of appendChild  to circumvent an IE6 bug.
             // This arises when a base node is used (#2709 and #4378).
-            head.insertBefore( script, head.firstChild );
+            head.insertBefore(script, head.firstChild);
 
         },
 
@@ -2354,7 +2355,7 @@ function OpenSeadragon( options ){
          * @function
          * @deprecated use {@link OpenSeadragon.Viewer#open}
          */
-        createFromDZI: function() {
+        createFromDZI: function () {
             throw "OpenSeadragon.createFromDZI is deprecated, use Viewer.open.";
         },
 
@@ -2364,34 +2365,34 @@ function OpenSeadragon( options ){
          * @param {String} string
          * @returns {Document}
          */
-        parseXml: function( string ) {
-            if ( window.DOMParser ) {
+        parseXml: function (string) {
+            if (window.DOMParser) {
 
-                $.parseXml = function( string ) {
+                $.parseXml = function (string) {
                     var xmlDoc = null,
                         parser;
 
                     parser = new DOMParser();
-                    xmlDoc = parser.parseFromString( string, "text/xml" );
+                    xmlDoc = parser.parseFromString(string, "text/xml");
                     return xmlDoc;
                 };
 
-            } else if ( window.ActiveXObject ) {
+            } else if (window.ActiveXObject) {
 
-                $.parseXml = function( string ) {
+                $.parseXml = function (string) {
                     var xmlDoc = null;
 
-                    xmlDoc = new ActiveXObject( "Microsoft.XMLDOM" );
+                    xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
                     xmlDoc.async = false;
-                    xmlDoc.loadXML( string );
+                    xmlDoc.loadXML(string);
                     return xmlDoc;
                 };
 
             } else {
-                throw new Error( "Browser doesn't support XML DOM." );
+                throw new Error("Browser doesn't support XML DOM.");
             }
 
-            return $.parseXml( string );
+            return $.parseXml(string);
         },
 
         /**
@@ -2400,12 +2401,12 @@ function OpenSeadragon( options ){
          * @param {String} string
          * @returns {Object}
          */
-        parseJSON: function(string) {
+        parseJSON: function (string) {
             if (window.JSON && window.JSON.parse) {
                 $.parseJSON = window.JSON.parse;
             } else {
                 // Should only be used by IE8 in non standards mode
-                $.parseJSON = function(string) {
+                $.parseJSON = function (string) {
                     /*jshint evil:true*/
                     //eslint-disable-next-line no-eval
                     return eval('(' + string + ')');
@@ -2421,10 +2422,10 @@ function OpenSeadragon( options ){
          * @param {String} [extension]
          * @returns {Boolean}
          */
-        imageFormatSupported: function( extension ) {
+        imageFormatSupported: function (extension) {
             extension = extension ? extension : "";
             // eslint-disable-next-line no-use-before-define
-            return !!FILEFORMATS[ extension.toLowerCase() ];
+            return !!FILEFORMATS[extension.toLowerCase()];
         }
 
     });
@@ -2441,92 +2442,92 @@ function OpenSeadragon( options ){
      * @property {Boolean} alpha - Does the browser support image alpha transparency.
      */
     $.Browser = {
-        vendor:     $.BROWSERS.UNKNOWN,
-        version:    0,
-        alpha:      true
+        vendor: $.BROWSERS.UNKNOWN,
+        version: 0,
+        alpha: true
     };
 
 
     var FILEFORMATS = {
-            "bmp":  false,
-            "jpeg": true,
-            "jpg":  true,
-            "png":  true,
-            "tif":  false,
-            "wdp":  false
-        },
+        "bmp": false,
+        "jpeg": true,
+        "jpg": true,
+        "png": true,
+        "tif": false,
+        "wdp": false
+    },
         URLPARAMS = {};
 
-    (function() {
+    (function () {
         //A small auto-executing routine to determine the browser vendor,
         //version and supporting feature sets.
         var ver = navigator.appVersion,
-            ua  = navigator.userAgent,
+            ua = navigator.userAgent,
             regex;
 
         //console.error( 'appName: ' + navigator.appName );
         //console.error( 'appVersion: ' + navigator.appVersion );
         //console.error( 'userAgent: ' + navigator.userAgent );
 
-        switch( navigator.appName ){
+        switch (navigator.appName) {
             case "Microsoft Internet Explorer":
-                if( !!window.attachEvent &&
-                    !!window.ActiveXObject ) {
+                if (!!window.attachEvent &&
+                    !!window.ActiveXObject) {
 
                     $.Browser.vendor = $.BROWSERS.IE;
                     $.Browser.version = parseFloat(
                         ua.substring(
-                            ua.indexOf( "MSIE" ) + 5,
-                            ua.indexOf( ";", ua.indexOf( "MSIE" ) ) )
-                        );
+                            ua.indexOf("MSIE") + 5,
+                            ua.indexOf(";", ua.indexOf("MSIE")))
+                    );
                 }
                 break;
             case "Netscape":
                 if (window.addEventListener) {
-                    if ( ua.indexOf( "Firefox" ) >= 0 ) {
+                    if (ua.indexOf("Firefox") >= 0) {
                         $.Browser.vendor = $.BROWSERS.FIREFOX;
                         $.Browser.version = parseFloat(
-                            ua.substring( ua.indexOf( "Firefox" ) + 8 )
+                            ua.substring(ua.indexOf("Firefox") + 8)
                         );
-                    } else if ( ua.indexOf( "Safari" ) >= 0 ) {
-                        $.Browser.vendor = ua.indexOf( "Chrome" ) >= 0 ?
+                    } else if (ua.indexOf("Safari") >= 0) {
+                        $.Browser.vendor = ua.indexOf("Chrome") >= 0 ?
                             $.BROWSERS.CHROME :
                             $.BROWSERS.SAFARI;
                         $.Browser.version = parseFloat(
                             ua.substring(
-                                ua.substring( 0, ua.indexOf( "Safari" ) ).lastIndexOf( "/" ) + 1,
-                                ua.indexOf( "Safari" )
+                                ua.substring(0, ua.indexOf("Safari")).lastIndexOf("/") + 1,
+                                ua.indexOf("Safari")
                             )
                         );
                     } else {
-                        regex = new RegExp( "Trident/.*rv:([0-9]{1,}[.0-9]{0,})");
-                        if ( regex.exec( ua ) !== null ) {
+                        regex = new RegExp("Trident/.*rv:([0-9]{1,}[.0-9]{0,})");
+                        if (regex.exec(ua) !== null) {
                             $.Browser.vendor = $.BROWSERS.IE;
-                            $.Browser.version = parseFloat( RegExp.$1 );
+                            $.Browser.version = parseFloat(RegExp.$1);
                         }
                     }
                 }
                 break;
             case "Opera":
                 $.Browser.vendor = $.BROWSERS.OPERA;
-                $.Browser.version = parseFloat( ver );
+                $.Browser.version = parseFloat(ver);
                 break;
         }
 
-            // ignore '?' portion of query string
-        var query = window.location.search.substring( 1 ),
+        // ignore '?' portion of query string
+        var query = window.location.search.substring(1),
             parts = query.split('&'),
             part,
             sep,
             i;
 
-        for ( i = 0; i < parts.length; i++ ) {
-            part = parts[ i ];
-            sep  = part.indexOf( '=' );
+        for (i = 0; i < parts.length; i++) {
+            part = parts[i];
+            sep = part.indexOf('=');
 
-            if ( sep > 0 ) {
-                URLPARAMS[ part.substring( 0, sep ) ] =
-                    decodeURIComponent( part.substring( sep + 1 ) );
+            if (sep > 0) {
+                URLPARAMS[part.substring(0, sep)] =
+                    decodeURIComponent(part.substring(sep + 1));
             }
         }
 
@@ -2561,16 +2562,16 @@ function OpenSeadragon( options ){
      * @static
      * @private
      */
-    var nullfunction = function( msg ){
-            //document.location.hash = msg;
-        };
+    var nullfunction = function (msg) {
+        //document.location.hash = msg;
+    };
 
     $.console = window.console || {
-        log:    nullfunction,
-        debug:  nullfunction,
-        info:   nullfunction,
-        warn:   nullfunction,
-        error:  nullfunction,
+        log: nullfunction,
+        debug: nullfunction,
+        info: nullfunction,
+        warn: nullfunction,
+        error: nullfunction,
         assert: nullfunction
     };
 
@@ -2578,7 +2579,7 @@ function OpenSeadragon( options ){
     // Adding support for HTML5's requestAnimationFrame as suggested by acdha.
     // Implementation taken from matt synder's post here:
     // http://mattsnider.com/cross-browser-and-legacy-supported-requestframeanimation/
-    (function( w ) {
+    (function (w) {
 
         // most browsers have an implementation
         var requestAnimationFrame = w.requestAnimationFrame ||
@@ -2592,14 +2593,14 @@ function OpenSeadragon( options ){
             w.msCancelAnimationFrame;
 
         // polyfill, when necessary
-        if ( requestAnimationFrame && cancelAnimationFrame ) {
+        if (requestAnimationFrame && cancelAnimationFrame) {
             // We can't assign these window methods directly to $ because they
             // expect their "this" to be "window", so we call them in wrappers.
-            $.requestAnimationFrame = function(){
-                return requestAnimationFrame.apply( w, arguments );
+            $.requestAnimationFrame = function () {
+                return requestAnimationFrame.apply(w, arguments);
             };
-            $.cancelAnimationFrame = function(){
-                return cancelAnimationFrame.apply( w, arguments );
+            $.cancelAnimationFrame = function () {
+                return cancelAnimationFrame.apply(w, arguments);
             };
         } else {
             var aAnimQueue = [],
@@ -2608,12 +2609,12 @@ function OpenSeadragon( options ){
                 iIntervalId;
 
             // create a mock requestAnimationFrame function
-            $.requestAnimationFrame = function( callback ) {
-                aAnimQueue.push( [ ++iRequestId, callback ] );
+            $.requestAnimationFrame = function (callback) {
+                aAnimQueue.push([++iRequestId, callback]);
 
-                if ( !iIntervalId ) {
-                    iIntervalId = setInterval( function() {
-                        if ( aAnimQueue.length ) {
+                if (!iIntervalId) {
+                    iIntervalId = setInterval(function () {
+                        if (aAnimQueue.length) {
                             var time = $.now();
                             // Process all of the currently outstanding frame
                             // requests, but none that get added during the
@@ -2623,12 +2624,12 @@ function OpenSeadragon( options ){
                             var temp = processing;
                             processing = aAnimQueue;
                             aAnimQueue = temp;
-                            while ( processing.length ) {
-                                processing.shift()[ 1 ]( time );
+                            while (processing.length) {
+                                processing.shift()[1](time);
                             }
                         } else {
                             // don't continue the interval, if unnecessary
-                            clearInterval( iIntervalId );
+                            clearInterval(iIntervalId);
                             iIntervalId = undefined;
                         }
                     }, 1000 / 50);  // estimating support for 50 frames per second
@@ -2638,12 +2639,12 @@ function OpenSeadragon( options ){
             };
 
             // create a mock cancelAnimationFrame function
-            $.cancelAnimationFrame = function( requestId ) {
+            $.cancelAnimationFrame = function (requestId) {
                 // find the request ID and remove it
                 var i, j;
-                for ( i = 0, j = aAnimQueue.length; i < j; i += 1 ) {
-                    if ( aAnimQueue[ i ][ 0 ] === requestId ) {
-                        aAnimQueue.splice( i, 1 );
+                for (i = 0, j = aAnimQueue.length; i < j; i += 1) {
+                    if (aAnimQueue[i][0] === requestId) {
+                        aAnimQueue.splice(i, 1);
                         return;
                     }
                 }
@@ -2651,15 +2652,15 @@ function OpenSeadragon( options ){
                 // If it's not in the queue, it may be in the set we're currently
                 // processing (if cancelAnimationFrame is called from within a
                 // requestAnimationFrame callback).
-                for ( i = 0, j = processing.length; i < j; i += 1 ) {
-                    if ( processing[ i ][ 0 ] === requestId ) {
-                        processing.splice( i, 1 );
+                for (i = 0, j = processing.length; i < j; i += 1) {
+                    if (processing[i][0] === requestId) {
+                        processing.splice(i, 1);
                         return;
                     }
                 }
             };
         }
-    })( window );
+    })(window);
 
     /**
      * @private
@@ -2669,8 +2670,8 @@ function OpenSeadragon( options ){
      * @param {Boolean} [isFixed]
      * @returns {Element}
      */
-    function getOffsetParent( element, isFixed ) {
-        if ( isFixed && element != document.body ) {
+    function getOffsetParent(element, isFixed) {
+        if (isFixed && element != document.body) {
             return document.body;
         } else {
             return element.offsetParent;

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1157,7 +1157,8 @@ function OpenSeadragon(options) {
             maxImageCacheCount: 200,
             timeout: 30000,
             useCanvas: true,  // Use canvas element for drawing if available
-            refetchFailedTiles: false,
+            tileRetryMax: 0,
+            tileRetryDelay: 2500,
 
             //INTERFACE RESOURCE SETTINGS
             prefixUrl: "/images/",

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -378,7 +378,8 @@
         this.imageLoader = new $.ImageLoader({
             jobLimit: this.imageLoaderLimit,
             timeout: options.timeout,
-            refetchFailedTiles: this.refetchFailedTiles
+            tileRetryMax: this.tileRetryMax,
+            tileRetryDelay: this.tileRetryDelay,
         });
 
         // Create the tile cache

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -32,3396 +32,3397 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-(function( $ ){
+(function ($) {
 
-// dictionary from hash to private properties
-var THIS = {};
-var nextHash = 1;
+    // dictionary from hash to private properties
+    var THIS = {};
+    var nextHash = 1;
 
-/**
- *
- * The main point of entry into creating a zoomable image on the page.<br>
- * <br>
- * We have provided an idiomatic javascript constructor which takes
- * a single object, but still support the legacy positional arguments.<br>
- * <br>
- * The options below are given in order that they appeared in the constructor
- * as arguments and we translate a positional call into an idiomatic call.<br>
- * <br>
- * To create a viewer, you can use either of this methods:<br>
- * <ul>
- * <li><code>var viewer = new OpenSeadragon.Viewer(options);</code></li>
- * <li><code>var viewer = OpenSeadragon(options);</code></li>
- * </ul>
- * @class Viewer
- * @classdesc The main OpenSeadragon viewer class.
- *
- * @memberof OpenSeadragon
- * @extends OpenSeadragon.EventSource
- * @extends OpenSeadragon.ControlDock
- * @param {OpenSeadragon.Options} options - Viewer options.
- *
- **/
-$.Viewer = function( options ) {
+    /**
+     *
+     * The main point of entry into creating a zoomable image on the page.<br>
+     * <br>
+     * We have provided an idiomatic javascript constructor which takes
+     * a single object, but still support the legacy positional arguments.<br>
+     * <br>
+     * The options below are given in order that they appeared in the constructor
+     * as arguments and we translate a positional call into an idiomatic call.<br>
+     * <br>
+     * To create a viewer, you can use either of this methods:<br>
+     * <ul>
+     * <li><code>var viewer = new OpenSeadragon.Viewer(options);</code></li>
+     * <li><code>var viewer = OpenSeadragon(options);</code></li>
+     * </ul>
+     * @class Viewer
+     * @classdesc The main OpenSeadragon viewer class.
+     *
+     * @memberof OpenSeadragon
+     * @extends OpenSeadragon.EventSource
+     * @extends OpenSeadragon.ControlDock
+     * @param {OpenSeadragon.Options} options - Viewer options.
+     *
+     **/
+    $.Viewer = function (options) {
 
-    var args  = arguments,
-        _this = this,
-        i;
+        var args = arguments,
+            _this = this,
+            i;
 
 
-    //backward compatibility for positional args while prefering more
-    //idiomatic javascript options object as the only argument
-    if( !$.isPlainObject( options ) ){
-        options = {
-            id:                 args[ 0 ],
-            xmlPath:            args.length > 1 ? args[ 1 ] : undefined,
-            prefixUrl:          args.length > 2 ? args[ 2 ] : undefined,
-            controls:           args.length > 3 ? args[ 3 ] : undefined,
-            overlays:           args.length > 4 ? args[ 4 ] : undefined
+        //backward compatibility for positional args while prefering more
+        //idiomatic javascript options object as the only argument
+        if (!$.isPlainObject(options)) {
+            options = {
+                id: args[0],
+                xmlPath: args.length > 1 ? args[1] : undefined,
+                prefixUrl: args.length > 2 ? args[2] : undefined,
+                controls: args.length > 3 ? args[3] : undefined,
+                overlays: args.length > 4 ? args[4] : undefined
+            };
+        }
+
+        //options.config and the general config argument are deprecated
+        //in favor of the more direct specification of optional settings
+        //being pass directly on the options object
+        if (options.config) {
+            $.extend(true, options, options.config);
+            delete options.config;
+        }
+
+        //Public properties
+        //Allow the options object to override global defaults
+        $.extend(true, this, {
+
+            //internal state and dom identifiers
+            id: options.id,
+            hash: options.hash || nextHash++,
+            /**
+             * Index for page to be shown first next time open() is called (only used in sequenceMode).
+             * @member {Number} initialPage
+             * @memberof OpenSeadragon.Viewer#
+             */
+            initialPage: 0,
+
+            //dom nodes
+            /**
+             * The parent element of this Viewer instance, passed in when the Viewer was created.
+             * @member {Element} element
+             * @memberof OpenSeadragon.Viewer#
+             */
+            element: null,
+            /**
+             * A &lt;div&gt; element (provided by {@link OpenSeadragon.ControlDock}), the base element of this Viewer instance.<br><br>
+             * Child element of {@link OpenSeadragon.Viewer#element}.
+             * @member {Element} container
+             * @memberof OpenSeadragon.Viewer#
+             */
+            container: null,
+            /**
+             * A &lt;div&gt; element, the element where user-input events are handled for panning and zooming.<br><br>
+             * Child element of {@link OpenSeadragon.Viewer#container},
+             * positioned on top of {@link OpenSeadragon.Viewer#keyboardCommandArea}.<br><br>
+             * The parent of {@link OpenSeadragon.Drawer#canvas} instances.
+             * @member {Element} canvas
+             * @memberof OpenSeadragon.Viewer#
+             */
+            canvas: null,
+
+            // Overlays list. An overlay allows to add html on top of the viewer.
+            overlays: [],
+            // Container inside the canvas where overlays are drawn.
+            overlaysContainer: null,
+
+            //private state properties
+            previousBody: [],
+
+            //This was originally initialized in the constructor and so could never
+            //have anything in it.  now it can because we allow it to be specified
+            //in the options and is only empty by default if not specified. Also
+            //this array was returned from get_controls which I find confusing
+            //since this object has a controls property which is treated in other
+            //functions like clearControls.  I'm removing the accessors.
+            customControls: [],
+
+            //These are originally not part options but declared as members
+            //in initialize.  It's still considered idiomatic to put them here
+            source: null,
+            /**
+             * Handles rendering of tiles in the viewer. Created for each TileSource opened.
+             * @member {OpenSeadragon.Drawer} drawer
+             * @memberof OpenSeadragon.Viewer#
+             */
+            drawer: null,
+            world: null,
+            /**
+             * Handles coordinate-related functionality - zoom, pan, rotation, etc. Created for each TileSource opened.
+             * @member {OpenSeadragon.Viewport} viewport
+             * @memberof OpenSeadragon.Viewer#
+             */
+            viewport: null,
+            /**
+             * @member {OpenSeadragon.Navigator} navigator
+             * @memberof OpenSeadragon.Viewer#
+             */
+            navigator: null,
+
+            //A collection viewport is a separate viewport used to provide
+            //simultaneous rendering of sets of tiles
+            collectionViewport: null,
+            collectionDrawer: null,
+
+            //UI image resources
+            //TODO: rename navImages to uiImages
+            navImages: null,
+
+            //interface button controls
+            buttons: null,
+
+            //TODO: this is defunct so safely remove it
+            profiler: null
+
+        }, $.DEFAULT_SETTINGS, options);
+
+        if (typeof (this.hash) === "undefined") {
+            throw new Error("A hash must be defined, either by specifying options.id or options.hash.");
+        }
+        if (typeof (THIS[this.hash]) !== "undefined") {
+            // We don't want to throw an error here, as the user might have discarded
+            // the previous viewer with the same hash and now want to recreate it.
+            $.console.warn("Hash " + this.hash + " has already been used.");
+        }
+
+        //Private state properties
+        THIS[this.hash] = {
+            "fsBoundsDelta": new $.Point(1, 1),
+            "prevContainerSize": null,
+            "animating": false,
+            "forceRedraw": false,
+            "mouseInside": false,
+            "group": null,
+            // whether we should be continuously zooming
+            "zooming": false,
+            // how much we should be continuously zooming by
+            "zoomFactor": null,
+            "lastZoomTime": null,
+            "fullPage": false,
+            "onfullscreenchange": null
         };
-    }
 
-    //options.config and the general config argument are deprecated
-    //in favor of the more direct specification of optional settings
-    //being pass directly on the options object
-    if ( options.config ){
-        $.extend( true, options, options.config );
-        delete options.config;
-    }
+        this._sequenceIndex = 0;
+        this._firstOpen = true;
+        this._updateRequestId = null;
+        this._loadQueue = [];
+        this.currentOverlays = [];
 
-    //Public properties
-    //Allow the options object to override global defaults
-    $.extend( true, this, {
+        this._lastScrollTime = $.now(); // variable used to help normalize the scroll event speed of different devices
 
-        //internal state and dom identifiers
-        id:             options.id,
-        hash:           options.hash || nextHash++,
-        /**
-         * Index for page to be shown first next time open() is called (only used in sequenceMode).
-         * @member {Number} initialPage
-         * @memberof OpenSeadragon.Viewer#
-         */
-        initialPage:    0,
+        //Inherit some behaviors and properties
+        $.EventSource.call(this);
 
-        //dom nodes
-        /**
-         * The parent element of this Viewer instance, passed in when the Viewer was created.
-         * @member {Element} element
-         * @memberof OpenSeadragon.Viewer#
-         */
-        element:        null,
-        /**
-         * A &lt;div&gt; element (provided by {@link OpenSeadragon.ControlDock}), the base element of this Viewer instance.<br><br>
-         * Child element of {@link OpenSeadragon.Viewer#element}.
-         * @member {Element} container
-         * @memberof OpenSeadragon.Viewer#
-         */
-        container:      null,
-        /**
-         * A &lt;div&gt; element, the element where user-input events are handled for panning and zooming.<br><br>
-         * Child element of {@link OpenSeadragon.Viewer#container},
-         * positioned on top of {@link OpenSeadragon.Viewer#keyboardCommandArea}.<br><br>
-         * The parent of {@link OpenSeadragon.Drawer#canvas} instances.
-         * @member {Element} canvas
-         * @memberof OpenSeadragon.Viewer#
-         */
-        canvas:         null,
+        this.addHandler('open-failed', function (event) {
+            var msg = $.getString("Errors.OpenFailed", event.eventSource, event.message);
+            _this._showMessage(msg);
+        });
 
-        // Overlays list. An overlay allows to add html on top of the viewer.
-        overlays:           [],
-        // Container inside the canvas where overlays are drawn.
-        overlaysContainer:  null,
+        $.ControlDock.call(this, options);
 
-        //private state properties
-        previousBody:   [],
+        //Deal with tile sources
+        if (this.xmlPath) {
+            //Deprecated option.  Now it is preferred to use the tileSources option
+            this.tileSources = [this.xmlPath];
+        }
 
-        //This was originally initialized in the constructor and so could never
-        //have anything in it.  now it can because we allow it to be specified
-        //in the options and is only empty by default if not specified. Also
-        //this array was returned from get_controls which I find confusing
-        //since this object has a controls property which is treated in other
-        //functions like clearControls.  I'm removing the accessors.
-        customControls: [],
+        this.element = this.element || document.getElementById(this.id);
+        this.canvas = $.makeNeutralElement("div");
 
-        //These are originally not part options but declared as members
-        //in initialize.  It's still considered idiomatic to put them here
-        source:         null,
-        /**
-         * Handles rendering of tiles in the viewer. Created for each TileSource opened.
-         * @member {OpenSeadragon.Drawer} drawer
-         * @memberof OpenSeadragon.Viewer#
-         */
-        drawer:             null,
-        world:              null,
-        /**
-         * Handles coordinate-related functionality - zoom, pan, rotation, etc. Created for each TileSource opened.
-         * @member {OpenSeadragon.Viewport} viewport
-         * @memberof OpenSeadragon.Viewer#
-         */
-        viewport:       null,
-        /**
-         * @member {OpenSeadragon.Navigator} navigator
-         * @memberof OpenSeadragon.Viewer#
-         */
-        navigator:      null,
+        this.canvas.className = "openseadragon-canvas";
+        (function (style) {
+            style.width = "100%";
+            style.height = "100%";
+            style.overflow = "hidden";
+            style.position = "absolute";
+            style.top = "0px";
+            style.left = "0px";
+        }(this.canvas.style));
+        $.setElementTouchActionNone(this.canvas);
+        if (options.tabIndex !== "") {
+            this.canvas.tabIndex = (options.tabIndex === undefined ? 0 : options.tabIndex);
+        }
 
-        //A collection viewport is a separate viewport used to provide
-        //simultaneous rendering of sets of tiles
-        collectionViewport:     null,
-        collectionDrawer:       null,
+        //the container is created through applying the ControlDock constructor above
+        this.container.className = "openseadragon-container";
+        (function (style) {
+            style.width = "100%";
+            style.height = "100%";
+            style.position = "relative";
+            style.overflow = "hidden";
+            style.left = "0px";
+            style.top = "0px";
+            style.textAlign = "left";  // needed to protect against
+        }(this.container.style));
 
-        //UI image resources
-        //TODO: rename navImages to uiImages
-        navImages:      null,
+        this.container.insertBefore(this.canvas, this.container.firstChild);
+        this.element.appendChild(this.container);
 
-        //interface button controls
-        buttons:        null,
+        //Used for toggling between fullscreen and default container size
+        //TODO: these can be closure private and shared across Viewer
+        //      instances.
+        this.bodyWidth = document.body.style.width;
+        this.bodyHeight = document.body.style.height;
+        this.bodyOverflow = document.body.style.overflow;
+        this.docOverflow = document.documentElement.style.overflow;
 
-        //TODO: this is defunct so safely remove it
-        profiler:       null
+        this.innerTracker = new $.MouseTracker({
+            element: this.canvas,
+            startDisabled: !this.mouseNavEnabled,
+            clickTimeThreshold: this.clickTimeThreshold,
+            clickDistThreshold: this.clickDistThreshold,
+            dblClickTimeThreshold: this.dblClickTimeThreshold,
+            dblClickDistThreshold: this.dblClickDistThreshold,
+            keyDownHandler: $.delegate(this, onCanvasKeyDown),
+            keyHandler: $.delegate(this, onCanvasKeyPress),
+            clickHandler: $.delegate(this, onCanvasClick),
+            dblClickHandler: $.delegate(this, onCanvasDblClick),
+            dragHandler: $.delegate(this, onCanvasDrag),
+            dragEndHandler: $.delegate(this, onCanvasDragEnd),
+            enterHandler: $.delegate(this, onCanvasEnter),
+            exitHandler: $.delegate(this, onCanvasExit),
+            pressHandler: $.delegate(this, onCanvasPress),
+            releaseHandler: $.delegate(this, onCanvasRelease),
+            nonPrimaryPressHandler: $.delegate(this, onCanvasNonPrimaryPress),
+            nonPrimaryReleaseHandler: $.delegate(this, onCanvasNonPrimaryRelease),
+            scrollHandler: $.delegate(this, onCanvasScroll),
+            pinchHandler: $.delegate(this, onCanvasPinch)
+        });
 
-    }, $.DEFAULT_SETTINGS, options );
+        this.outerTracker = new $.MouseTracker({
+            element: this.container,
+            startDisabled: !this.mouseNavEnabled,
+            clickTimeThreshold: this.clickTimeThreshold,
+            clickDistThreshold: this.clickDistThreshold,
+            dblClickTimeThreshold: this.dblClickTimeThreshold,
+            dblClickDistThreshold: this.dblClickDistThreshold,
+            enterHandler: $.delegate(this, onContainerEnter),
+            exitHandler: $.delegate(this, onContainerExit)
+        });
 
-    if ( typeof( this.hash) === "undefined" ) {
-        throw new Error("A hash must be defined, either by specifying options.id or options.hash.");
-    }
-    if ( typeof( THIS[ this.hash ] ) !== "undefined" ) {
-        // We don't want to throw an error here, as the user might have discarded
-        // the previous viewer with the same hash and now want to recreate it.
-        $.console.warn("Hash " + this.hash + " has already been used.");
-    }
+        if (this.toolbar) {
+            this.toolbar = new $.ControlDock({ element: this.toolbar });
+        }
 
-    //Private state properties
-    THIS[ this.hash ] = {
-        "fsBoundsDelta":     new $.Point( 1, 1 ),
-        "prevContainerSize": null,
-        "animating":         false,
-        "forceRedraw":       false,
-        "mouseInside":       false,
-        "group":             null,
-        // whether we should be continuously zooming
-        "zooming":           false,
-        // how much we should be continuously zooming by
-        "zoomFactor":        null,
-        "lastZoomTime":      null,
-        "fullPage":          false,
-        "onfullscreenchange": null
+        this.bindStandardControls();
+
+        THIS[this.hash].prevContainerSize = _getSafeElemSize(this.container);
+
+        // Create the world
+        this.world = new $.World({
+            viewer: this
+        });
+
+        this.world.addHandler('add-item', function (event) {
+            // For backwards compatibility, we maintain the source property
+            _this.source = _this.world.getItemAt(0).source;
+
+            THIS[_this.hash].forceRedraw = true;
+
+            if (!_this._updateRequestId) {
+                _this._updateRequestId = scheduleUpdate(_this, updateMulti);
+            }
+        });
+
+        this.world.addHandler('remove-item', function (event) {
+            // For backwards compatibility, we maintain the source property
+            if (_this.world.getItemCount()) {
+                _this.source = _this.world.getItemAt(0).source;
+            } else {
+                _this.source = null;
+            }
+
+            THIS[_this.hash].forceRedraw = true;
+        });
+
+        this.world.addHandler('metrics-change', function (event) {
+            if (_this.viewport) {
+                _this.viewport._setContentBounds(_this.world.getHomeBounds(), _this.world.getContentFactor());
+            }
+        });
+
+        this.world.addHandler('item-index-change', function (event) {
+            // For backwards compatibility, we maintain the source property
+            _this.source = _this.world.getItemAt(0).source;
+        });
+
+        // Create the viewport
+        this.viewport = new $.Viewport({
+            containerSize: THIS[this.hash].prevContainerSize,
+            springStiffness: this.springStiffness,
+            animationTime: this.animationTime,
+            minZoomImageRatio: this.minZoomImageRatio,
+            maxZoomPixelRatio: this.maxZoomPixelRatio,
+            visibilityRatio: this.visibilityRatio,
+            wrapHorizontal: this.wrapHorizontal,
+            wrapVertical: this.wrapVertical,
+            defaultZoomLevel: this.defaultZoomLevel,
+            minZoomLevel: this.minZoomLevel,
+            maxZoomLevel: this.maxZoomLevel,
+            viewer: this,
+            degrees: this.degrees,
+            navigatorRotate: this.navigatorRotate,
+            homeFillsViewer: this.homeFillsViewer,
+            margins: this.viewportMargins
+        });
+
+        this.viewport._setContentBounds(this.world.getHomeBounds(), this.world.getContentFactor());
+
+        // Create the image loader
+        this.imageLoader = new $.ImageLoader({
+            jobLimit: this.imageLoaderLimit,
+            timeout: options.timeout,
+            refetchFailedTiles: this.refetchFailedTiles
+        });
+
+        // Create the tile cache
+        this.tileCache = new $.TileCache({
+            maxImageCacheCount: this.maxImageCacheCount
+        });
+
+        // Create the drawer
+        this.drawer = new $.Drawer({
+            viewer: this,
+            viewport: this.viewport,
+            element: this.canvas,
+            debugGridColor: this.debugGridColor
+        });
+
+        // Overlay container
+        this.overlaysContainer = $.makeNeutralElement("div");
+        this.canvas.appendChild(this.overlaysContainer);
+
+        // Now that we have a drawer, see if it supports rotate. If not we need to remove the rotate buttons
+        if (!this.drawer.canRotate()) {
+            // Disable/remove the rotate left/right buttons since they aren't supported
+            if (this.rotateLeft) {
+                i = this.buttons.buttons.indexOf(this.rotateLeft);
+                this.buttons.buttons.splice(i, 1);
+                this.buttons.element.removeChild(this.rotateLeft.element);
+            }
+            if (this.rotateRight) {
+                i = this.buttons.buttons.indexOf(this.rotateRight);
+                this.buttons.buttons.splice(i, 1);
+                this.buttons.element.removeChild(this.rotateRight.element);
+            }
+        }
+
+        //Instantiate a navigator if configured
+        if (this.showNavigator) {
+            this.navigator = new $.Navigator({
+                id: this.navigatorId,
+                position: this.navigatorPosition,
+                sizeRatio: this.navigatorSizeRatio,
+                maintainSizeRatio: this.navigatorMaintainSizeRatio,
+                top: this.navigatorTop,
+                left: this.navigatorLeft,
+                width: this.navigatorWidth,
+                height: this.navigatorHeight,
+                autoResize: this.navigatorAutoResize,
+                autoFade: this.navigatorAutoFade,
+                prefixUrl: this.prefixUrl,
+                viewer: this,
+                navigatorRotate: this.navigatorRotate,
+                crossOriginPolicy: this.crossOriginPolicy
+            });
+        }
+
+        // Sequence mode
+        if (this.sequenceMode) {
+            this.bindSequenceControls();
+        }
+
+        // Open initial tilesources
+        if (this.tileSources) {
+            this.open(this.tileSources);
+        }
+
+        // Add custom controls
+        for (i = 0; i < this.customControls.length; i++) {
+            this.addControl(
+                this.customControls[i].id,
+                { anchor: this.customControls[i].anchor }
+            );
+        }
+
+        // Initial fade out
+        $.requestAnimationFrame(function () {
+            beginControlsAutoHide(_this);
+        });
     };
 
-    this._sequenceIndex = 0;
-    this._firstOpen = true;
-    this._updateRequestId = null;
-    this._loadQueue = [];
-    this.currentOverlays = [];
-
-    this._lastScrollTime = $.now(); // variable used to help normalize the scroll event speed of different devices
-
-    //Inherit some behaviors and properties
-    $.EventSource.call( this );
-
-    this.addHandler( 'open-failed', function ( event ) {
-        var msg = $.getString( "Errors.OpenFailed", event.eventSource, event.message);
-        _this._showMessage( msg );
-    });
-
-    $.ControlDock.call( this, options );
-
-    //Deal with tile sources
-    if (this.xmlPath) {
-        //Deprecated option.  Now it is preferred to use the tileSources option
-        this.tileSources = [ this.xmlPath ];
-    }
-
-    this.element              = this.element || document.getElementById( this.id );
-    this.canvas               = $.makeNeutralElement( "div" );
-
-    this.canvas.className = "openseadragon-canvas";
-    (function( style ){
-        style.width    = "100%";
-        style.height   = "100%";
-        style.overflow = "hidden";
-        style.position = "absolute";
-        style.top      = "0px";
-        style.left     = "0px";
-    }(this.canvas.style));
-    $.setElementTouchActionNone( this.canvas );
-    if (options.tabIndex !== "") {
-        this.canvas.tabIndex = (options.tabIndex === undefined ? 0 : options.tabIndex);
-    }
-
-    //the container is created through applying the ControlDock constructor above
-    this.container.className = "openseadragon-container";
-    (function( style ){
-        style.width     = "100%";
-        style.height    = "100%";
-        style.position  = "relative";
-        style.overflow  = "hidden";
-        style.left      = "0px";
-        style.top       = "0px";
-        style.textAlign = "left";  // needed to protect against
-    }( this.container.style ));
-
-    this.container.insertBefore( this.canvas, this.container.firstChild );
-    this.element.appendChild( this.container );
-
-    //Used for toggling between fullscreen and default container size
-    //TODO: these can be closure private and shared across Viewer
-    //      instances.
-    this.bodyWidth      = document.body.style.width;
-    this.bodyHeight     = document.body.style.height;
-    this.bodyOverflow   = document.body.style.overflow;
-    this.docOverflow    = document.documentElement.style.overflow;
-
-    this.innerTracker = new $.MouseTracker({
-        element:                  this.canvas,
-        startDisabled:            !this.mouseNavEnabled,
-        clickTimeThreshold:       this.clickTimeThreshold,
-        clickDistThreshold:       this.clickDistThreshold,
-        dblClickTimeThreshold:    this.dblClickTimeThreshold,
-        dblClickDistThreshold:    this.dblClickDistThreshold,
-        keyDownHandler:           $.delegate( this, onCanvasKeyDown ),
-        keyHandler:               $.delegate( this, onCanvasKeyPress ),
-        clickHandler:             $.delegate( this, onCanvasClick ),
-        dblClickHandler:          $.delegate( this, onCanvasDblClick ),
-        dragHandler:              $.delegate( this, onCanvasDrag ),
-        dragEndHandler:           $.delegate( this, onCanvasDragEnd ),
-        enterHandler:             $.delegate( this, onCanvasEnter ),
-        exitHandler:              $.delegate( this, onCanvasExit ),
-        pressHandler:             $.delegate( this, onCanvasPress ),
-        releaseHandler:           $.delegate( this, onCanvasRelease ),
-        nonPrimaryPressHandler:   $.delegate( this, onCanvasNonPrimaryPress ),
-        nonPrimaryReleaseHandler: $.delegate( this, onCanvasNonPrimaryRelease ),
-        scrollHandler:            $.delegate( this, onCanvasScroll ),
-        pinchHandler:             $.delegate( this, onCanvasPinch )
-    });
-
-    this.outerTracker = new $.MouseTracker({
-        element:               this.container,
-        startDisabled:         !this.mouseNavEnabled,
-        clickTimeThreshold:    this.clickTimeThreshold,
-        clickDistThreshold:    this.clickDistThreshold,
-        dblClickTimeThreshold: this.dblClickTimeThreshold,
-        dblClickDistThreshold: this.dblClickDistThreshold,
-        enterHandler:          $.delegate( this, onContainerEnter ),
-        exitHandler:           $.delegate( this, onContainerExit )
-    });
-
-    if( this.toolbar ){
-        this.toolbar = new $.ControlDock({ element: this.toolbar });
-    }
-
-    this.bindStandardControls();
-
-    THIS[ this.hash ].prevContainerSize = _getSafeElemSize( this.container );
-
-    // Create the world
-    this.world = new $.World({
-        viewer: this
-    });
-
-    this.world.addHandler('add-item', function(event) {
-        // For backwards compatibility, we maintain the source property
-        _this.source = _this.world.getItemAt(0).source;
-
-        THIS[ _this.hash ].forceRedraw = true;
-
-        if (!_this._updateRequestId) {
-            _this._updateRequestId = scheduleUpdate( _this, updateMulti );
-        }
-    });
-
-    this.world.addHandler('remove-item', function(event) {
-        // For backwards compatibility, we maintain the source property
-        if (_this.world.getItemCount()) {
-            _this.source = _this.world.getItemAt(0).source;
-        } else {
-            _this.source = null;
-        }
-
-        THIS[ _this.hash ].forceRedraw = true;
-    });
-
-    this.world.addHandler('metrics-change', function(event) {
-        if (_this.viewport) {
-            _this.viewport._setContentBounds(_this.world.getHomeBounds(), _this.world.getContentFactor());
-        }
-    });
-
-    this.world.addHandler('item-index-change', function(event) {
-        // For backwards compatibility, we maintain the source property
-        _this.source = _this.world.getItemAt(0).source;
-    });
-
-    // Create the viewport
-    this.viewport = new $.Viewport({
-        containerSize:      THIS[ this.hash ].prevContainerSize,
-        springStiffness:    this.springStiffness,
-        animationTime:      this.animationTime,
-        minZoomImageRatio:  this.minZoomImageRatio,
-        maxZoomPixelRatio:  this.maxZoomPixelRatio,
-        visibilityRatio:    this.visibilityRatio,
-        wrapHorizontal:     this.wrapHorizontal,
-        wrapVertical:       this.wrapVertical,
-        defaultZoomLevel:   this.defaultZoomLevel,
-        minZoomLevel:       this.minZoomLevel,
-        maxZoomLevel:       this.maxZoomLevel,
-        viewer:             this,
-        degrees:            this.degrees,
-        navigatorRotate:    this.navigatorRotate,
-        homeFillsViewer:    this.homeFillsViewer,
-        margins:            this.viewportMargins
-    });
-
-    this.viewport._setContentBounds(this.world.getHomeBounds(), this.world.getContentFactor());
-
-    // Create the image loader
-    this.imageLoader = new $.ImageLoader({
-        jobLimit: this.imageLoaderLimit,
-        timeout: options.timeout
-    });
-
-    // Create the tile cache
-    this.tileCache = new $.TileCache({
-        maxImageCacheCount: this.maxImageCacheCount
-    });
-
-    // Create the drawer
-    this.drawer = new $.Drawer({
-        viewer:             this,
-        viewport:           this.viewport,
-        element:            this.canvas,
-        debugGridColor:     this.debugGridColor
-    });
-
-    // Overlay container
-    this.overlaysContainer    = $.makeNeutralElement( "div" );
-    this.canvas.appendChild( this.overlaysContainer );
-
-    // Now that we have a drawer, see if it supports rotate. If not we need to remove the rotate buttons
-    if (!this.drawer.canRotate()) {
-        // Disable/remove the rotate left/right buttons since they aren't supported
-        if (this.rotateLeft) {
-            i = this.buttons.buttons.indexOf(this.rotateLeft);
-            this.buttons.buttons.splice(i, 1);
-            this.buttons.element.removeChild(this.rotateLeft.element);
-        }
-        if (this.rotateRight) {
-            i = this.buttons.buttons.indexOf(this.rotateRight);
-            this.buttons.buttons.splice(i, 1);
-            this.buttons.element.removeChild(this.rotateRight.element);
-        }
-    }
-
-    //Instantiate a navigator if configured
-    if ( this.showNavigator){
-        this.navigator = new $.Navigator({
-            id:                this.navigatorId,
-            position:          this.navigatorPosition,
-            sizeRatio:         this.navigatorSizeRatio,
-            maintainSizeRatio: this.navigatorMaintainSizeRatio,
-            top:               this.navigatorTop,
-            left:              this.navigatorLeft,
-            width:             this.navigatorWidth,
-            height:            this.navigatorHeight,
-            autoResize:        this.navigatorAutoResize,
-            autoFade:          this.navigatorAutoFade,
-            prefixUrl:         this.prefixUrl,
-            viewer:            this,
-            navigatorRotate:   this.navigatorRotate,
-            crossOriginPolicy: this.crossOriginPolicy
-        });
-    }
-
-    // Sequence mode
-    if (this.sequenceMode) {
-        this.bindSequenceControls();
-    }
-
-    // Open initial tilesources
-    if (this.tileSources) {
-        this.open( this.tileSources );
-    }
-
-    // Add custom controls
-    for ( i = 0; i < this.customControls.length; i++ ) {
-        this.addControl(
-            this.customControls[ i ].id,
-            {anchor: this.customControls[ i ].anchor}
-        );
-    }
-
-    // Initial fade out
-    $.requestAnimationFrame( function(){
-        beginControlsAutoHide( _this );
-    } );
-};
-
-$.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, /** @lends OpenSeadragon.Viewer.prototype */{
+    $.extend($.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, /** @lends OpenSeadragon.Viewer.prototype */{
 
 
-    /**
-     * @function
-     * @return {Boolean}
-     */
-    isOpen: function () {
-        return !!this.world.getItemCount();
-    },
+        /**
+         * @function
+         * @return {Boolean}
+         */
+        isOpen: function () {
+            return !!this.world.getItemCount();
+        },
 
-    // deprecated
-    openDzi: function ( dzi ) {
-        $.console.error( "[Viewer.openDzi] this function is deprecated; use Viewer.open() instead." );
-        return this.open( dzi );
-    },
+        // deprecated
+        openDzi: function (dzi) {
+            $.console.error("[Viewer.openDzi] this function is deprecated; use Viewer.open() instead.");
+            return this.open(dzi);
+        },
 
-    // deprecated
-    openTileSource: function ( tileSource ) {
-        $.console.error( "[Viewer.openTileSource] this function is deprecated; use Viewer.open() instead." );
-        return this.open( tileSource );
-    },
+        // deprecated
+        openTileSource: function (tileSource) {
+            $.console.error("[Viewer.openTileSource] this function is deprecated; use Viewer.open() instead.");
+            return this.open(tileSource);
+        },
 
-    /**
-     * Open tiled images into the viewer, closing any others.
-     * To get the TiledImage instance created by open, add an event listener for
-     * {@link OpenSeadragon.Viewer.html#.event:open}, which when fired can be used to get access
-     * to the instance, i.e., viewer.world.getItemAt(0).
-     * @function
-     * @param {Array|String|Object|Function} tileSources - This can be a TiledImage
-     * specifier, a TileSource specifier, or an array of either. A TiledImage specifier
-     * is the same as the options parameter for {@link OpenSeadragon.Viewer#addTiledImage},
-     * except for the index property; images are added in sequence.
-     * A TileSource specifier is anything you could pass as the tileSource property
-     * of the options parameter for {@link OpenSeadragon.Viewer#addTiledImage}.
-     * @param {Number} initialPage - If sequenceMode is true, display this page initially
-     * for the given tileSources. If specified, will overwrite the Viewer's existing initialPage property.
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:open
-     * @fires OpenSeadragon.Viewer.event:open-failed
-     */
-    open: function (tileSources, initialPage) {
-        var _this = this;
+        /**
+         * Open tiled images into the viewer, closing any others.
+         * To get the TiledImage instance created by open, add an event listener for
+         * {@link OpenSeadragon.Viewer.html#.event:open}, which when fired can be used to get access
+         * to the instance, i.e., viewer.world.getItemAt(0).
+         * @function
+         * @param {Array|String|Object|Function} tileSources - This can be a TiledImage
+         * specifier, a TileSource specifier, or an array of either. A TiledImage specifier
+         * is the same as the options parameter for {@link OpenSeadragon.Viewer#addTiledImage},
+         * except for the index property; images are added in sequence.
+         * A TileSource specifier is anything you could pass as the tileSource property
+         * of the options parameter for {@link OpenSeadragon.Viewer#addTiledImage}.
+         * @param {Number} initialPage - If sequenceMode is true, display this page initially
+         * for the given tileSources. If specified, will overwrite the Viewer's existing initialPage property.
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:open
+         * @fires OpenSeadragon.Viewer.event:open-failed
+         */
+        open: function (tileSources, initialPage) {
+            var _this = this;
 
-        this.close();
+            this.close();
 
-        if (!tileSources) {
-            return;
-        }
+            if (!tileSources) {
+                return;
+            }
 
-        if (this.sequenceMode && $.isArray(tileSources)) {
+            if (this.sequenceMode && $.isArray(tileSources)) {
+                if (this.referenceStrip) {
+                    this.referenceStrip.destroy();
+                    this.referenceStrip = null;
+                }
+
+                if (typeof initialPage != 'undefined' && !isNaN(initialPage)) {
+                    this.initialPage = initialPage;
+                }
+
+                this.tileSources = tileSources;
+                this._sequenceIndex = Math.max(0, Math.min(this.tileSources.length - 1, this.initialPage));
+                if (this.tileSources.length) {
+                    this.open(this.tileSources[this._sequenceIndex]);
+
+                    if (this.showReferenceStrip) {
+                        this.addReferenceStrip();
+                    }
+                }
+
+                this._updateSequenceButtons(this._sequenceIndex);
+                return;
+            }
+
+            if (!$.isArray(tileSources)) {
+                tileSources = [tileSources];
+            }
+
+            if (!tileSources.length) {
+                return;
+            }
+
+            this._opening = true;
+
+            var expected = tileSources.length;
+            var successes = 0;
+            var failures = 0;
+            var failEvent;
+
+            var checkCompletion = function () {
+                if (successes + failures === expected) {
+                    if (successes) {
+                        if (_this._firstOpen || !_this.preserveViewport) {
+                            _this.viewport.goHome(true);
+                            _this.viewport.update();
+                        }
+
+                        _this._firstOpen = false;
+
+                        var source = tileSources[0];
+                        if (source.tileSource) {
+                            source = source.tileSource;
+                        }
+
+                        // Global overlays
+                        if (_this.overlays && !_this.preserveOverlays) {
+                            for (var i = 0; i < _this.overlays.length; i++) {
+                                _this.currentOverlays[i] = getOverlayObject(_this, _this.overlays[i]);
+                            }
+                        }
+
+                        _this._drawOverlays();
+                        _this._opening = false;
+
+                        /**
+                         * Raised when the viewer has opened and loaded one or more TileSources.
+                         *
+                         * @event open
+                         * @memberof OpenSeadragon.Viewer
+                         * @type {object}
+                         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+                         * @property {OpenSeadragon.TileSource} source - The tile source that was opened.
+                         * @property {?Object} userData - Arbitrary subscriber-defined object.
+                         */
+                        // TODO: what if there are multiple sources?
+                        _this.raiseEvent('open', { source: source });
+                    } else {
+                        _this._opening = false;
+
+                        /**
+                         * Raised when an error occurs loading a TileSource.
+                         *
+                         * @event open-failed
+                         * @memberof OpenSeadragon.Viewer
+                         * @type {object}
+                         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+                         * @property {String} message - Information about what failed.
+                         * @property {String} source - The tile source that failed.
+                         * @property {?Object} userData - Arbitrary subscriber-defined object.
+                         */
+                        _this.raiseEvent('open-failed', failEvent);
+                    }
+                }
+            };
+
+            var doOne = function (options) {
+                if (!$.isPlainObject(options) || !options.tileSource) {
+                    options = {
+                        tileSource: options
+                    };
+                }
+
+                if (options.index !== undefined) {
+                    $.console.error('[Viewer.open] setting indexes here is not supported; use addTiledImage instead');
+                    delete options.index;
+                }
+
+                if (options.collectionImmediately === undefined) {
+                    options.collectionImmediately = true;
+                }
+
+                var originalSuccess = options.success;
+                options.success = function (event) {
+                    successes++;
+
+                    // TODO: now that options has other things besides tileSource, the overlays
+                    // should probably be at the options level, not the tileSource level.
+                    if (options.tileSource.overlays) {
+                        for (var i = 0; i < options.tileSource.overlays.length; i++) {
+                            _this.addOverlay(options.tileSource.overlays[i]);
+                        }
+                    }
+
+                    if (originalSuccess) {
+                        originalSuccess(event);
+                    }
+
+                    checkCompletion();
+                };
+
+                var originalError = options.error;
+                options.error = function (event) {
+                    failures++;
+
+                    if (!failEvent) {
+                        failEvent = event;
+                    }
+
+                    if (originalError) {
+                        originalError(event);
+                    }
+
+                    checkCompletion();
+                };
+
+                _this.addTiledImage(options);
+            };
+
+            // TileSources
+            for (var i = 0; i < tileSources.length; i++) {
+                doOne(tileSources[i]);
+            }
+
+            return this;
+        },
+
+
+        /**
+         * @function
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:close
+         */
+        close: function () {
+            if (!THIS[this.hash]) {
+                //this viewer has already been destroyed: returning immediately
+                return this;
+            }
+
+            this._opening = false;
+
+            if (this.navigator) {
+                this.navigator.close();
+            }
+
+            if (!this.preserveOverlays) {
+                this.clearOverlays();
+                this.overlaysContainer.innerHTML = "";
+            }
+
+            THIS[this.hash].animating = false;
+            this.world.removeAll();
+            this.imageLoader.clear();
+
+            /**
+             * Raised when the viewer is closed (see {@link OpenSeadragon.Viewer#close}).
+             *
+             * @event close
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent('close');
+
+            return this;
+        },
+
+
+        /**
+         * Function to destroy the viewer and clean up everything created by OpenSeadragon.
+         *
+         * Example:
+         * var viewer = OpenSeadragon({
+         *   [...]
+         * });
+         *
+         * //when you are done with the viewer:
+         * viewer.destroy();
+         * viewer = null; //important
+         *
+         * @function
+         */
+        destroy: function () {
+            if (!THIS[this.hash]) {
+                //this viewer has already been destroyed: returning immediately
+                return;
+            }
+
+            this.close();
+
+            this.clearOverlays();
+            this.overlaysContainer.innerHTML = "";
+
+            //TODO: implement this...
+            //this.unbindSequenceControls()
+            //this.unbindStandardControls()
+
             if (this.referenceStrip) {
                 this.referenceStrip.destroy();
                 this.referenceStrip = null;
             }
 
-            if (typeof initialPage != 'undefined' && !isNaN(initialPage)) {
-              this.initialPage = initialPage;
+            if (this._updateRequestId !== null) {
+                $.cancelAnimationFrame(this._updateRequestId);
+                this._updateRequestId = null;
             }
 
-            this.tileSources = tileSources;
-            this._sequenceIndex = Math.max(0, Math.min(this.tileSources.length - 1, this.initialPage));
-            if (this.tileSources.length) {
-                this.open(this.tileSources[this._sequenceIndex]);
+            if (this.drawer) {
+                this.drawer.destroy();
+            }
 
-                if ( this.showReferenceStrip ){
-                    this.addReferenceStrip();
+            this.removeAllHandlers();
+
+            // Go through top element (passed to us) and remove all children
+            // Use removeChild to make sure it handles SVG or any non-html
+            // also it performs better - http://jsperf.com/innerhtml-vs-removechild/15
+            if (this.element) {
+                while (this.element.firstChild) {
+                    this.element.removeChild(this.element.firstChild);
                 }
             }
 
-            this._updateSequenceButtons( this._sequenceIndex );
-            return;
-        }
-
-        if (!$.isArray(tileSources)) {
-            tileSources = [tileSources];
-        }
-
-        if (!tileSources.length) {
-            return;
-        }
-
-        this._opening = true;
-
-        var expected = tileSources.length;
-        var successes = 0;
-        var failures = 0;
-        var failEvent;
-
-        var checkCompletion = function() {
-            if (successes + failures === expected) {
-                if (successes) {
-                    if (_this._firstOpen || !_this.preserveViewport) {
-                        _this.viewport.goHome( true );
-                        _this.viewport.update();
-                    }
-
-                    _this._firstOpen = false;
-
-                    var source = tileSources[0];
-                    if (source.tileSource) {
-                        source = source.tileSource;
-                    }
-
-                    // Global overlays
-                    if( _this.overlays && !_this.preserveOverlays ){
-                        for ( var i = 0; i < _this.overlays.length; i++ ) {
-                            _this.currentOverlays[ i ] = getOverlayObject( _this, _this.overlays[ i ] );
-                        }
-                    }
-
-                    _this._drawOverlays();
-                    _this._opening = false;
-
-                    /**
-                     * Raised when the viewer has opened and loaded one or more TileSources.
-                     *
-                     * @event open
-                     * @memberof OpenSeadragon.Viewer
-                     * @type {object}
-                     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-                     * @property {OpenSeadragon.TileSource} source - The tile source that was opened.
-                     * @property {?Object} userData - Arbitrary subscriber-defined object.
-                     */
-                    // TODO: what if there are multiple sources?
-                    _this.raiseEvent( 'open', { source: source } );
-                } else {
-                    _this._opening = false;
-
-                    /**
-                     * Raised when an error occurs loading a TileSource.
-                     *
-                     * @event open-failed
-                     * @memberof OpenSeadragon.Viewer
-                     * @type {object}
-                     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-                     * @property {String} message - Information about what failed.
-                     * @property {String} source - The tile source that failed.
-                     * @property {?Object} userData - Arbitrary subscriber-defined object.
-                     */
-                    _this.raiseEvent( 'open-failed', failEvent );
-                }
+            // destroy the mouse trackers
+            if (this.innerTracker) {
+                this.innerTracker.destroy();
             }
-        };
-
-        var doOne = function(options) {
-            if (!$.isPlainObject(options) || !options.tileSource) {
-                options = {
-                    tileSource: options
-                };
+            if (this.outerTracker) {
+                this.outerTracker.destroy();
             }
 
-            if (options.index !== undefined) {
-                $.console.error('[Viewer.open] setting indexes here is not supported; use addTiledImage instead');
-                delete options.index;
-            }
+            THIS[this.hash] = null;
+            delete THIS[this.hash];
 
-            if (options.collectionImmediately === undefined) {
-                options.collectionImmediately = true;
-            }
+            // clear all our references to dom objects
+            this.canvas = null;
+            this.container = null;
 
-            var originalSuccess = options.success;
-            options.success = function(event) {
-                successes++;
+            // clear our reference to the main element - they will need to pass it in again, creating a new viewer
+            this.element = null;
+        },
 
-                // TODO: now that options has other things besides tileSource, the overlays
-                // should probably be at the options level, not the tileSource level.
-                if (options.tileSource.overlays) {
-                    for (var i = 0; i < options.tileSource.overlays.length; i++) {
-                        _this.addOverlay(options.tileSource.overlays[i]);
-                    }
-                }
+        /**
+         * @function
+         * @return {Boolean}
+         */
+        isMouseNavEnabled: function () {
+            return this.innerTracker.isTracking();
+        },
 
-                if (originalSuccess) {
-                    originalSuccess(event);
-                }
-
-                checkCompletion();
-            };
-
-            var originalError = options.error;
-            options.error = function(event) {
-                failures++;
-
-                if (!failEvent) {
-                    failEvent = event;
-                }
-
-                if (originalError) {
-                    originalError(event);
-                }
-
-                checkCompletion();
-            };
-
-            _this.addTiledImage(options);
-        };
-
-        // TileSources
-        for (var i = 0; i < tileSources.length; i++) {
-            doOne(tileSources[i]);
-        }
-
-        return this;
-    },
-
-
-    /**
-     * @function
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:close
-     */
-    close: function ( ) {
-        if ( !THIS[ this.hash ] ) {
-            //this viewer has already been destroyed: returning immediately
+        /**
+         * @function
+         * @param {Boolean} enabled - true to enable, false to disable
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:mouse-enabled
+         */
+        setMouseNavEnabled: function (enabled) {
+            this.innerTracker.setTracking(enabled);
+            this.outerTracker.setTracking(enabled);
+            /**
+             * Raised when mouse/touch navigation is enabled or disabled (see {@link OpenSeadragon.Viewer#setMouseNavEnabled}).
+             *
+             * @event mouse-enabled
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {Boolean} enabled
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent('mouse-enabled', { enabled: enabled });
             return this;
-        }
+        },
 
-        this._opening = false;
-
-        if ( this.navigator ) {
-            this.navigator.close();
-        }
-
-        if (!this.preserveOverlays) {
-            this.clearOverlays();
-            this.overlaysContainer.innerHTML = "";
-        }
-
-        THIS[ this.hash ].animating = false;
-        this.world.removeAll();
-        this.imageLoader.clear();
 
         /**
-         * Raised when the viewer is closed (see {@link OpenSeadragon.Viewer#close}).
-         *
-         * @event close
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         * @function
+         * @return {Boolean}
          */
-        this.raiseEvent( 'close' );
-
-        return this;
-    },
-
-
-    /**
-     * Function to destroy the viewer and clean up everything created by OpenSeadragon.
-     *
-     * Example:
-     * var viewer = OpenSeadragon({
-     *   [...]
-     * });
-     *
-     * //when you are done with the viewer:
-     * viewer.destroy();
-     * viewer = null; //important
-     *
-     * @function
-     */
-    destroy: function( ) {
-        if ( !THIS[ this.hash ] ) {
-            //this viewer has already been destroyed: returning immediately
-            return;
-        }
-
-        this.close();
-
-        this.clearOverlays();
-        this.overlaysContainer.innerHTML = "";
-
-        //TODO: implement this...
-        //this.unbindSequenceControls()
-        //this.unbindStandardControls()
-
-        if (this.referenceStrip) {
-            this.referenceStrip.destroy();
-            this.referenceStrip = null;
-        }
-
-        if ( this._updateRequestId !== null ) {
-            $.cancelAnimationFrame( this._updateRequestId );
-            this._updateRequestId = null;
-        }
-
-        if ( this.drawer ) {
-            this.drawer.destroy();
-        }
-
-        this.removeAllHandlers();
-
-        // Go through top element (passed to us) and remove all children
-        // Use removeChild to make sure it handles SVG or any non-html
-        // also it performs better - http://jsperf.com/innerhtml-vs-removechild/15
-        if (this.element){
-            while (this.element.firstChild) {
-                this.element.removeChild(this.element.firstChild);
+        areControlsEnabled: function () {
+            var enabled = this.controls.length,
+                i;
+            for (i = 0; i < this.controls.length; i++) {
+                enabled = enabled && this.controls[i].isVisibile();
             }
-        }
+            return enabled;
+        },
 
-        // destroy the mouse trackers
-        if (this.innerTracker){
-            this.innerTracker.destroy();
-        }
-        if (this.outerTracker){
-            this.outerTracker.destroy();
-        }
 
-        THIS[ this.hash ] = null;
-        delete THIS[ this.hash ];
-
-        // clear all our references to dom objects
-        this.canvas = null;
-        this.container = null;
-
-        // clear our reference to the main element - they will need to pass it in again, creating a new viewer
-        this.element = null;
-    },
-
-    /**
-     * @function
-     * @return {Boolean}
-     */
-    isMouseNavEnabled: function () {
-        return this.innerTracker.isTracking();
-    },
-
-    /**
-     * @function
-     * @param {Boolean} enabled - true to enable, false to disable
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:mouse-enabled
-     */
-    setMouseNavEnabled: function( enabled ){
-        this.innerTracker.setTracking( enabled );
-        this.outerTracker.setTracking( enabled );
         /**
-         * Raised when mouse/touch navigation is enabled or disabled (see {@link OpenSeadragon.Viewer#setMouseNavEnabled}).
+         * Shows or hides the controls (e.g. the default navigation buttons).
          *
-         * @event mouse-enabled
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {Boolean} enabled
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         * @function
+         * @param {Boolean} true to show, false to hide.
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:controls-enabled
          */
-        this.raiseEvent( 'mouse-enabled', { enabled: enabled } );
-        return this;
-    },
-
-
-    /**
-     * @function
-     * @return {Boolean}
-     */
-    areControlsEnabled: function () {
-        var enabled = this.controls.length,
-            i;
-        for( i = 0; i < this.controls.length; i++ ){
-            enabled = enabled && this.controls[ i ].isVisibile();
-        }
-        return enabled;
-    },
-
-
-    /**
-     * Shows or hides the controls (e.g. the default navigation buttons).
-     *
-     * @function
-     * @param {Boolean} true to show, false to hide.
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:controls-enabled
-     */
-    setControlsEnabled: function( enabled ) {
-        if( enabled ){
-            abortControlsAutoHide( this );
-        } else {
-            beginControlsAutoHide( this );
-        }
-        /**
-         * Raised when the navigation controls are shown or hidden (see {@link OpenSeadragon.Viewer#setControlsEnabled}).
-         *
-         * @event controls-enabled
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {Boolean} enabled
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
-         */
-        this.raiseEvent( 'controls-enabled', { enabled: enabled } );
-        return this;
-    },
-
-    /**
-     * Turns debugging mode on or off for this viewer.
-     *
-     * @function
-     * @param {Boolean} true to turn debug on, false to turn debug off.
-     */
-    setDebugMode: function(debugMode){
-
-        for (var i = 0; i < this.world.getItemCount(); i++) {
-            this.world.getItemAt(i).debugMode = debugMode;
-        }
-
-        this.debugMode = debugMode;
-        this.forceRedraw();
-    },
-
-    /**
-     * @function
-     * @return {Boolean}
-     */
-    isFullPage: function () {
-        return THIS[ this.hash ].fullPage;
-    },
-
-
-    /**
-     * Toggle full page mode.
-     * @function
-     * @param {Boolean} fullPage
-     *      If true, enter full page mode.  If false, exit full page mode.
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:pre-full-page
-     * @fires OpenSeadragon.Viewer.event:full-page
-     */
-    setFullPage: function( fullPage ) {
-
-        var body = document.body,
-            bodyStyle = body.style,
-            docStyle = document.documentElement.style,
-            _this = this,
-            nodes,
-            i;
-
-        //dont bother modifying the DOM if we are already in full page mode.
-        if ( fullPage == this.isFullPage() ) {
+        setControlsEnabled: function (enabled) {
+            if (enabled) {
+                abortControlsAutoHide(this);
+            } else {
+                beginControlsAutoHide(this);
+            }
+            /**
+             * Raised when the navigation controls are shown or hidden (see {@link OpenSeadragon.Viewer#setControlsEnabled}).
+             *
+             * @event controls-enabled
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {Boolean} enabled
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent('controls-enabled', { enabled: enabled });
             return this;
-        }
-
-        var fullPageEventArgs = {
-            fullPage: fullPage,
-            preventDefaultAction: false
-        };
-        /**
-         * Raised when the viewer is about to change to/from full-page mode (see {@link OpenSeadragon.Viewer#setFullPage}).
-         *
-         * @event pre-full-page
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {Boolean} fullPage - True if entering full-page mode, false if exiting full-page mode.
-         * @property {Boolean} preventDefaultAction - Set to true to prevent full-page mode change. Default: false.
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
-         */
-        this.raiseEvent( 'pre-full-page', fullPageEventArgs );
-        if ( fullPageEventArgs.preventDefaultAction ) {
-            return this;
-        }
-
-        if ( fullPage ) {
-
-            this.elementSize = $.getElementSize( this.element );
-            this.pageScroll = $.getPageScroll();
-
-            this.elementMargin = this.element.style.margin;
-            this.element.style.margin = "0";
-            this.elementPadding = this.element.style.padding;
-            this.element.style.padding = "0";
-
-            this.bodyMargin = bodyStyle.margin;
-            this.docMargin = docStyle.margin;
-            bodyStyle.margin = "0";
-            docStyle.margin = "0";
-
-            this.bodyPadding = bodyStyle.padding;
-            this.docPadding = docStyle.padding;
-            bodyStyle.padding = "0";
-            docStyle.padding = "0";
-
-            this.bodyWidth = bodyStyle.width;
-            this.docWidth = docStyle.width;
-            bodyStyle.width = "100%";
-            docStyle.width = "100%";
-
-            this.bodyHeight = bodyStyle.height;
-            this.docHeight = docStyle.height;
-            bodyStyle.height = "100%";
-            docStyle.height = "100%";
-
-            //when entering full screen on the ipad it wasnt sufficient to leave
-            //the body intact as only only the top half of the screen would
-            //respond to touch events on the canvas, while the bottom half treated
-            //them as touch events on the document body.  Thus we remove and store
-            //the bodies elements and replace them when we leave full screen.
-            this.previousBody = [];
-            THIS[ this.hash ].prevElementParent = this.element.parentNode;
-            THIS[ this.hash ].prevNextSibling = this.element.nextSibling;
-            THIS[ this.hash ].prevElementWidth = this.element.style.width;
-            THIS[ this.hash ].prevElementHeight = this.element.style.height;
-            nodes = body.childNodes.length;
-            for ( i = 0; i < nodes; i++ ) {
-                this.previousBody.push( body.childNodes[ 0 ] );
-                body.removeChild( body.childNodes[ 0 ] );
-            }
-
-            //If we've got a toolbar, we need to enable the user to use css to
-            //preserve it in fullpage mode
-            if ( this.toolbar && this.toolbar.element ) {
-                //save a reference to the parent so we can put it back
-                //in the long run we need a better strategy
-                this.toolbar.parentNode = this.toolbar.element.parentNode;
-                this.toolbar.nextSibling = this.toolbar.element.nextSibling;
-                body.appendChild( this.toolbar.element );
-
-                //Make sure the user has some ability to style the toolbar based
-                //on the mode
-                $.addClass( this.toolbar.element, 'fullpage' );
-            }
-
-            $.addClass( this.element, 'fullpage' );
-            body.appendChild( this.element );
-
-            this.element.style.height = $.getWindowSize().y + 'px';
-            this.element.style.width = $.getWindowSize().x + 'px';
-
-            if ( this.toolbar && this.toolbar.element ) {
-                this.element.style.height = (
-                    $.getElementSize( this.element ).y - $.getElementSize( this.toolbar.element ).y
-                ) + 'px';
-            }
-
-            THIS[ this.hash ].fullPage = true;
-
-            // mouse will be inside container now
-            $.delegate( this, onContainerEnter )( {} );
-
-        } else {
-
-            this.element.style.margin = this.elementMargin;
-            this.element.style.padding = this.elementPadding;
-
-            bodyStyle.margin = this.bodyMargin;
-            docStyle.margin = this.docMargin;
-
-            bodyStyle.padding = this.bodyPadding;
-            docStyle.padding = this.docPadding;
-
-            bodyStyle.width = this.bodyWidth;
-            docStyle.width = this.docWidth;
-
-            bodyStyle.height = this.bodyHeight;
-            docStyle.height = this.docHeight;
-
-            body.removeChild( this.element );
-            nodes = this.previousBody.length;
-            for ( i = 0; i < nodes; i++ ) {
-                body.appendChild( this.previousBody.shift() );
-            }
-
-            $.removeClass( this.element, 'fullpage' );
-            THIS[ this.hash ].prevElementParent.insertBefore(
-                this.element,
-                THIS[ this.hash ].prevNextSibling
-            );
-
-            //If we've got a toolbar, we need to enable the user to use css to
-            //reset it to its original state
-            if ( this.toolbar && this.toolbar.element ) {
-                body.removeChild( this.toolbar.element );
-
-                //Make sure the user has some ability to style the toolbar based
-                //on the mode
-                $.removeClass( this.toolbar.element, 'fullpage' );
-
-                this.toolbar.parentNode.insertBefore(
-                    this.toolbar.element,
-                    this.toolbar.nextSibling
-                );
-                delete this.toolbar.parentNode;
-                delete this.toolbar.nextSibling;
-            }
-
-            this.element.style.width = THIS[ this.hash ].prevElementWidth;
-            this.element.style.height = THIS[ this.hash ].prevElementHeight;
-
-            // After exiting fullPage or fullScreen, it can take some time
-            // before the browser can actually set the scroll.
-            var restoreScrollCounter = 0;
-            var restoreScroll = function() {
-                $.setPageScroll( _this.pageScroll );
-                var pageScroll = $.getPageScroll();
-                restoreScrollCounter++;
-                if (restoreScrollCounter < 10 &&
-                    (pageScroll.x !== _this.pageScroll.x ||
-                    pageScroll.y !== _this.pageScroll.y)) {
-                    $.requestAnimationFrame( restoreScroll );
-                }
-            };
-            $.requestAnimationFrame( restoreScroll );
-
-            THIS[ this.hash ].fullPage = false;
-
-            // mouse will likely be outside now
-            $.delegate( this, onContainerExit )( { } );
-
-        }
-
-        if ( this.navigator && this.viewport ) {
-            this.navigator.update( this.viewport );
-        }
+        },
 
         /**
-         * Raised when the viewer has changed to/from full-page mode (see {@link OpenSeadragon.Viewer#setFullPage}).
+         * Turns debugging mode on or off for this viewer.
          *
-         * @event full-page
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {Boolean} fullPage - True if changed to full-page mode, false if exited full-page mode.
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         * @function
+         * @param {Boolean} true to turn debug on, false to turn debug off.
          */
-        this.raiseEvent( 'full-page', { fullPage: fullPage } );
+        setDebugMode: function (debugMode) {
 
-        return this;
-    },
+            for (var i = 0; i < this.world.getItemCount(); i++) {
+                this.world.getItemAt(i).debugMode = debugMode;
+            }
 
-    /**
-     * Toggle full screen mode if supported. Toggle full page mode otherwise.
-     * @function
-     * @param {Boolean} fullScreen
-     *      If true, enter full screen mode.  If false, exit full screen mode.
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:pre-full-screen
-     * @fires OpenSeadragon.Viewer.event:full-screen
-     */
-    setFullScreen: function( fullScreen ) {
-        var _this = this;
+            this.debugMode = debugMode;
+            this.forceRedraw();
+        },
 
-        if ( !$.supportsFullScreen ) {
-            return this.setFullPage( fullScreen );
-        }
-
-        if ( $.isFullScreen() === fullScreen ) {
-            return this;
-        }
-
-        var fullScreeEventArgs = {
-            fullScreen: fullScreen,
-            preventDefaultAction: false
-        };
         /**
-         * Raised when the viewer is about to change to/from full-screen mode (see {@link OpenSeadragon.Viewer#setFullScreen}).
-         * Note: the pre-full-screen event is not raised when the user is exiting
-         * full-screen mode by pressing the Esc key. In that case, consider using
-         * the full-screen, pre-full-page or full-page events.
-         *
-         * @event pre-full-screen
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {Boolean} fullScreen - True if entering full-screen mode, false if exiting full-screen mode.
-         * @property {Boolean} preventDefaultAction - Set to true to prevent full-screen mode change. Default: false.
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         * @function
+         * @return {Boolean}
          */
-        this.raiseEvent( 'pre-full-screen', fullScreeEventArgs );
-        if ( fullScreeEventArgs.preventDefaultAction ) {
-            return this;
-        }
+        isFullPage: function () {
+            return THIS[this.hash].fullPage;
+        },
 
-        if ( fullScreen ) {
 
-            this.setFullPage( true );
-            // If the full page mode is not actually entered, we need to prevent
-            // the full screen mode.
-            if ( !this.isFullPage() ) {
+        /**
+         * Toggle full page mode.
+         * @function
+         * @param {Boolean} fullPage
+         *      If true, enter full page mode.  If false, exit full page mode.
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:pre-full-page
+         * @fires OpenSeadragon.Viewer.event:full-page
+         */
+        setFullPage: function (fullPage) {
+
+            var body = document.body,
+                bodyStyle = body.style,
+                docStyle = document.documentElement.style,
+                _this = this,
+                nodes,
+                i;
+
+            //dont bother modifying the DOM if we are already in full page mode.
+            if (fullPage == this.isFullPage()) {
                 return this;
             }
 
-            this.fullPageStyleWidth = this.element.style.width;
-            this.fullPageStyleHeight = this.element.style.height;
-            this.element.style.width = '100%';
-            this.element.style.height = '100%';
-
-            var onFullScreenChange = function() {
-                var isFullScreen = $.isFullScreen();
-                if ( !isFullScreen ) {
-                    $.removeEvent( document, $.fullScreenEventName, onFullScreenChange );
-                    $.removeEvent( document, $.fullScreenErrorEventName, onFullScreenChange );
-
-                    _this.setFullPage( false );
-                    if ( _this.isFullPage() ) {
-                        _this.element.style.width = _this.fullPageStyleWidth;
-                        _this.element.style.height = _this.fullPageStyleHeight;
-                    }
-                }
-                if ( _this.navigator && _this.viewport ) {
-                    _this.navigator.update( _this.viewport );
-                }
-                /**
-                 * Raised when the viewer has changed to/from full-screen mode (see {@link OpenSeadragon.Viewer#setFullScreen}).
-                 *
-                 * @event full-screen
-                 * @memberof OpenSeadragon.Viewer
-                 * @type {object}
-                 * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-                 * @property {Boolean} fullScreen - True if changed to full-screen mode, false if exited full-screen mode.
-                 * @property {?Object} userData - Arbitrary subscriber-defined object.
-                 */
-                _this.raiseEvent( 'full-screen', { fullScreen: isFullScreen } );
+            var fullPageEventArgs = {
+                fullPage: fullPage,
+                preventDefaultAction: false
             };
-            $.addEvent( document, $.fullScreenEventName, onFullScreenChange );
-            $.addEvent( document, $.fullScreenErrorEventName, onFullScreenChange );
-
-            $.requestFullScreen( document.body );
-
-        } else {
-            $.exitFullScreen();
-        }
-        return this;
-    },
-
-    /**
-     * @function
-     * @return {Boolean}
-     */
-    isVisible: function () {
-        return this.container.style.visibility != "hidden";
-    },
-
-
-    /**
-     * @function
-     * @param {Boolean} visible
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:visible
-     */
-    setVisible: function( visible ){
-        this.container.style.visibility = visible ? "" : "hidden";
-        /**
-         * Raised when the viewer is shown or hidden (see {@link OpenSeadragon.Viewer#setVisible}).
-         *
-         * @event visible
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {Boolean} visible
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
-         */
-        this.raiseEvent( 'visible', { visible: visible } );
-        return this;
-    },
-
-    /**
-     * Add a tiled image to the viewer.
-     * options.tileSource can be anything that {@link OpenSeadragon.Viewer#open}
-     *  supports except arrays of images.
-     * Note that you can specify options.width or options.height, but not both.
-     * The other dimension will be calculated according to the item's aspect ratio.
-     * If collectionMode is on (see {@link OpenSeadragon.Options}), the new image is
-     * automatically arranged with the others.
-     * @function
-     * @param {Object} options
-     * @param {String|Object|Function} options.tileSource - The TileSource specifier.
-     * A String implies a url used to determine the tileSource implementation
-     *      based on the file extension of url. JSONP is implied by *.js,
-     *      otherwise the url is retrieved as text and the resulting text is
-     *      introspected to determine if its json, xml, or text and parsed.
-     * An Object implies an inline configuration which has a single
-     *      property sufficient for being able to determine tileSource
-     *      implementation. If the object has a property which is a function
-     *      named 'getTileUrl', it is treated as a custom TileSource.
-     * @param {Number} [options.index] The index of the item. Added on top of
-     * all other items if not specified.
-     * @param {Boolean} [options.replace=false] If true, the item at options.index will be
-     * removed and the new item is added in its place. options.tileSource will be
-     * interpreted and fetched if necessary before the old item is removed to avoid leaving
-     * a gap in the world.
-     * @param {Number} [options.x=0] The X position for the image in viewport coordinates.
-     * @param {Number} [options.y=0] The Y position for the image in viewport coordinates.
-     * @param {Number} [options.width=1] The width for the image in viewport coordinates.
-     * @param {Number} [options.height] The height for the image in viewport coordinates.
-     * @param {OpenSeadragon.Rect} [options.fitBounds] The bounds in viewport coordinates
-     * to fit the image into. If specified, x, y, width and height get ignored.
-     * @param {OpenSeadragon.Placement} [options.fitBoundsPlacement=OpenSeadragon.Placement.CENTER]
-     * How to anchor the image in the bounds if options.fitBounds is set.
-     * @param {OpenSeadragon.Rect} [options.clip] - An area, in image pixels, to clip to
-     * (portions of the image outside of this area will not be visible). Only works on
-     * browsers that support the HTML5 canvas.
-     * @param {Number} [options.opacity=1] Proportional opacity of the tiled images (1=opaque, 0=hidden)
-     * @param {Boolean} [options.preload=false]  Default switch for loading hidden images (true loads, false blocks)
-     * @param {Number} [options.degrees=0] Initial rotation of the tiled image around
-     * its top left corner in degrees.
-     * @param {String} [options.compositeOperation] How the image is composited onto other images.
-     * @param {String} [options.crossOriginPolicy] The crossOriginPolicy for this specific image,
-     * overriding viewer.crossOriginPolicy.
-     * @param {Boolean} [options.ajaxWithCredentials] Whether to set withCredentials on tile AJAX
-     * @param {Boolean} [options.loadTilesWithAjax]
-     *      Whether to load tile data using AJAX requests.
-     *      Defaults to the setting in {@link OpenSeadragon.Options}.
-     * @param {Object} [options.ajaxHeaders]
-     *      A set of headers to include when making tile AJAX requests.
-     *      Note that these headers will be merged over any headers specified in {@link OpenSeadragon.Options}.
-     *      Specifying a falsy value for a header will clear its existing value set at the Viewer level (if any).
-     * requests.
-     * @param {Function} [options.success] A function that gets called when the image is
-     * successfully added. It's passed the event object which contains a single property:
-     * "item", which is the resulting instance of TiledImage.
-     * @param {Function} [options.error] A function that gets called if the image is
-     * unable to be added. It's passed the error event object, which contains "message"
-     * and "source" properties.
-     * @param {Boolean} [options.collectionImmediately=false] If collectionMode is on,
-     * specifies whether to snap to the new arrangement immediately or to animate to it.
-     * @param {String|CanvasGradient|CanvasPattern|Function} [options.placeholderFillStyle] - See {@link OpenSeadragon.Options}.
-     * @fires OpenSeadragon.World.event:add-item
-     * @fires OpenSeadragon.Viewer.event:add-item-failed
-     */
-    addTiledImage: function( options ) {
-        $.console.assert(options, "[Viewer.addTiledImage] options is required");
-        $.console.assert(options.tileSource, "[Viewer.addTiledImage] options.tileSource is required");
-        $.console.assert(!options.replace || (options.index > -1 && options.index < this.world.getItemCount()),
-            "[Viewer.addTiledImage] if options.replace is used, options.index must be a valid index in Viewer.world");
-
-        var _this = this;
-
-        if (options.replace) {
-            options.replaceItem = _this.world.getItemAt(options.index);
-        }
-
-        this._hideMessage();
-
-        if (options.placeholderFillStyle === undefined) {
-            options.placeholderFillStyle = this.placeholderFillStyle;
-        }
-        if (options.opacity === undefined) {
-            options.opacity = this.opacity;
-        }
-        if (options.preload === undefined) {
-            options.preload = this.preload;
-        }
-        if (options.compositeOperation === undefined) {
-            options.compositeOperation = this.compositeOperation;
-        }
-        if (options.crossOriginPolicy === undefined) {
-            options.crossOriginPolicy = options.tileSource.crossOriginPolicy !== undefined ? options.tileSource.crossOriginPolicy : this.crossOriginPolicy;
-        }
-        if (options.ajaxWithCredentials === undefined) {
-            options.ajaxWithCredentials = this.ajaxWithCredentials;
-        }
-        if (options.loadTilesWithAjax === undefined) {
-            options.loadTilesWithAjax = this.loadTilesWithAjax;
-        }
-        if (options.ajaxHeaders === undefined || options.ajaxHeaders === null) {
-            options.ajaxHeaders = this.ajaxHeaders;
-        } else if ($.isPlainObject(options.ajaxHeaders) && $.isPlainObject(this.ajaxHeaders)) {
-            options.ajaxHeaders = $.extend({}, this.ajaxHeaders, options.ajaxHeaders);
-        }
-
-        var myQueueItem = {
-            options: options
-        };
-
-        function raiseAddItemFailed( event ) {
-            for (var i = 0; i < _this._loadQueue.length; i++) {
-                if (_this._loadQueue[i] === myQueueItem) {
-                    _this._loadQueue.splice(i, 1);
-                    break;
-                }
-            }
-
-            if (_this._loadQueue.length === 0) {
-                refreshWorld(myQueueItem);
-            }
-
-             /**
-             * Raised when an error occurs while adding a item.
-             * @event add-item-failed
-             * @memberOf OpenSeadragon.Viewer
+            /**
+             * Raised when the viewer is about to change to/from full-page mode (see {@link OpenSeadragon.Viewer#setFullPage}).
+             *
+             * @event pre-full-page
+             * @memberof OpenSeadragon.Viewer
              * @type {object}
              * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-             * @property {String} message
-             * @property {String} source
-             * @property {Object} options The options passed to the addTiledImage method.
+             * @property {Boolean} fullPage - True if entering full-page mode, false if exiting full-page mode.
+             * @property {Boolean} preventDefaultAction - Set to true to prevent full-page mode change. Default: false.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            _this.raiseEvent( 'add-item-failed', event );
-
-            if (options.error) {
-                options.error(event);
+            this.raiseEvent('pre-full-page', fullPageEventArgs);
+            if (fullPageEventArgs.preventDefaultAction) {
+                return this;
             }
-        }
 
-        function refreshWorld(theItem) {
-            if (_this.collectionMode) {
-                _this.world.arrange({
-                    immediately: theItem.options.collectionImmediately,
-                    rows: _this.collectionRows,
-                    columns: _this.collectionColumns,
-                    layout: _this.collectionLayout,
-                    tileSize: _this.collectionTileSize,
-                    tileMargin: _this.collectionTileMargin
-                });
-                _this.world.setAutoRefigureSizes(true);
-            }
-        }
+            if (fullPage) {
 
-        if ($.isArray(options.tileSource)) {
-            setTimeout(function() {
-                raiseAddItemFailed({
-                    message: "[Viewer.addTiledImage] Sequences can not be added; add them one at a time instead.",
-                    source: options.tileSource,
-                    options: options
-                });
-            });
-            return;
-        }
+                this.elementSize = $.getElementSize(this.element);
+                this.pageScroll = $.getPageScroll();
 
-        this._loadQueue.push(myQueueItem);
+                this.elementMargin = this.element.style.margin;
+                this.element.style.margin = "0";
+                this.elementPadding = this.element.style.padding;
+                this.element.style.padding = "0";
 
-        function processReadyItems() {
-            var queueItem, tiledImage, optionsClone;
-            while (_this._loadQueue.length) {
-                queueItem = _this._loadQueue[0];
-                if (!queueItem.tileSource) {
-                    break;
+                this.bodyMargin = bodyStyle.margin;
+                this.docMargin = docStyle.margin;
+                bodyStyle.margin = "0";
+                docStyle.margin = "0";
+
+                this.bodyPadding = bodyStyle.padding;
+                this.docPadding = docStyle.padding;
+                bodyStyle.padding = "0";
+                docStyle.padding = "0";
+
+                this.bodyWidth = bodyStyle.width;
+                this.docWidth = docStyle.width;
+                bodyStyle.width = "100%";
+                docStyle.width = "100%";
+
+                this.bodyHeight = bodyStyle.height;
+                this.docHeight = docStyle.height;
+                bodyStyle.height = "100%";
+                docStyle.height = "100%";
+
+                //when entering full screen on the ipad it wasnt sufficient to leave
+                //the body intact as only only the top half of the screen would
+                //respond to touch events on the canvas, while the bottom half treated
+                //them as touch events on the document body.  Thus we remove and store
+                //the bodies elements and replace them when we leave full screen.
+                this.previousBody = [];
+                THIS[this.hash].prevElementParent = this.element.parentNode;
+                THIS[this.hash].prevNextSibling = this.element.nextSibling;
+                THIS[this.hash].prevElementWidth = this.element.style.width;
+                THIS[this.hash].prevElementHeight = this.element.style.height;
+                nodes = body.childNodes.length;
+                for (i = 0; i < nodes; i++) {
+                    this.previousBody.push(body.childNodes[0]);
+                    body.removeChild(body.childNodes[0]);
                 }
 
-                _this._loadQueue.splice(0, 1);
+                //If we've got a toolbar, we need to enable the user to use css to
+                //preserve it in fullpage mode
+                if (this.toolbar && this.toolbar.element) {
+                    //save a reference to the parent so we can put it back
+                    //in the long run we need a better strategy
+                    this.toolbar.parentNode = this.toolbar.element.parentNode;
+                    this.toolbar.nextSibling = this.toolbar.element.nextSibling;
+                    body.appendChild(this.toolbar.element);
 
-                if (queueItem.options.replace) {
-                    var newIndex = _this.world.getIndexOfItem(queueItem.options.replaceItem);
-                    if (newIndex != -1) {
-                        queueItem.options.index = newIndex;
+                    //Make sure the user has some ability to style the toolbar based
+                    //on the mode
+                    $.addClass(this.toolbar.element, 'fullpage');
+                }
+
+                $.addClass(this.element, 'fullpage');
+                body.appendChild(this.element);
+
+                this.element.style.height = $.getWindowSize().y + 'px';
+                this.element.style.width = $.getWindowSize().x + 'px';
+
+                if (this.toolbar && this.toolbar.element) {
+                    this.element.style.height = (
+                        $.getElementSize(this.element).y - $.getElementSize(this.toolbar.element).y
+                    ) + 'px';
+                }
+
+                THIS[this.hash].fullPage = true;
+
+                // mouse will be inside container now
+                $.delegate(this, onContainerEnter)({});
+
+            } else {
+
+                this.element.style.margin = this.elementMargin;
+                this.element.style.padding = this.elementPadding;
+
+                bodyStyle.margin = this.bodyMargin;
+                docStyle.margin = this.docMargin;
+
+                bodyStyle.padding = this.bodyPadding;
+                docStyle.padding = this.docPadding;
+
+                bodyStyle.width = this.bodyWidth;
+                docStyle.width = this.docWidth;
+
+                bodyStyle.height = this.bodyHeight;
+                docStyle.height = this.docHeight;
+
+                body.removeChild(this.element);
+                nodes = this.previousBody.length;
+                for (i = 0; i < nodes; i++) {
+                    body.appendChild(this.previousBody.shift());
+                }
+
+                $.removeClass(this.element, 'fullpage');
+                THIS[this.hash].prevElementParent.insertBefore(
+                    this.element,
+                    THIS[this.hash].prevNextSibling
+                );
+
+                //If we've got a toolbar, we need to enable the user to use css to
+                //reset it to its original state
+                if (this.toolbar && this.toolbar.element) {
+                    body.removeChild(this.toolbar.element);
+
+                    //Make sure the user has some ability to style the toolbar based
+                    //on the mode
+                    $.removeClass(this.toolbar.element, 'fullpage');
+
+                    this.toolbar.parentNode.insertBefore(
+                        this.toolbar.element,
+                        this.toolbar.nextSibling
+                    );
+                    delete this.toolbar.parentNode;
+                    delete this.toolbar.nextSibling;
+                }
+
+                this.element.style.width = THIS[this.hash].prevElementWidth;
+                this.element.style.height = THIS[this.hash].prevElementHeight;
+
+                // After exiting fullPage or fullScreen, it can take some time
+                // before the browser can actually set the scroll.
+                var restoreScrollCounter = 0;
+                var restoreScroll = function () {
+                    $.setPageScroll(_this.pageScroll);
+                    var pageScroll = $.getPageScroll();
+                    restoreScrollCounter++;
+                    if (restoreScrollCounter < 10 &&
+                        (pageScroll.x !== _this.pageScroll.x ||
+                            pageScroll.y !== _this.pageScroll.y)) {
+                        $.requestAnimationFrame(restoreScroll);
                     }
-                    _this.world.removeItem(queueItem.options.replaceItem);
+                };
+                $.requestAnimationFrame(restoreScroll);
+
+                THIS[this.hash].fullPage = false;
+
+                // mouse will likely be outside now
+                $.delegate(this, onContainerExit)({});
+
+            }
+
+            if (this.navigator && this.viewport) {
+                this.navigator.update(this.viewport);
+            }
+
+            /**
+             * Raised when the viewer has changed to/from full-page mode (see {@link OpenSeadragon.Viewer#setFullPage}).
+             *
+             * @event full-page
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {Boolean} fullPage - True if changed to full-page mode, false if exited full-page mode.
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent('full-page', { fullPage: fullPage });
+
+            return this;
+        },
+
+        /**
+         * Toggle full screen mode if supported. Toggle full page mode otherwise.
+         * @function
+         * @param {Boolean} fullScreen
+         *      If true, enter full screen mode.  If false, exit full screen mode.
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:pre-full-screen
+         * @fires OpenSeadragon.Viewer.event:full-screen
+         */
+        setFullScreen: function (fullScreen) {
+            var _this = this;
+
+            if (!$.supportsFullScreen) {
+                return this.setFullPage(fullScreen);
+            }
+
+            if ($.isFullScreen() === fullScreen) {
+                return this;
+            }
+
+            var fullScreeEventArgs = {
+                fullScreen: fullScreen,
+                preventDefaultAction: false
+            };
+            /**
+             * Raised when the viewer is about to change to/from full-screen mode (see {@link OpenSeadragon.Viewer#setFullScreen}).
+             * Note: the pre-full-screen event is not raised when the user is exiting
+             * full-screen mode by pressing the Esc key. In that case, consider using
+             * the full-screen, pre-full-page or full-page events.
+             *
+             * @event pre-full-screen
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {Boolean} fullScreen - True if entering full-screen mode, false if exiting full-screen mode.
+             * @property {Boolean} preventDefaultAction - Set to true to prevent full-screen mode change. Default: false.
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent('pre-full-screen', fullScreeEventArgs);
+            if (fullScreeEventArgs.preventDefaultAction) {
+                return this;
+            }
+
+            if (fullScreen) {
+
+                this.setFullPage(true);
+                // If the full page mode is not actually entered, we need to prevent
+                // the full screen mode.
+                if (!this.isFullPage()) {
+                    return this;
                 }
 
-                tiledImage = new $.TiledImage({
-                    viewer: _this,
-                    source: queueItem.tileSource,
-                    viewport: _this.viewport,
-                    drawer: _this.drawer,
-                    tileCache: _this.tileCache,
-                    imageLoader: _this.imageLoader,
-                    x: queueItem.options.x,
-                    y: queueItem.options.y,
-                    width: queueItem.options.width,
-                    height: queueItem.options.height,
-                    fitBounds: queueItem.options.fitBounds,
-                    fitBoundsPlacement: queueItem.options.fitBoundsPlacement,
-                    clip: queueItem.options.clip,
-                    placeholderFillStyle: queueItem.options.placeholderFillStyle,
-                    opacity: queueItem.options.opacity,
-                    preload: queueItem.options.preload,
-                    degrees: queueItem.options.degrees,
-                    compositeOperation: queueItem.options.compositeOperation,
-                    springStiffness: _this.springStiffness,
-                    animationTime: _this.animationTime,
-                    minZoomImageRatio: _this.minZoomImageRatio,
-                    wrapHorizontal: _this.wrapHorizontal,
-                    wrapVertical: _this.wrapVertical,
-                    immediateRender: _this.immediateRender,
-                    blendTime: _this.blendTime,
-                    alwaysBlend: _this.alwaysBlend,
-                    minPixelRatio: _this.minPixelRatio,
-                    smoothTileEdgesMinZoom: _this.smoothTileEdgesMinZoom,
-                    iOSDevice: _this.iOSDevice,
-                    crossOriginPolicy: queueItem.options.crossOriginPolicy,
-                    ajaxWithCredentials: queueItem.options.ajaxWithCredentials,
-                    loadTilesWithAjax: queueItem.options.loadTilesWithAjax,
-                    ajaxHeaders: queueItem.options.ajaxHeaders,
-                    debugMode: _this.debugMode
-                });
+                this.fullPageStyleWidth = this.element.style.width;
+                this.fullPageStyleHeight = this.element.style.height;
+                this.element.style.width = '100%';
+                this.element.style.height = '100%';
 
-                if (_this.collectionMode) {
-                    _this.world.setAutoRefigureSizes(false);
+                var onFullScreenChange = function () {
+                    var isFullScreen = $.isFullScreen();
+                    if (!isFullScreen) {
+                        $.removeEvent(document, $.fullScreenEventName, onFullScreenChange);
+                        $.removeEvent(document, $.fullScreenErrorEventName, onFullScreenChange);
+
+                        _this.setFullPage(false);
+                        if (_this.isFullPage()) {
+                            _this.element.style.width = _this.fullPageStyleWidth;
+                            _this.element.style.height = _this.fullPageStyleHeight;
+                        }
+                    }
+                    if (_this.navigator && _this.viewport) {
+                        _this.navigator.update(_this.viewport);
+                    }
+                    /**
+                     * Raised when the viewer has changed to/from full-screen mode (see {@link OpenSeadragon.Viewer#setFullScreen}).
+                     *
+                     * @event full-screen
+                     * @memberof OpenSeadragon.Viewer
+                     * @type {object}
+                     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+                     * @property {Boolean} fullScreen - True if changed to full-screen mode, false if exited full-screen mode.
+                     * @property {?Object} userData - Arbitrary subscriber-defined object.
+                     */
+                    _this.raiseEvent('full-screen', { fullScreen: isFullScreen });
+                };
+                $.addEvent(document, $.fullScreenEventName, onFullScreenChange);
+                $.addEvent(document, $.fullScreenErrorEventName, onFullScreenChange);
+
+                $.requestFullScreen(document.body);
+
+            } else {
+                $.exitFullScreen();
+            }
+            return this;
+        },
+
+        /**
+         * @function
+         * @return {Boolean}
+         */
+        isVisible: function () {
+            return this.container.style.visibility != "hidden";
+        },
+
+
+        /**
+         * @function
+         * @param {Boolean} visible
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:visible
+         */
+        setVisible: function (visible) {
+            this.container.style.visibility = visible ? "" : "hidden";
+            /**
+             * Raised when the viewer is shown or hidden (see {@link OpenSeadragon.Viewer#setVisible}).
+             *
+             * @event visible
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {Boolean} visible
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent('visible', { visible: visible });
+            return this;
+        },
+
+        /**
+         * Add a tiled image to the viewer.
+         * options.tileSource can be anything that {@link OpenSeadragon.Viewer#open}
+         *  supports except arrays of images.
+         * Note that you can specify options.width or options.height, but not both.
+         * The other dimension will be calculated according to the item's aspect ratio.
+         * If collectionMode is on (see {@link OpenSeadragon.Options}), the new image is
+         * automatically arranged with the others.
+         * @function
+         * @param {Object} options
+         * @param {String|Object|Function} options.tileSource - The TileSource specifier.
+         * A String implies a url used to determine the tileSource implementation
+         *      based on the file extension of url. JSONP is implied by *.js,
+         *      otherwise the url is retrieved as text and the resulting text is
+         *      introspected to determine if its json, xml, or text and parsed.
+         * An Object implies an inline configuration which has a single
+         *      property sufficient for being able to determine tileSource
+         *      implementation. If the object has a property which is a function
+         *      named 'getTileUrl', it is treated as a custom TileSource.
+         * @param {Number} [options.index] The index of the item. Added on top of
+         * all other items if not specified.
+         * @param {Boolean} [options.replace=false] If true, the item at options.index will be
+         * removed and the new item is added in its place. options.tileSource will be
+         * interpreted and fetched if necessary before the old item is removed to avoid leaving
+         * a gap in the world.
+         * @param {Number} [options.x=0] The X position for the image in viewport coordinates.
+         * @param {Number} [options.y=0] The Y position for the image in viewport coordinates.
+         * @param {Number} [options.width=1] The width for the image in viewport coordinates.
+         * @param {Number} [options.height] The height for the image in viewport coordinates.
+         * @param {OpenSeadragon.Rect} [options.fitBounds] The bounds in viewport coordinates
+         * to fit the image into. If specified, x, y, width and height get ignored.
+         * @param {OpenSeadragon.Placement} [options.fitBoundsPlacement=OpenSeadragon.Placement.CENTER]
+         * How to anchor the image in the bounds if options.fitBounds is set.
+         * @param {OpenSeadragon.Rect} [options.clip] - An area, in image pixels, to clip to
+         * (portions of the image outside of this area will not be visible). Only works on
+         * browsers that support the HTML5 canvas.
+         * @param {Number} [options.opacity=1] Proportional opacity of the tiled images (1=opaque, 0=hidden)
+         * @param {Boolean} [options.preload=false]  Default switch for loading hidden images (true loads, false blocks)
+         * @param {Number} [options.degrees=0] Initial rotation of the tiled image around
+         * its top left corner in degrees.
+         * @param {String} [options.compositeOperation] How the image is composited onto other images.
+         * @param {String} [options.crossOriginPolicy] The crossOriginPolicy for this specific image,
+         * overriding viewer.crossOriginPolicy.
+         * @param {Boolean} [options.ajaxWithCredentials] Whether to set withCredentials on tile AJAX
+         * @param {Boolean} [options.loadTilesWithAjax]
+         *      Whether to load tile data using AJAX requests.
+         *      Defaults to the setting in {@link OpenSeadragon.Options}.
+         * @param {Object} [options.ajaxHeaders]
+         *      A set of headers to include when making tile AJAX requests.
+         *      Note that these headers will be merged over any headers specified in {@link OpenSeadragon.Options}.
+         *      Specifying a falsy value for a header will clear its existing value set at the Viewer level (if any).
+         * requests.
+         * @param {Function} [options.success] A function that gets called when the image is
+         * successfully added. It's passed the event object which contains a single property:
+         * "item", which is the resulting instance of TiledImage.
+         * @param {Function} [options.error] A function that gets called if the image is
+         * unable to be added. It's passed the error event object, which contains "message"
+         * and "source" properties.
+         * @param {Boolean} [options.collectionImmediately=false] If collectionMode is on,
+         * specifies whether to snap to the new arrangement immediately or to animate to it.
+         * @param {String|CanvasGradient|CanvasPattern|Function} [options.placeholderFillStyle] - See {@link OpenSeadragon.Options}.
+         * @fires OpenSeadragon.World.event:add-item
+         * @fires OpenSeadragon.Viewer.event:add-item-failed
+         */
+        addTiledImage: function (options) {
+            $.console.assert(options, "[Viewer.addTiledImage] options is required");
+            $.console.assert(options.tileSource, "[Viewer.addTiledImage] options.tileSource is required");
+            $.console.assert(!options.replace || (options.index > -1 && options.index < this.world.getItemCount()),
+                "[Viewer.addTiledImage] if options.replace is used, options.index must be a valid index in Viewer.world");
+
+            var _this = this;
+
+            if (options.replace) {
+                options.replaceItem = _this.world.getItemAt(options.index);
+            }
+
+            this._hideMessage();
+
+            if (options.placeholderFillStyle === undefined) {
+                options.placeholderFillStyle = this.placeholderFillStyle;
+            }
+            if (options.opacity === undefined) {
+                options.opacity = this.opacity;
+            }
+            if (options.preload === undefined) {
+                options.preload = this.preload;
+            }
+            if (options.compositeOperation === undefined) {
+                options.compositeOperation = this.compositeOperation;
+            }
+            if (options.crossOriginPolicy === undefined) {
+                options.crossOriginPolicy = options.tileSource.crossOriginPolicy !== undefined ? options.tileSource.crossOriginPolicy : this.crossOriginPolicy;
+            }
+            if (options.ajaxWithCredentials === undefined) {
+                options.ajaxWithCredentials = this.ajaxWithCredentials;
+            }
+            if (options.loadTilesWithAjax === undefined) {
+                options.loadTilesWithAjax = this.loadTilesWithAjax;
+            }
+            if (options.ajaxHeaders === undefined || options.ajaxHeaders === null) {
+                options.ajaxHeaders = this.ajaxHeaders;
+            } else if ($.isPlainObject(options.ajaxHeaders) && $.isPlainObject(this.ajaxHeaders)) {
+                options.ajaxHeaders = $.extend({}, this.ajaxHeaders, options.ajaxHeaders);
+            }
+
+            var myQueueItem = {
+                options: options
+            };
+
+            function raiseAddItemFailed(event) {
+                for (var i = 0; i < _this._loadQueue.length; i++) {
+                    if (_this._loadQueue[i] === myQueueItem) {
+                        _this._loadQueue.splice(i, 1);
+                        break;
+                    }
                 }
-                _this.world.addItem( tiledImage, {
-                    index: queueItem.options.index
-                });
 
                 if (_this._loadQueue.length === 0) {
-                    //this restores the autoRefigureSizes flag to true.
-                    refreshWorld(queueItem);
+                    refreshWorld(myQueueItem);
                 }
 
-                if (_this.world.getItemCount() === 1 && !_this.preserveViewport) {
-                    _this.viewport.goHome(true);
-                }
+                /**
+                * Raised when an error occurs while adding a item.
+                * @event add-item-failed
+                * @memberOf OpenSeadragon.Viewer
+                * @type {object}
+                * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+                * @property {String} message
+                * @property {String} source
+                * @property {Object} options The options passed to the addTiledImage method.
+                * @property {?Object} userData - Arbitrary subscriber-defined object.
+                */
+                _this.raiseEvent('add-item-failed', event);
 
-                if (_this.navigator) {
-                    optionsClone = $.extend({}, queueItem.options, {
-                        replace: false, // navigator already removed the layer, nothing to replace
-                        originalTiledImage: tiledImage,
-                        tileSource: queueItem.tileSource
+                if (options.error) {
+                    options.error(event);
+                }
+            }
+
+            function refreshWorld(theItem) {
+                if (_this.collectionMode) {
+                    _this.world.arrange({
+                        immediately: theItem.options.collectionImmediately,
+                        rows: _this.collectionRows,
+                        columns: _this.collectionColumns,
+                        layout: _this.collectionLayout,
+                        tileSize: _this.collectionTileSize,
+                        tileMargin: _this.collectionTileMargin
+                    });
+                    _this.world.setAutoRefigureSizes(true);
+                }
+            }
+
+            if ($.isArray(options.tileSource)) {
+                setTimeout(function () {
+                    raiseAddItemFailed({
+                        message: "[Viewer.addTiledImage] Sequences can not be added; add them one at a time instead.",
+                        source: options.tileSource,
+                        options: options
+                    });
+                });
+                return;
+            }
+
+            this._loadQueue.push(myQueueItem);
+
+            function processReadyItems() {
+                var queueItem, tiledImage, optionsClone;
+                while (_this._loadQueue.length) {
+                    queueItem = _this._loadQueue[0];
+                    if (!queueItem.tileSource) {
+                        break;
+                    }
+
+                    _this._loadQueue.splice(0, 1);
+
+                    if (queueItem.options.replace) {
+                        var newIndex = _this.world.getIndexOfItem(queueItem.options.replaceItem);
+                        if (newIndex != -1) {
+                            queueItem.options.index = newIndex;
+                        }
+                        _this.world.removeItem(queueItem.options.replaceItem);
+                    }
+
+                    tiledImage = new $.TiledImage({
+                        viewer: _this,
+                        source: queueItem.tileSource,
+                        viewport: _this.viewport,
+                        drawer: _this.drawer,
+                        tileCache: _this.tileCache,
+                        imageLoader: _this.imageLoader,
+                        x: queueItem.options.x,
+                        y: queueItem.options.y,
+                        width: queueItem.options.width,
+                        height: queueItem.options.height,
+                        fitBounds: queueItem.options.fitBounds,
+                        fitBoundsPlacement: queueItem.options.fitBoundsPlacement,
+                        clip: queueItem.options.clip,
+                        placeholderFillStyle: queueItem.options.placeholderFillStyle,
+                        opacity: queueItem.options.opacity,
+                        preload: queueItem.options.preload,
+                        degrees: queueItem.options.degrees,
+                        compositeOperation: queueItem.options.compositeOperation,
+                        springStiffness: _this.springStiffness,
+                        animationTime: _this.animationTime,
+                        minZoomImageRatio: _this.minZoomImageRatio,
+                        wrapHorizontal: _this.wrapHorizontal,
+                        wrapVertical: _this.wrapVertical,
+                        immediateRender: _this.immediateRender,
+                        blendTime: _this.blendTime,
+                        alwaysBlend: _this.alwaysBlend,
+                        minPixelRatio: _this.minPixelRatio,
+                        smoothTileEdgesMinZoom: _this.smoothTileEdgesMinZoom,
+                        iOSDevice: _this.iOSDevice,
+                        crossOriginPolicy: queueItem.options.crossOriginPolicy,
+                        ajaxWithCredentials: queueItem.options.ajaxWithCredentials,
+                        loadTilesWithAjax: queueItem.options.loadTilesWithAjax,
+                        ajaxHeaders: queueItem.options.ajaxHeaders,
+                        debugMode: _this.debugMode
                     });
 
-                    _this.navigator.addTiledImage(optionsClone);
-                }
-
-                if (queueItem.options.success) {
-                    queueItem.options.success({
-                        item: tiledImage
+                    if (_this.collectionMode) {
+                        _this.world.setAutoRefigureSizes(false);
+                    }
+                    _this.world.addItem(tiledImage, {
+                        index: queueItem.options.index
                     });
+
+                    if (_this._loadQueue.length === 0) {
+                        //this restores the autoRefigureSizes flag to true.
+                        refreshWorld(queueItem);
+                    }
+
+                    if (_this.world.getItemCount() === 1 && !_this.preserveViewport) {
+                        _this.viewport.goHome(true);
+                    }
+
+                    if (_this.navigator) {
+                        optionsClone = $.extend({}, queueItem.options, {
+                            replace: false, // navigator already removed the layer, nothing to replace
+                            originalTiledImage: tiledImage,
+                            tileSource: queueItem.tileSource
+                        });
+
+                        _this.navigator.addTiledImage(optionsClone);
+                    }
+
+                    if (queueItem.options.success) {
+                        queueItem.options.success({
+                            item: tiledImage
+                        });
+                    }
                 }
             }
-        }
 
-        getTileSourceImplementation( this, options.tileSource, options, function( tileSource ) {
+            getTileSourceImplementation(this, options.tileSource, options, function (tileSource) {
 
-            myQueueItem.tileSource = tileSource;
+                myQueueItem.tileSource = tileSource;
 
-            // add everybody at the front of the queue that's ready to go
-            processReadyItems();
-        }, function( event ) {
-            event.options = options;
-            raiseAddItemFailed(event);
+                // add everybody at the front of the queue that's ready to go
+                processReadyItems();
+            }, function (event) {
+                event.options = options;
+                raiseAddItemFailed(event);
 
-            // add everybody at the front of the queue that's ready to go
-            processReadyItems();
-        } );
-    },
-
-    /**
-     * Add a simple image to the viewer.
-     * The options are the same as the ones in {@link OpenSeadragon.Viewer#addTiledImage}
-     * except for options.tileSource which is replaced by options.url.
-     * @function
-     * @param {Object} options - See {@link OpenSeadragon.Viewer#addTiledImage}
-     * for all the options
-     * @param {String} options.url - The URL of the image to add.
-     * @fires OpenSeadragon.World.event:add-item
-     * @fires OpenSeadragon.Viewer.event:add-item-failed
-     */
-    addSimpleImage: function(options) {
-        $.console.assert(options, "[Viewer.addSimpleImage] options is required");
-        $.console.assert(options.url, "[Viewer.addSimpleImage] options.url is required");
-
-        var opts = $.extend({}, options, {
-            tileSource: {
-                type: 'image',
-                url:  options.url
-            }
-        });
-        delete opts.url;
-        this.addTiledImage(opts);
-    },
-
-    // deprecated
-    addLayer: function( options ) {
-        var _this = this;
-
-        $.console.error( "[Viewer.addLayer] this function is deprecated; use Viewer.addTiledImage() instead." );
-
-        var optionsClone = $.extend({}, options, {
-            success: function(event) {
-                _this.raiseEvent("add-layer", {
-                    options: options,
-                    drawer: event.item
-                });
-            },
-            error: function(event) {
-                _this.raiseEvent("add-layer-failed", event);
-            }
-        });
-
-        this.addTiledImage(optionsClone);
-        return this;
-    },
-
-    // deprecated
-    getLayerAtLevel: function( level ) {
-        $.console.error( "[Viewer.getLayerAtLevel] this function is deprecated; use World.getItemAt() instead." );
-        return this.world.getItemAt(level);
-    },
-
-    // deprecated
-    getLevelOfLayer: function( drawer ) {
-        $.console.error( "[Viewer.getLevelOfLayer] this function is deprecated; use World.getIndexOfItem() instead." );
-        return this.world.getIndexOfItem(drawer);
-    },
-
-    // deprecated
-    getLayersCount: function() {
-        $.console.error( "[Viewer.getLayersCount] this function is deprecated; use World.getItemCount() instead." );
-        return this.world.getItemCount();
-    },
-
-    // deprecated
-    setLayerLevel: function( drawer, level ) {
-        $.console.error( "[Viewer.setLayerLevel] this function is deprecated; use World.setItemIndex() instead." );
-        return this.world.setItemIndex(drawer, level);
-    },
-
-    // deprecated
-    removeLayer: function( drawer ) {
-        $.console.error( "[Viewer.removeLayer] this function is deprecated; use World.removeItem() instead." );
-        return this.world.removeItem(drawer);
-    },
-
-    /**
-     * Force the viewer to redraw its contents.
-     * @returns {OpenSeadragon.Viewer} Chainable.
-     */
-    forceRedraw: function() {
-        THIS[ this.hash ].forceRedraw = true;
-        return this;
-    },
-
-    /**
-     * @function
-     * @return {OpenSeadragon.Viewer} Chainable.
-     */
-    bindSequenceControls: function(){
-
-        //////////////////////////////////////////////////////////////////////////
-        // Image Sequence Controls
-        //////////////////////////////////////////////////////////////////////////
-        var onFocusHandler          = $.delegate( this, onFocus ),
-            onBlurHandler           = $.delegate( this, onBlur ),
-            onNextHandler           = $.delegate( this, onNext ),
-            onPreviousHandler       = $.delegate( this, onPrevious ),
-            navImages               = this.navImages,
-            useGroup                = true;
-
-        if( this.showSequenceControl ){
-
-            if( this.previousButton || this.nextButton ){
-                //if we are binding to custom buttons then layout and
-                //grouping is the responsibility of the page author
-                useGroup = false;
-            }
-
-            this.previousButton = new $.Button({
-                element:    this.previousButton ? $.getElement( this.previousButton ) : null,
-                clickTimeThreshold: this.clickTimeThreshold,
-                clickDistThreshold: this.clickDistThreshold,
-                tooltip:    $.getString( "Tooltips.PreviousPage" ),
-                srcRest:    resolveUrl( this.prefixUrl, navImages.previous.REST ),
-                srcGroup:   resolveUrl( this.prefixUrl, navImages.previous.GROUP ),
-                srcHover:   resolveUrl( this.prefixUrl, navImages.previous.HOVER ),
-                srcDown:    resolveUrl( this.prefixUrl, navImages.previous.DOWN ),
-                onRelease:  onPreviousHandler,
-                onFocus:    onFocusHandler,
-                onBlur:     onBlurHandler
+                // add everybody at the front of the queue that's ready to go
+                processReadyItems();
             });
-
-            this.nextButton = new $.Button({
-                element:    this.nextButton ? $.getElement( this.nextButton ) : null,
-                clickTimeThreshold: this.clickTimeThreshold,
-                clickDistThreshold: this.clickDistThreshold,
-                tooltip:    $.getString( "Tooltips.NextPage" ),
-                srcRest:    resolveUrl( this.prefixUrl, navImages.next.REST ),
-                srcGroup:   resolveUrl( this.prefixUrl, navImages.next.GROUP ),
-                srcHover:   resolveUrl( this.prefixUrl, navImages.next.HOVER ),
-                srcDown:    resolveUrl( this.prefixUrl, navImages.next.DOWN ),
-                onRelease:  onNextHandler,
-                onFocus:    onFocusHandler,
-                onBlur:     onBlurHandler
-            });
-
-            if( !this.navPrevNextWrap ){
-                this.previousButton.disable();
-            }
-
-            if (!this.tileSources || !this.tileSources.length) {
-                this.nextButton.disable();
-            }
-
-            if( useGroup ){
-                this.paging = new $.ButtonGroup({
-                    buttons: [
-                        this.previousButton,
-                        this.nextButton
-                    ],
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold
-                });
-
-                this.pagingControl = this.paging.element;
-
-                if( this.toolbar ){
-                    this.toolbar.addControl(
-                        this.pagingControl,
-                        {anchor: $.ControlAnchor.BOTTOM_RIGHT}
-                    );
-                }else{
-                    this.addControl(
-                        this.pagingControl,
-                        {anchor: this.sequenceControlAnchor || $.ControlAnchor.TOP_LEFT}
-                    );
-                }
-            }
-        }
-        return this;
-    },
-
-
-    /**
-     * @function
-     * @return {OpenSeadragon.Viewer} Chainable.
-     */
-    bindStandardControls: function(){
-        //////////////////////////////////////////////////////////////////////////
-        // Navigation Controls
-        //////////////////////////////////////////////////////////////////////////
-        var beginZoomingInHandler   = $.delegate( this, beginZoomingIn ),
-            endZoomingHandler       = $.delegate( this, endZooming ),
-            doSingleZoomInHandler   = $.delegate( this, doSingleZoomIn ),
-            beginZoomingOutHandler  = $.delegate( this, beginZoomingOut ),
-            doSingleZoomOutHandler  = $.delegate( this, doSingleZoomOut ),
-            onHomeHandler           = $.delegate( this, onHome ),
-            onFullScreenHandler     = $.delegate( this, onFullScreen ),
-            onRotateLeftHandler     = $.delegate( this, onRotateLeft ),
-            onRotateRightHandler    = $.delegate( this, onRotateRight ),
-            onFocusHandler          = $.delegate( this, onFocus ),
-            onBlurHandler           = $.delegate( this, onBlur ),
-            navImages               = this.navImages,
-            buttons                 = [],
-            useGroup                = true;
-
-
-        if ( this.showNavigationControl ) {
-
-            if( this.zoomInButton || this.zoomOutButton ||
-                this.homeButton || this.fullPageButton ||
-                this.rotateLeftButton || this.rotateRightButton ) {
-                //if we are binding to custom buttons then layout and
-                //grouping is the responsibility of the page author
-                useGroup = false;
-            }
-
-            if ( this.showZoomControl ) {
-                buttons.push( this.zoomInButton = new $.Button({
-                    element:    this.zoomInButton ? $.getElement( this.zoomInButton ) : null,
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold,
-                    tooltip:    $.getString( "Tooltips.ZoomIn" ),
-                    srcRest:    resolveUrl( this.prefixUrl, navImages.zoomIn.REST ),
-                    srcGroup:   resolveUrl( this.prefixUrl, navImages.zoomIn.GROUP ),
-                    srcHover:   resolveUrl( this.prefixUrl, navImages.zoomIn.HOVER ),
-                    srcDown:    resolveUrl( this.prefixUrl, navImages.zoomIn.DOWN ),
-                    onPress:    beginZoomingInHandler,
-                    onRelease:  endZoomingHandler,
-                    onClick:    doSingleZoomInHandler,
-                    onEnter:    beginZoomingInHandler,
-                    onExit:     endZoomingHandler,
-                    onFocus:    onFocusHandler,
-                    onBlur:     onBlurHandler
-                }));
-
-                buttons.push( this.zoomOutButton = new $.Button({
-                    element:    this.zoomOutButton ? $.getElement( this.zoomOutButton ) : null,
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold,
-                    tooltip:    $.getString( "Tooltips.ZoomOut" ),
-                    srcRest:    resolveUrl( this.prefixUrl, navImages.zoomOut.REST ),
-                    srcGroup:   resolveUrl( this.prefixUrl, navImages.zoomOut.GROUP ),
-                    srcHover:   resolveUrl( this.prefixUrl, navImages.zoomOut.HOVER ),
-                    srcDown:    resolveUrl( this.prefixUrl, navImages.zoomOut.DOWN ),
-                    onPress:    beginZoomingOutHandler,
-                    onRelease:  endZoomingHandler,
-                    onClick:    doSingleZoomOutHandler,
-                    onEnter:    beginZoomingOutHandler,
-                    onExit:     endZoomingHandler,
-                    onFocus:    onFocusHandler,
-                    onBlur:     onBlurHandler
-                }));
-            }
-
-            if ( this.showHomeControl ) {
-                buttons.push( this.homeButton = new $.Button({
-                    element:    this.homeButton ? $.getElement( this.homeButton ) : null,
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold,
-                    tooltip:    $.getString( "Tooltips.Home" ),
-                    srcRest:    resolveUrl( this.prefixUrl, navImages.home.REST ),
-                    srcGroup:   resolveUrl( this.prefixUrl, navImages.home.GROUP ),
-                    srcHover:   resolveUrl( this.prefixUrl, navImages.home.HOVER ),
-                    srcDown:    resolveUrl( this.prefixUrl, navImages.home.DOWN ),
-                    onRelease:  onHomeHandler,
-                    onFocus:    onFocusHandler,
-                    onBlur:     onBlurHandler
-                }));
-            }
-
-            if ( this.showFullPageControl ) {
-                buttons.push( this.fullPageButton = new $.Button({
-                    element:    this.fullPageButton ? $.getElement( this.fullPageButton ) : null,
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold,
-                    tooltip:    $.getString( "Tooltips.FullPage" ),
-                    srcRest:    resolveUrl( this.prefixUrl, navImages.fullpage.REST ),
-                    srcGroup:   resolveUrl( this.prefixUrl, navImages.fullpage.GROUP ),
-                    srcHover:   resolveUrl( this.prefixUrl, navImages.fullpage.HOVER ),
-                    srcDown:    resolveUrl( this.prefixUrl, navImages.fullpage.DOWN ),
-                    onRelease:  onFullScreenHandler,
-                    onFocus:    onFocusHandler,
-                    onBlur:     onBlurHandler
-                }));
-            }
-
-            if ( this.showRotationControl ) {
-                buttons.push( this.rotateLeftButton = new $.Button({
-                    element:    this.rotateLeftButton ? $.getElement( this.rotateLeftButton ) : null,
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold,
-                    tooltip:    $.getString( "Tooltips.RotateLeft" ),
-                    srcRest:    resolveUrl( this.prefixUrl, navImages.rotateleft.REST ),
-                    srcGroup:   resolveUrl( this.prefixUrl, navImages.rotateleft.GROUP ),
-                    srcHover:   resolveUrl( this.prefixUrl, navImages.rotateleft.HOVER ),
-                    srcDown:    resolveUrl( this.prefixUrl, navImages.rotateleft.DOWN ),
-                    onRelease:  onRotateLeftHandler,
-                    onFocus:    onFocusHandler,
-                    onBlur:     onBlurHandler
-                }));
-
-                buttons.push( this.rotateRightButton = new $.Button({
-                    element:    this.rotateRightButton ? $.getElement( this.rotateRightButton ) : null,
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold,
-                    tooltip:    $.getString( "Tooltips.RotateRight" ),
-                    srcRest:    resolveUrl( this.prefixUrl, navImages.rotateright.REST ),
-                    srcGroup:   resolveUrl( this.prefixUrl, navImages.rotateright.GROUP ),
-                    srcHover:   resolveUrl( this.prefixUrl, navImages.rotateright.HOVER ),
-                    srcDown:    resolveUrl( this.prefixUrl, navImages.rotateright.DOWN ),
-                    onRelease:  onRotateRightHandler,
-                    onFocus:    onFocusHandler,
-                    onBlur:     onBlurHandler
-                }));
-
-            }
-
-            if ( useGroup ) {
-                this.buttons = new $.ButtonGroup({
-                    buttons:            buttons,
-                    clickTimeThreshold: this.clickTimeThreshold,
-                    clickDistThreshold: this.clickDistThreshold
-                });
-
-                this.navControl  = this.buttons.element;
-                this.addHandler( 'open', $.delegate( this, lightUp ) );
-
-                if( this.toolbar ){
-                    this.toolbar.addControl(
-                        this.navControl,
-                        {anchor: this.navigationControlAnchor || $.ControlAnchor.TOP_LEFT}
-                    );
-                } else {
-                    this.addControl(
-                        this.navControl,
-                        {anchor: this.navigationControlAnchor || $.ControlAnchor.TOP_LEFT}
-                    );
-                }
-            }
-
-        }
-        return this;
-    },
-
-    /**
-     * Gets the active page of a sequence
-     * @function
-     * @return {Number}
-     */
-    currentPage: function() {
-        return this._sequenceIndex;
-    },
-
-    /**
-     * @function
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:page
-     */
-    goToPage: function( page ){
-        if( this.tileSources && page >= 0 && page < this.tileSources.length ){
-            this._sequenceIndex = page;
-
-            this._updateSequenceButtons( page );
-
-            this.open( this.tileSources[ page ] );
-
-            if( this.referenceStrip ){
-                this.referenceStrip.setFocus( page );
-            }
-
-            /**
-             * Raised when the page is changed on a viewer configured with multiple image sources (see {@link OpenSeadragon.Viewer#goToPage}).
-             *
-             * @event page
-             * @memberof OpenSeadragon.Viewer
-             * @type {Object}
-             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-             * @property {Number} page - The page index.
-             * @property {?Object} userData - Arbitrary subscriber-defined object.
-             */
-            this.raiseEvent( 'page', { page: page } );
-        }
-
-        return this;
-    },
-
-   /**
-     * Adds an html element as an overlay to the current viewport.  Useful for
-     * highlighting words or areas of interest on an image or other zoomable
-     * interface. The overlays added via this method are removed when the viewport
-     * is closed which include when changing page.
-     * @method
-     * @param {Element|String|Object} element - A reference to an element or an id for
-     *      the element which will be overlayed. Or an Object specifying the configuration for the overlay.
-     *      If using an object, see {@link OpenSeadragon.Overlay} for a list of
-     *      all available options.
-     * @param {OpenSeadragon.Point|OpenSeadragon.Rect} location - The point or
-     *      rectangle which will be overlayed. This is a viewport relative location.
-     * @param {OpenSeadragon.Placement} placement - The position of the
-     *      viewport which the location coordinates will be treated as relative
-     *      to.
-     * @param {function} onDraw - If supplied the callback is called when the overlay
-     *      needs to be drawn. It it the responsibility of the callback to do any drawing/positioning.
-     *      It is passed position, size and element.
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:add-overlay
-     */
-    addOverlay: function( element, location, placement, onDraw ) {
-        var options;
-        if( $.isPlainObject( element ) ){
-            options = element;
-        } else {
-            options = {
-                element: element,
-                location: location,
-                placement: placement,
-                onDraw: onDraw
-            };
-        }
-
-        element = $.getElement( options.element );
-
-        if ( getOverlayIndex( this.currentOverlays, element ) >= 0 ) {
-            // they're trying to add a duplicate overlay
-            return this;
-        }
-
-        var overlay = getOverlayObject( this, options);
-        this.currentOverlays.push(overlay);
-        overlay.drawHTML( this.overlaysContainer, this.viewport );
+        },
 
         /**
-         * Raised when an overlay is added to the viewer (see {@link OpenSeadragon.Viewer#addOverlay}).
-         *
-         * @event add-overlay
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {Element} element - The overlay element.
-         * @property {OpenSeadragon.Point|OpenSeadragon.Rect} location
-         * @property {OpenSeadragon.Placement} placement
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         * Add a simple image to the viewer.
+         * The options are the same as the ones in {@link OpenSeadragon.Viewer#addTiledImage}
+         * except for options.tileSource which is replaced by options.url.
+         * @function
+         * @param {Object} options - See {@link OpenSeadragon.Viewer#addTiledImage}
+         * for all the options
+         * @param {String} options.url - The URL of the image to add.
+         * @fires OpenSeadragon.World.event:add-item
+         * @fires OpenSeadragon.Viewer.event:add-item-failed
          */
-        this.raiseEvent( 'add-overlay', {
-            element: element,
-            location: options.location,
-            placement: options.placement
-        });
-        return this;
-    },
+        addSimpleImage: function (options) {
+            $.console.assert(options, "[Viewer.addSimpleImage] options is required");
+            $.console.assert(options.url, "[Viewer.addSimpleImage] options.url is required");
 
-    /**
-     * Updates the overlay represented by the reference to the element or
-     * element id moving it to the new location, relative to the new placement.
-     * @method
-     * @param {Element|String} element - A reference to an element or an id for
-     *      the element which is overlayed.
-     * @param {OpenSeadragon.Point|OpenSeadragon.Rect} location - The point or
-     *      rectangle which will be overlayed. This is a viewport relative location.
-     * @param {OpenSeadragon.Placement} placement - The position of the
-     *      viewport which the location coordinates will be treated as relative
-     *      to.
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:update-overlay
-     */
-    updateOverlay: function( element, location, placement ) {
-        var i;
+            var opts = $.extend({}, options, {
+                tileSource: {
+                    type: 'image',
+                    url: options.url
+                }
+            });
+            delete opts.url;
+            this.addTiledImage(opts);
+        },
 
-        element = $.getElement( element );
-        i = getOverlayIndex( this.currentOverlays, element );
+        // deprecated
+        addLayer: function (options) {
+            var _this = this;
 
-        if ( i >= 0 ) {
-            this.currentOverlays[ i ].update( location, placement );
-            THIS[ this.hash ].forceRedraw = true;
+            $.console.error("[Viewer.addLayer] this function is deprecated; use Viewer.addTiledImage() instead.");
+
+            var optionsClone = $.extend({}, options, {
+                success: function (event) {
+                    _this.raiseEvent("add-layer", {
+                        options: options,
+                        drawer: event.item
+                    });
+                },
+                error: function (event) {
+                    _this.raiseEvent("add-layer-failed", event);
+                }
+            });
+
+            this.addTiledImage(optionsClone);
+            return this;
+        },
+
+        // deprecated
+        getLayerAtLevel: function (level) {
+            $.console.error("[Viewer.getLayerAtLevel] this function is deprecated; use World.getItemAt() instead.");
+            return this.world.getItemAt(level);
+        },
+
+        // deprecated
+        getLevelOfLayer: function (drawer) {
+            $.console.error("[Viewer.getLevelOfLayer] this function is deprecated; use World.getIndexOfItem() instead.");
+            return this.world.getIndexOfItem(drawer);
+        },
+
+        // deprecated
+        getLayersCount: function () {
+            $.console.error("[Viewer.getLayersCount] this function is deprecated; use World.getItemCount() instead.");
+            return this.world.getItemCount();
+        },
+
+        // deprecated
+        setLayerLevel: function (drawer, level) {
+            $.console.error("[Viewer.setLayerLevel] this function is deprecated; use World.setItemIndex() instead.");
+            return this.world.setItemIndex(drawer, level);
+        },
+
+        // deprecated
+        removeLayer: function (drawer) {
+            $.console.error("[Viewer.removeLayer] this function is deprecated; use World.removeItem() instead.");
+            return this.world.removeItem(drawer);
+        },
+
+        /**
+         * Force the viewer to redraw its contents.
+         * @returns {OpenSeadragon.Viewer} Chainable.
+         */
+        forceRedraw: function () {
+            THIS[this.hash].forceRedraw = true;
+            return this;
+        },
+
+        /**
+         * @function
+         * @return {OpenSeadragon.Viewer} Chainable.
+         */
+        bindSequenceControls: function () {
+
+            //////////////////////////////////////////////////////////////////////////
+            // Image Sequence Controls
+            //////////////////////////////////////////////////////////////////////////
+            var onFocusHandler = $.delegate(this, onFocus),
+                onBlurHandler = $.delegate(this, onBlur),
+                onNextHandler = $.delegate(this, onNext),
+                onPreviousHandler = $.delegate(this, onPrevious),
+                navImages = this.navImages,
+                useGroup = true;
+
+            if (this.showSequenceControl) {
+
+                if (this.previousButton || this.nextButton) {
+                    //if we are binding to custom buttons then layout and
+                    //grouping is the responsibility of the page author
+                    useGroup = false;
+                }
+
+                this.previousButton = new $.Button({
+                    element: this.previousButton ? $.getElement(this.previousButton) : null,
+                    clickTimeThreshold: this.clickTimeThreshold,
+                    clickDistThreshold: this.clickDistThreshold,
+                    tooltip: $.getString("Tooltips.PreviousPage"),
+                    srcRest: resolveUrl(this.prefixUrl, navImages.previous.REST),
+                    srcGroup: resolveUrl(this.prefixUrl, navImages.previous.GROUP),
+                    srcHover: resolveUrl(this.prefixUrl, navImages.previous.HOVER),
+                    srcDown: resolveUrl(this.prefixUrl, navImages.previous.DOWN),
+                    onRelease: onPreviousHandler,
+                    onFocus: onFocusHandler,
+                    onBlur: onBlurHandler
+                });
+
+                this.nextButton = new $.Button({
+                    element: this.nextButton ? $.getElement(this.nextButton) : null,
+                    clickTimeThreshold: this.clickTimeThreshold,
+                    clickDistThreshold: this.clickDistThreshold,
+                    tooltip: $.getString("Tooltips.NextPage"),
+                    srcRest: resolveUrl(this.prefixUrl, navImages.next.REST),
+                    srcGroup: resolveUrl(this.prefixUrl, navImages.next.GROUP),
+                    srcHover: resolveUrl(this.prefixUrl, navImages.next.HOVER),
+                    srcDown: resolveUrl(this.prefixUrl, navImages.next.DOWN),
+                    onRelease: onNextHandler,
+                    onFocus: onFocusHandler,
+                    onBlur: onBlurHandler
+                });
+
+                if (!this.navPrevNextWrap) {
+                    this.previousButton.disable();
+                }
+
+                if (!this.tileSources || !this.tileSources.length) {
+                    this.nextButton.disable();
+                }
+
+                if (useGroup) {
+                    this.paging = new $.ButtonGroup({
+                        buttons: [
+                            this.previousButton,
+                            this.nextButton
+                        ],
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold
+                    });
+
+                    this.pagingControl = this.paging.element;
+
+                    if (this.toolbar) {
+                        this.toolbar.addControl(
+                            this.pagingControl,
+                            { anchor: $.ControlAnchor.BOTTOM_RIGHT }
+                        );
+                    } else {
+                        this.addControl(
+                            this.pagingControl,
+                            { anchor: this.sequenceControlAnchor || $.ControlAnchor.TOP_LEFT }
+                        );
+                    }
+                }
+            }
+            return this;
+        },
+
+
+        /**
+         * @function
+         * @return {OpenSeadragon.Viewer} Chainable.
+         */
+        bindStandardControls: function () {
+            //////////////////////////////////////////////////////////////////////////
+            // Navigation Controls
+            //////////////////////////////////////////////////////////////////////////
+            var beginZoomingInHandler = $.delegate(this, beginZoomingIn),
+                endZoomingHandler = $.delegate(this, endZooming),
+                doSingleZoomInHandler = $.delegate(this, doSingleZoomIn),
+                beginZoomingOutHandler = $.delegate(this, beginZoomingOut),
+                doSingleZoomOutHandler = $.delegate(this, doSingleZoomOut),
+                onHomeHandler = $.delegate(this, onHome),
+                onFullScreenHandler = $.delegate(this, onFullScreen),
+                onRotateLeftHandler = $.delegate(this, onRotateLeft),
+                onRotateRightHandler = $.delegate(this, onRotateRight),
+                onFocusHandler = $.delegate(this, onFocus),
+                onBlurHandler = $.delegate(this, onBlur),
+                navImages = this.navImages,
+                buttons = [],
+                useGroup = true;
+
+
+            if (this.showNavigationControl) {
+
+                if (this.zoomInButton || this.zoomOutButton ||
+                    this.homeButton || this.fullPageButton ||
+                    this.rotateLeftButton || this.rotateRightButton) {
+                    //if we are binding to custom buttons then layout and
+                    //grouping is the responsibility of the page author
+                    useGroup = false;
+                }
+
+                if (this.showZoomControl) {
+                    buttons.push(this.zoomInButton = new $.Button({
+                        element: this.zoomInButton ? $.getElement(this.zoomInButton) : null,
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold,
+                        tooltip: $.getString("Tooltips.ZoomIn"),
+                        srcRest: resolveUrl(this.prefixUrl, navImages.zoomIn.REST),
+                        srcGroup: resolveUrl(this.prefixUrl, navImages.zoomIn.GROUP),
+                        srcHover: resolveUrl(this.prefixUrl, navImages.zoomIn.HOVER),
+                        srcDown: resolveUrl(this.prefixUrl, navImages.zoomIn.DOWN),
+                        onPress: beginZoomingInHandler,
+                        onRelease: endZoomingHandler,
+                        onClick: doSingleZoomInHandler,
+                        onEnter: beginZoomingInHandler,
+                        onExit: endZoomingHandler,
+                        onFocus: onFocusHandler,
+                        onBlur: onBlurHandler
+                    }));
+
+                    buttons.push(this.zoomOutButton = new $.Button({
+                        element: this.zoomOutButton ? $.getElement(this.zoomOutButton) : null,
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold,
+                        tooltip: $.getString("Tooltips.ZoomOut"),
+                        srcRest: resolveUrl(this.prefixUrl, navImages.zoomOut.REST),
+                        srcGroup: resolveUrl(this.prefixUrl, navImages.zoomOut.GROUP),
+                        srcHover: resolveUrl(this.prefixUrl, navImages.zoomOut.HOVER),
+                        srcDown: resolveUrl(this.prefixUrl, navImages.zoomOut.DOWN),
+                        onPress: beginZoomingOutHandler,
+                        onRelease: endZoomingHandler,
+                        onClick: doSingleZoomOutHandler,
+                        onEnter: beginZoomingOutHandler,
+                        onExit: endZoomingHandler,
+                        onFocus: onFocusHandler,
+                        onBlur: onBlurHandler
+                    }));
+                }
+
+                if (this.showHomeControl) {
+                    buttons.push(this.homeButton = new $.Button({
+                        element: this.homeButton ? $.getElement(this.homeButton) : null,
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold,
+                        tooltip: $.getString("Tooltips.Home"),
+                        srcRest: resolveUrl(this.prefixUrl, navImages.home.REST),
+                        srcGroup: resolveUrl(this.prefixUrl, navImages.home.GROUP),
+                        srcHover: resolveUrl(this.prefixUrl, navImages.home.HOVER),
+                        srcDown: resolveUrl(this.prefixUrl, navImages.home.DOWN),
+                        onRelease: onHomeHandler,
+                        onFocus: onFocusHandler,
+                        onBlur: onBlurHandler
+                    }));
+                }
+
+                if (this.showFullPageControl) {
+                    buttons.push(this.fullPageButton = new $.Button({
+                        element: this.fullPageButton ? $.getElement(this.fullPageButton) : null,
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold,
+                        tooltip: $.getString("Tooltips.FullPage"),
+                        srcRest: resolveUrl(this.prefixUrl, navImages.fullpage.REST),
+                        srcGroup: resolveUrl(this.prefixUrl, navImages.fullpage.GROUP),
+                        srcHover: resolveUrl(this.prefixUrl, navImages.fullpage.HOVER),
+                        srcDown: resolveUrl(this.prefixUrl, navImages.fullpage.DOWN),
+                        onRelease: onFullScreenHandler,
+                        onFocus: onFocusHandler,
+                        onBlur: onBlurHandler
+                    }));
+                }
+
+                if (this.showRotationControl) {
+                    buttons.push(this.rotateLeftButton = new $.Button({
+                        element: this.rotateLeftButton ? $.getElement(this.rotateLeftButton) : null,
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold,
+                        tooltip: $.getString("Tooltips.RotateLeft"),
+                        srcRest: resolveUrl(this.prefixUrl, navImages.rotateleft.REST),
+                        srcGroup: resolveUrl(this.prefixUrl, navImages.rotateleft.GROUP),
+                        srcHover: resolveUrl(this.prefixUrl, navImages.rotateleft.HOVER),
+                        srcDown: resolveUrl(this.prefixUrl, navImages.rotateleft.DOWN),
+                        onRelease: onRotateLeftHandler,
+                        onFocus: onFocusHandler,
+                        onBlur: onBlurHandler
+                    }));
+
+                    buttons.push(this.rotateRightButton = new $.Button({
+                        element: this.rotateRightButton ? $.getElement(this.rotateRightButton) : null,
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold,
+                        tooltip: $.getString("Tooltips.RotateRight"),
+                        srcRest: resolveUrl(this.prefixUrl, navImages.rotateright.REST),
+                        srcGroup: resolveUrl(this.prefixUrl, navImages.rotateright.GROUP),
+                        srcHover: resolveUrl(this.prefixUrl, navImages.rotateright.HOVER),
+                        srcDown: resolveUrl(this.prefixUrl, navImages.rotateright.DOWN),
+                        onRelease: onRotateRightHandler,
+                        onFocus: onFocusHandler,
+                        onBlur: onBlurHandler
+                    }));
+
+                }
+
+                if (useGroup) {
+                    this.buttons = new $.ButtonGroup({
+                        buttons: buttons,
+                        clickTimeThreshold: this.clickTimeThreshold,
+                        clickDistThreshold: this.clickDistThreshold
+                    });
+
+                    this.navControl = this.buttons.element;
+                    this.addHandler('open', $.delegate(this, lightUp));
+
+                    if (this.toolbar) {
+                        this.toolbar.addControl(
+                            this.navControl,
+                            { anchor: this.navigationControlAnchor || $.ControlAnchor.TOP_LEFT }
+                        );
+                    } else {
+                        this.addControl(
+                            this.navControl,
+                            { anchor: this.navigationControlAnchor || $.ControlAnchor.TOP_LEFT }
+                        );
+                    }
+                }
+
+            }
+            return this;
+        },
+
+        /**
+         * Gets the active page of a sequence
+         * @function
+         * @return {Number}
+         */
+        currentPage: function () {
+            return this._sequenceIndex;
+        },
+
+        /**
+         * @function
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:page
+         */
+        goToPage: function (page) {
+            if (this.tileSources && page >= 0 && page < this.tileSources.length) {
+                this._sequenceIndex = page;
+
+                this._updateSequenceButtons(page);
+
+                this.open(this.tileSources[page]);
+
+                if (this.referenceStrip) {
+                    this.referenceStrip.setFocus(page);
+                }
+
+                /**
+                 * Raised when the page is changed on a viewer configured with multiple image sources (see {@link OpenSeadragon.Viewer#goToPage}).
+                 *
+                 * @event page
+                 * @memberof OpenSeadragon.Viewer
+                 * @type {Object}
+                 * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+                 * @property {Number} page - The page index.
+                 * @property {?Object} userData - Arbitrary subscriber-defined object.
+                 */
+                this.raiseEvent('page', { page: page });
+            }
+
+            return this;
+        },
+
+        /**
+          * Adds an html element as an overlay to the current viewport.  Useful for
+          * highlighting words or areas of interest on an image or other zoomable
+          * interface. The overlays added via this method are removed when the viewport
+          * is closed which include when changing page.
+          * @method
+          * @param {Element|String|Object} element - A reference to an element or an id for
+          *      the element which will be overlayed. Or an Object specifying the configuration for the overlay.
+          *      If using an object, see {@link OpenSeadragon.Overlay} for a list of
+          *      all available options.
+          * @param {OpenSeadragon.Point|OpenSeadragon.Rect} location - The point or
+          *      rectangle which will be overlayed. This is a viewport relative location.
+          * @param {OpenSeadragon.Placement} placement - The position of the
+          *      viewport which the location coordinates will be treated as relative
+          *      to.
+          * @param {function} onDraw - If supplied the callback is called when the overlay
+          *      needs to be drawn. It it the responsibility of the callback to do any drawing/positioning.
+          *      It is passed position, size and element.
+          * @return {OpenSeadragon.Viewer} Chainable.
+          * @fires OpenSeadragon.Viewer.event:add-overlay
+          */
+        addOverlay: function (element, location, placement, onDraw) {
+            var options;
+            if ($.isPlainObject(element)) {
+                options = element;
+            } else {
+                options = {
+                    element: element,
+                    location: location,
+                    placement: placement,
+                    onDraw: onDraw
+                };
+            }
+
+            element = $.getElement(options.element);
+
+            if (getOverlayIndex(this.currentOverlays, element) >= 0) {
+                // they're trying to add a duplicate overlay
+                return this;
+            }
+
+            var overlay = getOverlayObject(this, options);
+            this.currentOverlays.push(overlay);
+            overlay.drawHTML(this.overlaysContainer, this.viewport);
+
             /**
-             * Raised when an overlay's location or placement changes
-             * (see {@link OpenSeadragon.Viewer#updateOverlay}).
+             * Raised when an overlay is added to the viewer (see {@link OpenSeadragon.Viewer#addOverlay}).
              *
-             * @event update-overlay
+             * @event add-overlay
              * @memberof OpenSeadragon.Viewer
              * @type {object}
-             * @property {OpenSeadragon.Viewer} eventSource - A reference to the
-             * Viewer which raised the event.
-             * @property {Element} element
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+             * @property {Element} element - The overlay element.
              * @property {OpenSeadragon.Point|OpenSeadragon.Rect} location
              * @property {OpenSeadragon.Placement} placement
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            this.raiseEvent( 'update-overlay', {
+            this.raiseEvent('add-overlay', {
                 element: element,
-                location: location,
-                placement: placement
+                location: options.location,
+                placement: options.placement
             });
-        }
-        return this;
-    },
+            return this;
+        },
 
-    /**
-     * Removes an overlay identified by the reference element or element id
-     * and schedules an update.
-     * @method
-     * @param {Element|String} element - A reference to the element or an
-     *      element id which represent the ovelay content to be removed.
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:remove-overlay
-     */
-    removeOverlay: function( element ) {
-        var i;
+        /**
+         * Updates the overlay represented by the reference to the element or
+         * element id moving it to the new location, relative to the new placement.
+         * @method
+         * @param {Element|String} element - A reference to an element or an id for
+         *      the element which is overlayed.
+         * @param {OpenSeadragon.Point|OpenSeadragon.Rect} location - The point or
+         *      rectangle which will be overlayed. This is a viewport relative location.
+         * @param {OpenSeadragon.Placement} placement - The position of the
+         *      viewport which the location coordinates will be treated as relative
+         *      to.
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:update-overlay
+         */
+        updateOverlay: function (element, location, placement) {
+            var i;
 
-        element = $.getElement( element );
-        i = getOverlayIndex( this.currentOverlays, element );
+            element = $.getElement(element);
+            i = getOverlayIndex(this.currentOverlays, element);
 
-        if ( i >= 0 ) {
-            this.currentOverlays[ i ].destroy();
-            this.currentOverlays.splice( i, 1 );
-            THIS[ this.hash ].forceRedraw = true;
+            if (i >= 0) {
+                this.currentOverlays[i].update(location, placement);
+                THIS[this.hash].forceRedraw = true;
+                /**
+                 * Raised when an overlay's location or placement changes
+                 * (see {@link OpenSeadragon.Viewer#updateOverlay}).
+                 *
+                 * @event update-overlay
+                 * @memberof OpenSeadragon.Viewer
+                 * @type {object}
+                 * @property {OpenSeadragon.Viewer} eventSource - A reference to the
+                 * Viewer which raised the event.
+                 * @property {Element} element
+                 * @property {OpenSeadragon.Point|OpenSeadragon.Rect} location
+                 * @property {OpenSeadragon.Placement} placement
+                 * @property {?Object} userData - Arbitrary subscriber-defined object.
+                 */
+                this.raiseEvent('update-overlay', {
+                    element: element,
+                    location: location,
+                    placement: placement
+                });
+            }
+            return this;
+        },
+
+        /**
+         * Removes an overlay identified by the reference element or element id
+         * and schedules an update.
+         * @method
+         * @param {Element|String} element - A reference to the element or an
+         *      element id which represent the ovelay content to be removed.
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:remove-overlay
+         */
+        removeOverlay: function (element) {
+            var i;
+
+            element = $.getElement(element);
+            i = getOverlayIndex(this.currentOverlays, element);
+
+            if (i >= 0) {
+                this.currentOverlays[i].destroy();
+                this.currentOverlays.splice(i, 1);
+                THIS[this.hash].forceRedraw = true;
+                /**
+                 * Raised when an overlay is removed from the viewer
+                 * (see {@link OpenSeadragon.Viewer#removeOverlay}).
+                 *
+                 * @event remove-overlay
+                 * @memberof OpenSeadragon.Viewer
+                 * @type {object}
+                 * @property {OpenSeadragon.Viewer} eventSource - A reference to the
+                 * Viewer which raised the event.
+                 * @property {Element} element - The overlay element.
+                 * @property {?Object} userData - Arbitrary subscriber-defined object.
+                 */
+                this.raiseEvent('remove-overlay', {
+                    element: element
+                });
+            }
+            return this;
+        },
+
+        /**
+         * Removes all currently configured Overlays from this Viewer and schedules
+         * an update.
+         * @method
+         * @return {OpenSeadragon.Viewer} Chainable.
+         * @fires OpenSeadragon.Viewer.event:clear-overlay
+         */
+        clearOverlays: function () {
+            while (this.currentOverlays.length > 0) {
+                this.currentOverlays.pop().destroy();
+            }
+            THIS[this.hash].forceRedraw = true;
             /**
-             * Raised when an overlay is removed from the viewer
-             * (see {@link OpenSeadragon.Viewer#removeOverlay}).
+             * Raised when all overlays are removed from the viewer (see {@link OpenSeadragon.Drawer#clearOverlays}).
              *
-             * @event remove-overlay
+             * @event clear-overlay
              * @memberof OpenSeadragon.Viewer
              * @type {object}
-             * @property {OpenSeadragon.Viewer} eventSource - A reference to the
-             * Viewer which raised the event.
-             * @property {Element} element - The overlay element.
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            this.raiseEvent( 'remove-overlay', {
-                element: element
-            });
-        }
-        return this;
-    },
+            this.raiseEvent('clear-overlay', {});
+            return this;
+        },
 
-    /**
-     * Removes all currently configured Overlays from this Viewer and schedules
-     * an update.
-     * @method
-     * @return {OpenSeadragon.Viewer} Chainable.
-     * @fires OpenSeadragon.Viewer.event:clear-overlay
-     */
-    clearOverlays: function() {
-        while ( this.currentOverlays.length > 0 ) {
-            this.currentOverlays.pop().destroy();
-        }
-        THIS[ this.hash ].forceRedraw = true;
         /**
-         * Raised when all overlays are removed from the viewer (see {@link OpenSeadragon.Drawer#clearOverlays}).
-         *
-         * @event clear-overlay
-         * @memberof OpenSeadragon.Viewer
-         * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-         * @property {?Object} userData - Arbitrary subscriber-defined object.
+        * Finds an overlay identified by the reference element or element id
+        * and returns it as an object, return null if not found.
+        * @method
+        * @param {Element|String} element - A reference to the element or an
+        *      element id which represents the overlay content.
+        * @return {OpenSeadragon.Overlay} the matching overlay or null if none found.
+        */
+        getOverlayById: function (element) {
+            var i;
+
+            element = $.getElement(element);
+            i = getOverlayIndex(this.currentOverlays, element);
+
+            if (i >= 0) {
+                return this.currentOverlays[i];
+            } else {
+                return null;
+            }
+        },
+
+        /**
+         * Updates the sequence buttons.
+         * @function OpenSeadragon.Viewer.prototype._updateSequenceButtons
+         * @private
+         * @param {Number} Sequence Value
          */
-        this.raiseEvent( 'clear-overlay', {} );
-        return this;
-    },
+        _updateSequenceButtons: function (page) {
 
-     /**
-     * Finds an overlay identified by the reference element or element id
-     * and returns it as an object, return null if not found.
-     * @method
-     * @param {Element|String} element - A reference to the element or an
-     *      element id which represents the overlay content.
-     * @return {OpenSeadragon.Overlay} the matching overlay or null if none found.
-     */
-    getOverlayById: function( element ) {
-        var i;
-
-        element = $.getElement( element );
-        i = getOverlayIndex( this.currentOverlays, element );
-
-        if (i >= 0) {
-            return this.currentOverlays[i];
-        } else {
-            return null;
-        }
-    },
-
-    /**
-     * Updates the sequence buttons.
-     * @function OpenSeadragon.Viewer.prototype._updateSequenceButtons
-     * @private
-     * @param {Number} Sequence Value
-     */
-    _updateSequenceButtons: function( page ) {
-
-            if ( this.nextButton ) {
-                if(!this.tileSources || this.tileSources.length - 1 === page) {
+            if (this.nextButton) {
+                if (!this.tileSources || this.tileSources.length - 1 === page) {
                     //Disable next button
-                    if ( !this.navPrevNextWrap ) {
+                    if (!this.navPrevNextWrap) {
                         this.nextButton.disable();
                     }
                 } else {
                     this.nextButton.enable();
                 }
             }
-            if ( this.previousButton ) {
-                if ( page > 0 ) {
+            if (this.previousButton) {
+                if (page > 0) {
                     //Enable previous button
                     this.previousButton.enable();
                 } else {
-                    if ( !this.navPrevNextWrap ) {
+                    if (!this.navPrevNextWrap) {
                         this.previousButton.disable();
                     }
                 }
             }
-      },
+        },
 
-    /**
-     * Display a message in the viewport
-     * @function OpenSeadragon.Viewer.prototype._showMessage
-     * @private
-     * @param {String} text message
-     */
-    _showMessage: function ( message ) {
-        this._hideMessage();
+        /**
+         * Display a message in the viewport
+         * @function OpenSeadragon.Viewer.prototype._showMessage
+         * @private
+         * @param {String} text message
+         */
+        _showMessage: function (message) {
+            this._hideMessage();
 
-        var div = $.makeNeutralElement( "div" );
-        div.appendChild( document.createTextNode( message ) );
+            var div = $.makeNeutralElement("div");
+            div.appendChild(document.createTextNode(message));
 
-        this.messageDiv = $.makeCenteredNode( div );
+            this.messageDiv = $.makeCenteredNode(div);
 
-        $.addClass(this.messageDiv, "openseadragon-message");
+            $.addClass(this.messageDiv, "openseadragon-message");
 
-        this.container.appendChild( this.messageDiv );
-    },
+            this.container.appendChild(this.messageDiv);
+        },
 
-    /**
-     * Hide any currently displayed viewport message
-     * @function OpenSeadragon.Viewer.prototype._hideMessage
-     * @private
-     */
-    _hideMessage: function () {
-        var div = this.messageDiv;
-        if (div) {
-            div.parentNode.removeChild(div);
-            delete this.messageDiv;
-        }
-    },
+        /**
+         * Hide any currently displayed viewport message
+         * @function OpenSeadragon.Viewer.prototype._hideMessage
+         * @private
+         */
+        _hideMessage: function () {
+            var div = this.messageDiv;
+            if (div) {
+                div.parentNode.removeChild(div);
+                delete this.messageDiv;
+            }
+        },
 
-    /**
-     * Gets this viewer's gesture settings for the given pointer device type.
-     * @method
-     * @param {String} type - The pointer device type to get the gesture settings for ("mouse", "touch", "pen", etc.).
-     * @return {OpenSeadragon.GestureSettings}
-     */
-    gestureSettingsByDeviceType: function ( type ) {
-        switch ( type ) {
-            case 'mouse':
-                return this.gestureSettingsMouse;
-            case 'touch':
-                return this.gestureSettingsTouch;
-            case 'pen':
-                return this.gestureSettingsPen;
-            default:
-                return this.gestureSettingsUnknown;
-        }
-    },
+        /**
+         * Gets this viewer's gesture settings for the given pointer device type.
+         * @method
+         * @param {String} type - The pointer device type to get the gesture settings for ("mouse", "touch", "pen", etc.).
+         * @return {OpenSeadragon.GestureSettings}
+         */
+        gestureSettingsByDeviceType: function (type) {
+            switch (type) {
+                case 'mouse':
+                    return this.gestureSettingsMouse;
+                case 'touch':
+                    return this.gestureSettingsTouch;
+                case 'pen':
+                    return this.gestureSettingsPen;
+                default:
+                    return this.gestureSettingsUnknown;
+            }
+        },
 
-    // private
-    _drawOverlays: function() {
-        var i,
-            length = this.currentOverlays.length;
-        for ( i = 0; i < length; i++ ) {
-            this.currentOverlays[ i ].drawHTML( this.overlaysContainer, this.viewport );
-        }
-    },
+        // private
+        _drawOverlays: function () {
+            var i,
+                length = this.currentOverlays.length;
+            for (i = 0; i < length; i++) {
+                this.currentOverlays[i].drawHTML(this.overlaysContainer, this.viewport);
+            }
+        },
 
-    /**
-     * Cancel the "in flight" images.
-     */
-    _cancelPendingImages: function() {
-        this._loadQueue = [];
-    },
+        /**
+         * Cancel the "in flight" images.
+         */
+        _cancelPendingImages: function () {
+            this._loadQueue = [];
+        },
 
-    /**
-     * Removes the reference strip and disables displaying it.
-     * @function
-     */
-    removeReferenceStrip: function() {
-        this.showReferenceStrip = false;
+        /**
+         * Removes the reference strip and disables displaying it.
+         * @function
+         */
+        removeReferenceStrip: function () {
+            this.showReferenceStrip = false;
 
-        if (this.referenceStrip) {
-            this.referenceStrip.destroy();
-            this.referenceStrip = null;
-        }
-    },
-
-    /**
-     * Enables and displays the reference strip based on the currently set tileSources.
-     * Works only when the Viewer has sequenceMode set to true.
-     * @function
-     */
-    addReferenceStrip: function() {
-        this.showReferenceStrip = true;
-
-        if (this.sequenceMode) {
             if (this.referenceStrip) {
-                return;
+                this.referenceStrip.destroy();
+                this.referenceStrip = null;
             }
+        },
 
-            if (this.tileSources.length && this.tileSources.length > 1) {
-                this.referenceStrip = new $.ReferenceStrip({
-                    id:          this.referenceStripElement,
-                    position:    this.referenceStripPosition,
-                    sizeRatio:   this.referenceStripSizeRatio,
-                    scroll:      this.referenceStripScroll,
-                    height:      this.referenceStripHeight,
-                    width:       this.referenceStripWidth,
-                    tileSources: this.tileSources,
-                    prefixUrl:   this.prefixUrl,
-                    viewer:      this
-                });
+        /**
+         * Enables and displays the reference strip based on the currently set tileSources.
+         * Works only when the Viewer has sequenceMode set to true.
+         * @function
+         */
+        addReferenceStrip: function () {
+            this.showReferenceStrip = true;
 
-                this.referenceStrip.setFocus( this._sequenceIndex );
-            }
-        } else {
-            $.console.warn('Attempting to display a reference strip while "sequenceMode" is off.');
-        }
-    }
-});
-
-
-/**
- * _getSafeElemSize is like getElementSize(), but refuses to return 0 for x or y,
- * which was causing some calling operations to return NaN.
- * @returns {Point}
- * @private
- */
-function _getSafeElemSize (oElement) {
-    oElement = $.getElement( oElement );
-
-    return new $.Point(
-        (oElement.clientWidth === 0 ? 1 : oElement.clientWidth),
-        (oElement.clientHeight === 0 ? 1 : oElement.clientHeight)
-    );
-}
-
-
-/**
- * @function
- * @private
- */
-function getTileSourceImplementation( viewer, tileSource, imgOptions, successCallback,
-    failCallback ) {
-    var _this = viewer;
-
-    //allow plain xml strings or json strings to be parsed here
-    if ( $.type( tileSource ) == 'string' ) {
-        //xml should start with "<" and end with ">"
-        if ( tileSource.match( /^\s*<.*>\s*$/ ) ) {
-            tileSource = $.parseXml( tileSource );
-        //json should start with "{" or "[" and end with "}" or "]"
-        } else if ( tileSource.match(/^\s*[\{\[].*[\}\]]\s*$/ ) ) {
-            try {
-              var tileSourceJ = $.parseJSON(tileSource);
-              tileSource = tileSourceJ;
-            } catch (e) {
-              //tileSource = tileSource;
-            }
-        }
-    }
-
-    function waitUntilReady(tileSource, originalTileSource) {
-        if (tileSource.ready) {
-            successCallback(tileSource);
-        } else {
-            tileSource.addHandler('ready', function () {
-                successCallback(tileSource);
-            });
-            tileSource.addHandler('open-failed', function (event) {
-                failCallback({
-                    message: event.message,
-                    source: originalTileSource
-                });
-            });
-        }
-    }
-
-    setTimeout( function() {
-        if ( $.type( tileSource ) == 'string' ) {
-            //If its still a string it means it must be a url at this point
-            tileSource = new $.TileSource({
-                url: tileSource,
-                crossOriginPolicy: imgOptions.crossOriginPolicy !== undefined ?
-                    imgOptions.crossOriginPolicy : viewer.crossOriginPolicy,
-                ajaxWithCredentials: viewer.ajaxWithCredentials,
-                ajaxHeaders: viewer.ajaxHeaders,
-                useCanvas: viewer.useCanvas,
-                success: function( event ) {
-                    successCallback( event.tileSource );
-                }
-            });
-            tileSource.addHandler( 'open-failed', function( event ) {
-                failCallback( event );
-            } );
-
-        } else if ($.isPlainObject(tileSource) || tileSource.nodeType) {
-            if (tileSource.crossOriginPolicy === undefined &&
-                (imgOptions.crossOriginPolicy !== undefined || viewer.crossOriginPolicy !== undefined)) {
-                tileSource.crossOriginPolicy = imgOptions.crossOriginPolicy !== undefined ?
-                    imgOptions.crossOriginPolicy : viewer.crossOriginPolicy;
-            }
-            if (tileSource.ajaxWithCredentials === undefined) {
-                tileSource.ajaxWithCredentials = viewer.ajaxWithCredentials;
-            }
-            if (tileSource.useCanvas === undefined) {
-                tileSource.useCanvas = viewer.useCanvas;
-            }
-
-            if ( $.isFunction( tileSource.getTileUrl ) ) {
-                //Custom tile source
-                var customTileSource = new $.TileSource( tileSource );
-                customTileSource.getTileUrl = tileSource.getTileUrl;
-                successCallback( customTileSource );
-            } else {
-                //inline configuration
-                var $TileSource = $.TileSource.determineType( _this, tileSource );
-                if ( !$TileSource ) {
-                    failCallback( {
-                        message: "Unable to load TileSource",
-                        source: tileSource
-                    });
+            if (this.sequenceMode) {
+                if (this.referenceStrip) {
                     return;
                 }
-                var options = $TileSource.prototype.configure.apply( _this, [ tileSource ] );
-                waitUntilReady(new $TileSource(options), tileSource);
+
+                if (this.tileSources.length && this.tileSources.length > 1) {
+                    this.referenceStrip = new $.ReferenceStrip({
+                        id: this.referenceStripElement,
+                        position: this.referenceStripPosition,
+                        sizeRatio: this.referenceStripSizeRatio,
+                        scroll: this.referenceStripScroll,
+                        height: this.referenceStripHeight,
+                        width: this.referenceStripWidth,
+                        tileSources: this.tileSources,
+                        prefixUrl: this.prefixUrl,
+                        viewer: this
+                    });
+
+                    this.referenceStrip.setFocus(this._sequenceIndex);
+                }
+            } else {
+                $.console.warn('Attempting to display a reference strip while "sequenceMode" is off.');
             }
-        } else {
-            //can assume it's already a tile source implementation
-            waitUntilReady(tileSource, tileSource);
         }
     });
-}
 
-function getOverlayObject( viewer, overlay ) {
-    if ( overlay instanceof $.Overlay ) {
-        return overlay;
-    }
 
-    var element = null;
-    if ( overlay.element ) {
-        element = $.getElement( overlay.element );
-    } else {
-        var id = overlay.id ?
-            overlay.id :
-            "openseadragon-overlay-" + Math.floor( Math.random() * 10000000 );
+    /**
+     * _getSafeElemSize is like getElementSize(), but refuses to return 0 for x or y,
+     * which was causing some calling operations to return NaN.
+     * @returns {Point}
+     * @private
+     */
+    function _getSafeElemSize(oElement) {
+        oElement = $.getElement(oElement);
 
-        element = $.getElement( overlay.id );
-        if ( !element ) {
-            element         = document.createElement( "a" );
-            element.href    = "#/overlay/" + id;
-        }
-        element.id = id;
-        $.addClass( element, overlay.className ?
-            overlay.className :
-            "openseadragon-overlay"
+        return new $.Point(
+            (oElement.clientWidth === 0 ? 1 : oElement.clientWidth),
+            (oElement.clientHeight === 0 ? 1 : oElement.clientHeight)
         );
     }
 
-    var location = overlay.location;
-    var width = overlay.width;
-    var height = overlay.height;
-    if (!location) {
-        var x = overlay.x;
-        var y = overlay.y;
-        if (overlay.px !== undefined) {
-            var rect = viewer.viewport.imageToViewportRectangle(new $.Rect(
-                overlay.px,
-                overlay.py,
-                width || 0,
-                height || 0));
-            x = rect.x;
-            y = rect.y;
-            width = width !== undefined ? rect.width : undefined;
-            height = height !== undefined ? rect.height : undefined;
-        }
-        location = new $.Point(x, y);
-    }
 
-    var placement = overlay.placement;
-    if (placement && $.type(placement) === "string") {
-        placement = $.Placement[overlay.placement.toUpperCase()];
-    }
+    /**
+     * @function
+     * @private
+     */
+    function getTileSourceImplementation(viewer, tileSource, imgOptions, successCallback,
+        failCallback) {
+        var _this = viewer;
 
-    return new $.Overlay({
-        element: element,
-        location: location,
-        placement: placement,
-        onDraw: overlay.onDraw,
-        checkResize: overlay.checkResize,
-        width: width,
-        height: height,
-        rotationMode: overlay.rotationMode
-    });
-}
-
-/**
- * @private
- * @inner
- * Determines the index of the given overlay in the given overlays array.
- */
-function getOverlayIndex( overlays, element ) {
-    var i;
-    for ( i = overlays.length - 1; i >= 0; i-- ) {
-        if ( overlays[ i ].element === element ) {
-            return i;
-        }
-    }
-
-    return -1;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Schedulers provide the general engine for animation
-///////////////////////////////////////////////////////////////////////////////
-function scheduleUpdate( viewer, updateFunc ){
-    return $.requestAnimationFrame( function(){
-        updateFunc( viewer );
-    } );
-}
-
-
-//provides a sequence in the fade animation
-function scheduleControlsFade( viewer ) {
-    $.requestAnimationFrame( function(){
-        updateControlsFade( viewer );
-    });
-}
-
-
-//initiates an animation to hide the controls
-function beginControlsAutoHide( viewer ) {
-    if ( !viewer.autoHideControls ) {
-        return;
-    }
-    viewer.controlsShouldFade = true;
-    viewer.controlsFadeBeginTime =
-        $.now() +
-        viewer.controlsFadeDelay;
-
-    window.setTimeout( function(){
-        scheduleControlsFade( viewer );
-    }, viewer.controlsFadeDelay );
-}
-
-
-//determines if fade animation is done or continues the animation
-function updateControlsFade( viewer ) {
-    var currentTime,
-        deltaTime,
-        opacity,
-        i;
-    if ( viewer.controlsShouldFade ) {
-        currentTime = $.now();
-        deltaTime = currentTime - viewer.controlsFadeBeginTime;
-        opacity = 1.0 - deltaTime / viewer.controlsFadeLength;
-
-        opacity = Math.min( 1.0, opacity );
-        opacity = Math.max( 0.0, opacity );
-
-        for ( i = viewer.controls.length - 1; i >= 0; i--) {
-            if (viewer.controls[ i ].autoFade) {
-                viewer.controls[ i ].setOpacity( opacity );
+        //allow plain xml strings or json strings to be parsed here
+        if ($.type(tileSource) == 'string') {
+            //xml should start with "<" and end with ">"
+            if (tileSource.match(/^\s*<.*>\s*$/)) {
+                tileSource = $.parseXml(tileSource);
+                //json should start with "{" or "[" and end with "}" or "]"
+            } else if (tileSource.match(/^\s*[\{\[].*[\}\]]\s*$/)) {
+                try {
+                    var tileSourceJ = $.parseJSON(tileSource);
+                    tileSource = tileSourceJ;
+                } catch (e) {
+                    //tileSource = tileSource;
+                }
             }
         }
 
-        if ( opacity > 0 ) {
-            // fade again
-            scheduleControlsFade( viewer );
+        function waitUntilReady(tileSource, originalTileSource) {
+            if (tileSource.ready) {
+                successCallback(tileSource);
+            } else {
+                tileSource.addHandler('ready', function () {
+                    successCallback(tileSource);
+                });
+                tileSource.addHandler('open-failed', function (event) {
+                    failCallback({
+                        message: event.message,
+                        source: originalTileSource
+                    });
+                });
+            }
         }
-    }
-}
 
+        setTimeout(function () {
+            if ($.type(tileSource) == 'string') {
+                //If its still a string it means it must be a url at this point
+                tileSource = new $.TileSource({
+                    url: tileSource,
+                    crossOriginPolicy: imgOptions.crossOriginPolicy !== undefined ?
+                        imgOptions.crossOriginPolicy : viewer.crossOriginPolicy,
+                    ajaxWithCredentials: viewer.ajaxWithCredentials,
+                    ajaxHeaders: viewer.ajaxHeaders,
+                    useCanvas: viewer.useCanvas,
+                    success: function (event) {
+                        successCallback(event.tileSource);
+                    }
+                });
+                tileSource.addHandler('open-failed', function (event) {
+                    failCallback(event);
+                });
 
-//stop the fade animation on the controls and show them
-function abortControlsAutoHide( viewer ) {
-    var i;
-    viewer.controlsShouldFade = false;
-    for ( i = viewer.controls.length - 1; i >= 0; i-- ) {
-        viewer.controls[ i ].setOpacity( 1.0 );
-    }
-}
-
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Default view event handlers.
-///////////////////////////////////////////////////////////////////////////////
-function onFocus(){
-    abortControlsAutoHide( this );
-}
-
-function onBlur(){
-    beginControlsAutoHide( this );
-
-}
-
-function onCanvasKeyDown( event ) {
-    if ( !event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
-        switch( event.keyCode ){
-            case 38://up arrow
-                if ( event.shift ) {
-                    this.viewport.zoomBy(1.1);
-                } else {
-                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, -this.pixelsPerArrowPress)));
+            } else if ($.isPlainObject(tileSource) || tileSource.nodeType) {
+                if (tileSource.crossOriginPolicy === undefined &&
+                    (imgOptions.crossOriginPolicy !== undefined || viewer.crossOriginPolicy !== undefined)) {
+                    tileSource.crossOriginPolicy = imgOptions.crossOriginPolicy !== undefined ?
+                        imgOptions.crossOriginPolicy : viewer.crossOriginPolicy;
                 }
-                this.viewport.applyConstraints();
-                return false;
-            case 40://down arrow
-                if ( event.shift ) {
-                    this.viewport.zoomBy(0.9);
-                } else {
-                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, this.pixelsPerArrowPress)));
+                if (tileSource.ajaxWithCredentials === undefined) {
+                    tileSource.ajaxWithCredentials = viewer.ajaxWithCredentials;
                 }
-                this.viewport.applyConstraints();
-                return false;
-            case 37://left arrow
-                this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(-this.pixelsPerArrowPress, 0)));
-                this.viewport.applyConstraints();
-                return false;
-            case 39://right arrow
-                this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(this.pixelsPerArrowPress, 0)));
-                this.viewport.applyConstraints();
-                return false;
-            default:
-                //console.log( 'navigator keycode %s', event.keyCode );
-                return true;
+                if (tileSource.useCanvas === undefined) {
+                    tileSource.useCanvas = viewer.useCanvas;
+                }
+
+                if ($.isFunction(tileSource.getTileUrl)) {
+                    //Custom tile source
+                    var customTileSource = new $.TileSource(tileSource);
+                    customTileSource.getTileUrl = tileSource.getTileUrl;
+                    successCallback(customTileSource);
+                } else {
+                    //inline configuration
+                    var $TileSource = $.TileSource.determineType(_this, tileSource);
+                    if (!$TileSource) {
+                        failCallback({
+                            message: "Unable to load TileSource",
+                            source: tileSource
+                        });
+                        return;
+                    }
+                    var options = $TileSource.prototype.configure.apply(_this, [tileSource]);
+                    waitUntilReady(new $TileSource(options), tileSource);
+                }
+            } else {
+                //can assume it's already a tile source implementation
+                waitUntilReady(tileSource, tileSource);
+            }
+        });
+    }
+
+    function getOverlayObject(viewer, overlay) {
+        if (overlay instanceof $.Overlay) {
+            return overlay;
         }
-    } else {
-        return true;
-    }
-}
 
-function onCanvasKeyPress( event ) {
-    if ( !event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
-        switch( event.keyCode ){
-            case 43://=|+
-            case 61://=|+
-                this.viewport.zoomBy(1.1);
-                this.viewport.applyConstraints();
-                return false;
-            case 45://-|_
-                this.viewport.zoomBy(0.9);
-                this.viewport.applyConstraints();
-                return false;
-            case 48://0|)
-                this.viewport.goHome();
-                this.viewport.applyConstraints();
-                return false;
-            case 119://w
-            case 87://W
-                if ( event.shift ) {
-                    this.viewport.zoomBy(1.1);
-                } else {
-                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, -40)));
-                }
-                this.viewport.applyConstraints();
-                return false;
-            case 115://s
-            case 83://S
-                if ( event.shift ) {
-                    this.viewport.zoomBy(0.9);
-                } else {
-                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, 40)));
-                }
-                this.viewport.applyConstraints();
-                return false;
-            case 97://a
-                this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(-40, 0)));
-                this.viewport.applyConstraints();
-                return false;
-            case 100://d
-                this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(40, 0)));
-                this.viewport.applyConstraints();
-                return false;
-            default:
-                //console.log( 'navigator keycode %s', event.keyCode );
-                return true;
-        }
-    } else {
-        return true;
-    }
-}
+        var element = null;
+        if (overlay.element) {
+            element = $.getElement(overlay.element);
+        } else {
+            var id = overlay.id ?
+                overlay.id :
+                "openseadragon-overlay-" + Math.floor(Math.random() * 10000000);
 
-function onCanvasClick( event ) {
-    var gestureSettings;
-
-    var haveKeyboardFocus = document.activeElement == this.canvas;
-
-    // If we don't have keyboard focus, request it.
-    if ( !haveKeyboardFocus ) {
-        this.canvas.focus();
-    }
-
-    var canvasClickEventArgs = {
-        tracker: event.eventSource,
-        position: event.position,
-        quick: event.quick,
-        shift: event.shift,
-        originalEvent: event.originalEvent,
-        preventDefaultAction: event.preventDefaultAction
-    };
-
-    /**
-     * Raised when a mouse press/release or touch/remove occurs on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-click
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Boolean} quick - True only if the clickDistThreshold and clickTimeThreshold are both passed. Useful for differentiating between clicks and drags.
-     * @property {Boolean} shift - True if the shift key was pressed during this event.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {Boolean} preventDefaultAction - Set to true to prevent default click to zoom behaviour. Default: false.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-click', canvasClickEventArgs);
-
-    if ( !canvasClickEventArgs.preventDefaultAction && this.viewport && event.quick ) {
-        gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
-        if ( gestureSettings.clickToZoom ) {
-            this.viewport.zoomBy(
-                event.shift ? 1.0 / this.zoomPerClick : this.zoomPerClick,
-                this.viewport.pointFromPixel( event.position, true )
+            element = $.getElement(overlay.id);
+            if (!element) {
+                element = document.createElement("a");
+                element.href = "#/overlay/" + id;
+            }
+            element.id = id;
+            $.addClass(element, overlay.className ?
+                overlay.className :
+                "openseadragon-overlay"
             );
-            this.viewport.applyConstraints();
-        }
-    }
-}
-
-function onCanvasDblClick( event ) {
-    var gestureSettings;
-
-    var canvasDblClickEventArgs = {
-        tracker: event.eventSource,
-        position: event.position,
-        shift: event.shift,
-        originalEvent: event.originalEvent,
-        preventDefaultAction: event.preventDefaultAction
-    };
-
-    /**
-     * Raised when a double mouse press/release or touch/remove occurs on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-double-click
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Boolean} shift - True if the shift key was pressed during this event.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {Boolean} preventDefaultAction - Set to true to prevent default double tap to zoom behaviour. Default: false.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-double-click', canvasDblClickEventArgs);
-
-    if ( !canvasDblClickEventArgs.preventDefaultAction && this.viewport ) {
-        gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
-        if ( gestureSettings.dblClickToZoom ) {
-            this.viewport.zoomBy(
-                event.shift ? 1.0 / this.zoomPerClick : this.zoomPerClick,
-                this.viewport.pointFromPixel( event.position, true )
-            );
-            this.viewport.applyConstraints();
-        }
-    }
-}
-
-function onCanvasDrag( event ) {
-    var gestureSettings;
-
-    var canvasDragEventArgs = {
-        tracker: event.eventSource,
-        position: event.position,
-        delta: event.delta,
-        speed: event.speed,
-        direction: event.direction,
-        shift: event.shift,
-        originalEvent: event.originalEvent,
-        preventDefaultAction: event.preventDefaultAction
-    };
-
-    /**
-     * Raised when a mouse or touch drag operation occurs on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-drag
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {OpenSeadragon.Point} delta - The x,y components of the difference between start drag and end drag.
-     * @property {Number} speed - Current computed speed, in pixels per second.
-     * @property {Number} direction - Current computed direction, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
-     * @property {Boolean} shift - True if the shift key was pressed during this event.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {Boolean} preventDefaultAction - Set to true to prevent default drag behaviour. Default: false.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-drag', canvasDragEventArgs);
-
-    if ( !canvasDragEventArgs.preventDefaultAction && this.viewport ) {
-        gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
-        if( !this.panHorizontal ){
-            event.delta.x = 0;
-        }
-        if( !this.panVertical ){
-            event.delta.y = 0;
         }
 
-        if( this.constrainDuringPan ){
-            var delta = this.viewport.deltaPointsFromPixels( event.delta.negate() );
-
-            this.viewport.centerSpringX.target.value += delta.x;
-            this.viewport.centerSpringY.target.value += delta.y;
-
-            var bounds = this.viewport.getBounds();
-            var constrainedBounds = this.viewport.getConstrainedBounds();
-
-            this.viewport.centerSpringX.target.value -= delta.x;
-            this.viewport.centerSpringY.target.value -= delta.y;
-
-            if (bounds.x != constrainedBounds.x) {
-                event.delta.x = 0;
+        var location = overlay.location;
+        var width = overlay.width;
+        var height = overlay.height;
+        if (!location) {
+            var x = overlay.x;
+            var y = overlay.y;
+            if (overlay.px !== undefined) {
+                var rect = viewer.viewport.imageToViewportRectangle(new $.Rect(
+                    overlay.px,
+                    overlay.py,
+                    width || 0,
+                    height || 0));
+                x = rect.x;
+                y = rect.y;
+                width = width !== undefined ? rect.width : undefined;
+                height = height !== undefined ? rect.height : undefined;
             }
-
-            if (bounds.y != constrainedBounds.y) {
-                event.delta.y = 0;
-            }
+            location = new $.Point(x, y);
         }
 
-        this.viewport.panBy( this.viewport.deltaPointsFromPixels( event.delta.negate() ), gestureSettings.flickEnabled && !this.constrainDuringPan);
-    }
-}
-
-function onCanvasDragEnd( event ) {
-    if (!event.preventDefaultAction && this.viewport) {
-        var gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
-        if (gestureSettings.flickEnabled &&
-            event.speed >= gestureSettings.flickMinSpeed) {
-            var amplitudeX = 0;
-            if (this.panHorizontal) {
-                amplitudeX = gestureSettings.flickMomentum * event.speed *
-                    Math.cos(event.direction);
-            }
-            var amplitudeY = 0;
-            if (this.panVertical) {
-                amplitudeY = gestureSettings.flickMomentum * event.speed *
-                    Math.sin(event.direction);
-            }
-            var center = this.viewport.pixelFromPoint(
-                this.viewport.getCenter(true));
-            var target = this.viewport.pointFromPixel(
-                new $.Point(center.x - amplitudeX, center.y - amplitudeY));
-            this.viewport.panTo(target, false);
+        var placement = overlay.placement;
+        if (placement && $.type(placement) === "string") {
+            placement = $.Placement[overlay.placement.toUpperCase()];
         }
-        this.viewport.applyConstraints();
-    }
-    /**
-     * Raised when a mouse or touch drag operation ends on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-drag-end
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Number} speed - Speed at the end of a drag gesture, in pixels per second.
-     * @property {Number} direction - Direction at the end of a drag gesture, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
-     * @property {Boolean} shift - True if the shift key was pressed during this event.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent('canvas-drag-end', {
-        tracker: event.eventSource,
-        position: event.position,
-        speed: event.speed,
-        direction: event.direction,
-        shift: event.shift,
-        originalEvent: event.originalEvent
-    });
-}
 
-function onCanvasEnter( event ) {
-    /**
-     * Raised when a pointer enters the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-enter
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {String} pointerType - "mouse", "touch", "pen", etc.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
-     * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
-     * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
-     * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-enter', {
-        tracker: event.eventSource,
-        pointerType: event.pointerType,
-        position: event.position,
-        buttons: event.buttons,
-        pointers: event.pointers,
-        insideElementPressed: event.insideElementPressed,
-        buttonDownAny: event.buttonDownAny,
-        originalEvent: event.originalEvent
-    });
-}
-
-function onCanvasExit( event ) {
-
-    if (window.location != window.parent.location){
-        $.MouseTracker.resetAllMouseTrackers();
+        return new $.Overlay({
+            element: element,
+            location: location,
+            placement: placement,
+            onDraw: overlay.onDraw,
+            checkResize: overlay.checkResize,
+            width: width,
+            height: height,
+            rotationMode: overlay.rotationMode
+        });
     }
 
     /**
-     * Raised when a pointer leaves the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-exit
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {String} pointerType - "mouse", "touch", "pen", etc.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
-     * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
-     * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
-     * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
+     * @private
+     * @inner
+     * Determines the index of the given overlay in the given overlays array.
      */
-    this.raiseEvent( 'canvas-exit', {
-        tracker: event.eventSource,
-        pointerType: event.pointerType,
-        position: event.position,
-        buttons: event.buttons,
-        pointers: event.pointers,
-        insideElementPressed: event.insideElementPressed,
-        buttonDownAny: event.buttonDownAny,
-        originalEvent: event.originalEvent
-    });
-}
-
-function onCanvasPress( event ) {
-    /**
-     * Raised when the primary mouse button is pressed or touch starts on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-press
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {String} pointerType - "mouse", "touch", "pen", etc.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
-     * @property {Boolean} insideElementReleased - True if the cursor still inside the tracked element when the button was released.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-press', {
-        tracker: event.eventSource,
-        pointerType: event.pointerType,
-        position: event.position,
-        insideElementPressed: event.insideElementPressed,
-        insideElementReleased: event.insideElementReleased,
-        originalEvent: event.originalEvent
-    });
-}
-
-function onCanvasRelease( event ) {
-    /**
-     * Raised when the primary mouse button is released or touch ends on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-release
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {String} pointerType - "mouse", "touch", "pen", etc.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
-     * @property {Boolean} insideElementReleased - True if the cursor still inside the tracked element when the button was released.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-release', {
-        tracker: event.eventSource,
-        pointerType: event.pointerType,
-        position: event.position,
-        insideElementPressed: event.insideElementPressed,
-        insideElementReleased: event.insideElementReleased,
-        originalEvent: event.originalEvent
-    });
-}
-
-function onCanvasNonPrimaryPress( event ) {
-    /**
-     * Raised when any non-primary pointer button is pressed on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-nonprimary-press
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {String} pointerType - "mouse", "touch", "pen", etc.
-     * @property {Number} button - Button which caused the event.
-     *      -1: none, 0: primary/left, 1: aux/middle, 2: secondary/right, 3: X1/back, 4: X2/forward, 5: pen eraser.
-     * @property {Number} buttons - Current buttons pressed.
-     *      Combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-nonprimary-press', {
-        tracker: event.eventSource,
-        position: event.position,
-        pointerType: event.pointerType,
-        button: event.button,
-        buttons: event.buttons,
-        originalEvent: event.originalEvent
-    });
-}
-
-function onCanvasNonPrimaryRelease( event ) {
-    /**
-     * Raised when any non-primary pointer button is released on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-nonprimary-release
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {String} pointerType - "mouse", "touch", "pen", etc.
-     * @property {Number} button - Button which caused the event.
-     *      -1: none, 0: primary/left, 1: aux/middle, 2: secondary/right, 3: X1/back, 4: X2/forward, 5: pen eraser.
-     * @property {Number} buttons - Current buttons pressed.
-     *      Combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'canvas-nonprimary-release', {
-        tracker: event.eventSource,
-        position: event.position,
-        pointerType: event.pointerType,
-        button: event.button,
-        buttons: event.buttons,
-        originalEvent: event.originalEvent
-    });
-}
-
-function onCanvasPinch( event ) {
-    var gestureSettings,
-        centerPt,
-        lastCenterPt,
-        panByPt;
-
-    if ( !event.preventDefaultAction && this.viewport ) {
-        gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
-        if ( gestureSettings.pinchToZoom ) {
-            centerPt = this.viewport.pointFromPixel( event.center, true );
-            lastCenterPt = this.viewport.pointFromPixel( event.lastCenter, true );
-            panByPt = lastCenterPt.minus( centerPt );
-            if( !this.panHorizontal ) {
-                panByPt.x = 0;
+    function getOverlayIndex(overlays, element) {
+        var i;
+        for (i = overlays.length - 1; i >= 0; i--) {
+            if (overlays[i].element === element) {
+                return i;
             }
-            if( !this.panVertical ) {
-                panByPt.y = 0;
-            }
-            this.viewport.zoomBy( event.distance / event.lastDistance, centerPt, true );
-            this.viewport.panBy( panByPt, true );
-            this.viewport.applyConstraints();
         }
-        if ( gestureSettings.pinchRotate ) {
-            // Pinch rotate
-            var angle1 = Math.atan2(event.gesturePoints[0].currentPos.y - event.gesturePoints[1].currentPos.y,
-                event.gesturePoints[0].currentPos.x - event.gesturePoints[1].currentPos.x);
-            var angle2 = Math.atan2(event.gesturePoints[0].lastPos.y - event.gesturePoints[1].lastPos.y,
-                event.gesturePoints[0].lastPos.x - event.gesturePoints[1].lastPos.x);
-            this.viewport.setRotation(this.viewport.getRotation() + ((angle1 - angle2) * (180 / Math.PI)));
+
+        return -1;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Schedulers provide the general engine for animation
+    ///////////////////////////////////////////////////////////////////////////////
+    function scheduleUpdate(viewer, updateFunc) {
+        return $.requestAnimationFrame(function () {
+            updateFunc(viewer);
+        });
+    }
+
+
+    //provides a sequence in the fade animation
+    function scheduleControlsFade(viewer) {
+        $.requestAnimationFrame(function () {
+            updateControlsFade(viewer);
+        });
+    }
+
+
+    //initiates an animation to hide the controls
+    function beginControlsAutoHide(viewer) {
+        if (!viewer.autoHideControls) {
+            return;
+        }
+        viewer.controlsShouldFade = true;
+        viewer.controlsFadeBeginTime =
+            $.now() +
+            viewer.controlsFadeDelay;
+
+        window.setTimeout(function () {
+            scheduleControlsFade(viewer);
+        }, viewer.controlsFadeDelay);
+    }
+
+
+    //determines if fade animation is done or continues the animation
+    function updateControlsFade(viewer) {
+        var currentTime,
+            deltaTime,
+            opacity,
+            i;
+        if (viewer.controlsShouldFade) {
+            currentTime = $.now();
+            deltaTime = currentTime - viewer.controlsFadeBeginTime;
+            opacity = 1.0 - deltaTime / viewer.controlsFadeLength;
+
+            opacity = Math.min(1.0, opacity);
+            opacity = Math.max(0.0, opacity);
+
+            for (i = viewer.controls.length - 1; i >= 0; i--) {
+                if (viewer.controls[i].autoFade) {
+                    viewer.controls[i].setOpacity(opacity);
+                }
+            }
+
+            if (opacity > 0) {
+                // fade again
+                scheduleControlsFade(viewer);
+            }
         }
     }
-    /**
-     * Raised when a pinch event occurs on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-pinch
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {Array.<OpenSeadragon.MouseTracker.GesturePoint>} gesturePoints - Gesture points associated with the gesture. Velocity data can be found here.
-     * @property {OpenSeadragon.Point} lastCenter - The previous center point of the two pinch contact points relative to the tracked element.
-     * @property {OpenSeadragon.Point} center - The center point of the two pinch contact points relative to the tracked element.
-     * @property {Number} lastDistance - The previous distance between the two pinch contact points in CSS pixels.
-     * @property {Number} distance - The distance between the two pinch contact points in CSS pixels.
-     * @property {Boolean} shift - True if the shift key was pressed during this event.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent('canvas-pinch', {
-        tracker: event.eventSource,
-        gesturePoints: event.gesturePoints,
-        lastCenter: event.lastCenter,
-        center: event.center,
-        lastDistance: event.lastDistance,
-        distance: event.distance,
-        shift: event.shift,
-        originalEvent: event.originalEvent
-    });
-    //cancels event
-    return false;
-}
 
-function onCanvasScroll( event ) {
-    var gestureSettings,
-        factor,
-        thisScrollTime,
-        deltaScrollTime;
 
-    /* Certain scroll devices fire the scroll event way too fast so we are injecting a simple adjustment to keep things
-     * partially normalized. If we have already fired an event within the last 'minScrollDelta' milliseconds we skip
-     * this one and wait for the next event. */
-    thisScrollTime = $.now();
-    deltaScrollTime = thisScrollTime - this._lastScrollTime;
-    if (deltaScrollTime > this.minScrollDeltaTime) {
-        this._lastScrollTime = thisScrollTime;
-
-        if ( !event.preventDefaultAction && this.viewport ) {
-            gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
-            if ( gestureSettings.scrollToZoom ) {
-                factor = Math.pow( this.zoomPerScroll, event.scroll );
-                this.viewport.zoomBy(
-                    factor,
-                    this.viewport.pointFromPixel( event.position, true )
-                );
-                this.viewport.applyConstraints();
-            }
+    //stop the fade animation on the controls and show them
+    function abortControlsAutoHide(viewer) {
+        var i;
+        viewer.controlsShouldFade = false;
+        for (i = viewer.controls.length - 1; i >= 0; i--) {
+            viewer.controls[i].setOpacity(1.0);
         }
+    }
+
+
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Default view event handlers.
+    ///////////////////////////////////////////////////////////////////////////////
+    function onFocus() {
+        abortControlsAutoHide(this);
+    }
+
+    function onBlur() {
+        beginControlsAutoHide(this);
+
+    }
+
+    function onCanvasKeyDown(event) {
+        if (!event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta) {
+            switch (event.keyCode) {
+                case 38://up arrow
+                    if (event.shift) {
+                        this.viewport.zoomBy(1.1);
+                    } else {
+                        this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, -this.pixelsPerArrowPress)));
+                    }
+                    this.viewport.applyConstraints();
+                    return false;
+                case 40://down arrow
+                    if (event.shift) {
+                        this.viewport.zoomBy(0.9);
+                    } else {
+                        this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, this.pixelsPerArrowPress)));
+                    }
+                    this.viewport.applyConstraints();
+                    return false;
+                case 37://left arrow
+                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(-this.pixelsPerArrowPress, 0)));
+                    this.viewport.applyConstraints();
+                    return false;
+                case 39://right arrow
+                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(this.pixelsPerArrowPress, 0)));
+                    this.viewport.applyConstraints();
+                    return false;
+                default:
+                    //console.log( 'navigator keycode %s', event.keyCode );
+                    return true;
+            }
+        } else {
+            return true;
+        }
+    }
+
+    function onCanvasKeyPress(event) {
+        if (!event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta) {
+            switch (event.keyCode) {
+                case 43://=|+
+                case 61://=|+
+                    this.viewport.zoomBy(1.1);
+                    this.viewport.applyConstraints();
+                    return false;
+                case 45://-|_
+                    this.viewport.zoomBy(0.9);
+                    this.viewport.applyConstraints();
+                    return false;
+                case 48://0|)
+                    this.viewport.goHome();
+                    this.viewport.applyConstraints();
+                    return false;
+                case 119://w
+                case 87://W
+                    if (event.shift) {
+                        this.viewport.zoomBy(1.1);
+                    } else {
+                        this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, -40)));
+                    }
+                    this.viewport.applyConstraints();
+                    return false;
+                case 115://s
+                case 83://S
+                    if (event.shift) {
+                        this.viewport.zoomBy(0.9);
+                    } else {
+                        this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(0, 40)));
+                    }
+                    this.viewport.applyConstraints();
+                    return false;
+                case 97://a
+                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(-40, 0)));
+                    this.viewport.applyConstraints();
+                    return false;
+                case 100://d
+                    this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(40, 0)));
+                    this.viewport.applyConstraints();
+                    return false;
+                default:
+                    //console.log( 'navigator keycode %s', event.keyCode );
+                    return true;
+            }
+        } else {
+            return true;
+        }
+    }
+
+    function onCanvasClick(event) {
+        var gestureSettings;
+
+        var haveKeyboardFocus = document.activeElement == this.canvas;
+
+        // If we don't have keyboard focus, request it.
+        if (!haveKeyboardFocus) {
+            this.canvas.focus();
+        }
+
+        var canvasClickEventArgs = {
+            tracker: event.eventSource,
+            position: event.position,
+            quick: event.quick,
+            shift: event.shift,
+            originalEvent: event.originalEvent,
+            preventDefaultAction: event.preventDefaultAction
+        };
+
         /**
-         * Raised when a scroll event occurs on the {@link OpenSeadragon.Viewer#canvas} element (mouse wheel).
+         * Raised when a mouse press/release or touch/remove occurs on the {@link OpenSeadragon.Viewer#canvas} element.
          *
-         * @event canvas-scroll
+         * @event canvas-click
          * @memberof OpenSeadragon.Viewer
          * @type {object}
          * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
          * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
          * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-         * @property {Number} scroll - The scroll delta for the event.
+         * @property {Boolean} quick - True only if the clickDistThreshold and clickTimeThreshold are both passed. Useful for differentiating between clicks and drags.
+         * @property {Boolean} shift - True if the shift key was pressed during this event.
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {Boolean} preventDefaultAction - Set to true to prevent default click to zoom behaviour. Default: false.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-click', canvasClickEventArgs);
+
+        if (!canvasClickEventArgs.preventDefaultAction && this.viewport && event.quick) {
+            gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
+            if (gestureSettings.clickToZoom) {
+                this.viewport.zoomBy(
+                    event.shift ? 1.0 / this.zoomPerClick : this.zoomPerClick,
+                    this.viewport.pointFromPixel(event.position, true)
+                );
+                this.viewport.applyConstraints();
+            }
+        }
+    }
+
+    function onCanvasDblClick(event) {
+        var gestureSettings;
+
+        var canvasDblClickEventArgs = {
+            tracker: event.eventSource,
+            position: event.position,
+            shift: event.shift,
+            originalEvent: event.originalEvent,
+            preventDefaultAction: event.preventDefaultAction
+        };
+
+        /**
+         * Raised when a double mouse press/release or touch/remove occurs on the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-double-click
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Boolean} shift - True if the shift key was pressed during this event.
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {Boolean} preventDefaultAction - Set to true to prevent default double tap to zoom behaviour. Default: false.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-double-click', canvasDblClickEventArgs);
+
+        if (!canvasDblClickEventArgs.preventDefaultAction && this.viewport) {
+            gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
+            if (gestureSettings.dblClickToZoom) {
+                this.viewport.zoomBy(
+                    event.shift ? 1.0 / this.zoomPerClick : this.zoomPerClick,
+                    this.viewport.pointFromPixel(event.position, true)
+                );
+                this.viewport.applyConstraints();
+            }
+        }
+    }
+
+    function onCanvasDrag(event) {
+        var gestureSettings;
+
+        var canvasDragEventArgs = {
+            tracker: event.eventSource,
+            position: event.position,
+            delta: event.delta,
+            speed: event.speed,
+            direction: event.direction,
+            shift: event.shift,
+            originalEvent: event.originalEvent,
+            preventDefaultAction: event.preventDefaultAction
+        };
+
+        /**
+         * Raised when a mouse or touch drag operation occurs on the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-drag
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {OpenSeadragon.Point} delta - The x,y components of the difference between start drag and end drag.
+         * @property {Number} speed - Current computed speed, in pixels per second.
+         * @property {Number} direction - Current computed direction, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
+         * @property {Boolean} shift - True if the shift key was pressed during this event.
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {Boolean} preventDefaultAction - Set to true to prevent default drag behaviour. Default: false.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-drag', canvasDragEventArgs);
+
+        if (!canvasDragEventArgs.preventDefaultAction && this.viewport) {
+            gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
+            if (!this.panHorizontal) {
+                event.delta.x = 0;
+            }
+            if (!this.panVertical) {
+                event.delta.y = 0;
+            }
+
+            if (this.constrainDuringPan) {
+                var delta = this.viewport.deltaPointsFromPixels(event.delta.negate());
+
+                this.viewport.centerSpringX.target.value += delta.x;
+                this.viewport.centerSpringY.target.value += delta.y;
+
+                var bounds = this.viewport.getBounds();
+                var constrainedBounds = this.viewport.getConstrainedBounds();
+
+                this.viewport.centerSpringX.target.value -= delta.x;
+                this.viewport.centerSpringY.target.value -= delta.y;
+
+                if (bounds.x != constrainedBounds.x) {
+                    event.delta.x = 0;
+                }
+
+                if (bounds.y != constrainedBounds.y) {
+                    event.delta.y = 0;
+                }
+            }
+
+            this.viewport.panBy(this.viewport.deltaPointsFromPixels(event.delta.negate()), gestureSettings.flickEnabled && !this.constrainDuringPan);
+        }
+    }
+
+    function onCanvasDragEnd(event) {
+        if (!event.preventDefaultAction && this.viewport) {
+            var gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
+            if (gestureSettings.flickEnabled &&
+                event.speed >= gestureSettings.flickMinSpeed) {
+                var amplitudeX = 0;
+                if (this.panHorizontal) {
+                    amplitudeX = gestureSettings.flickMomentum * event.speed *
+                        Math.cos(event.direction);
+                }
+                var amplitudeY = 0;
+                if (this.panVertical) {
+                    amplitudeY = gestureSettings.flickMomentum * event.speed *
+                        Math.sin(event.direction);
+                }
+                var center = this.viewport.pixelFromPoint(
+                    this.viewport.getCenter(true));
+                var target = this.viewport.pointFromPixel(
+                    new $.Point(center.x - amplitudeX, center.y - amplitudeY));
+                this.viewport.panTo(target, false);
+            }
+            this.viewport.applyConstraints();
+        }
+        /**
+         * Raised when a mouse or touch drag operation ends on the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-drag-end
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Number} speed - Speed at the end of a drag gesture, in pixels per second.
+         * @property {Number} direction - Direction at the end of a drag gesture, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
          * @property {Boolean} shift - True if the shift key was pressed during this event.
          * @property {Object} originalEvent - The original DOM event.
          * @property {?Object} userData - Arbitrary subscriber-defined object.
          */
-        this.raiseEvent( 'canvas-scroll', {
+        this.raiseEvent('canvas-drag-end', {
             tracker: event.eventSource,
             position: event.position,
-            scroll: event.scroll,
+            speed: event.speed,
+            direction: event.direction,
             shift: event.shift,
             originalEvent: event.originalEvent
         });
-        if (gestureSettings && gestureSettings.scrollToZoom) {
-            //cancels event
-            return false;
+    }
+
+    function onCanvasEnter(event) {
+        /**
+         * Raised when a pointer enters the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-enter
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {String} pointerType - "mouse", "touch", "pen", etc.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
+         * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
+         * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-enter', {
+            tracker: event.eventSource,
+            pointerType: event.pointerType,
+            position: event.position,
+            buttons: event.buttons,
+            pointers: event.pointers,
+            insideElementPressed: event.insideElementPressed,
+            buttonDownAny: event.buttonDownAny,
+            originalEvent: event.originalEvent
+        });
+    }
+
+    function onCanvasExit(event) {
+
+        if (window.location != window.parent.location) {
+            $.MouseTracker.resetAllMouseTrackers();
         }
-    }
-    else {
-        gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
-        if (gestureSettings && gestureSettings.scrollToZoom) {
-            return false;   // We are swallowing this event
-        }
-    }
-}
 
-function onContainerEnter( event ) {
-    THIS[ this.hash ].mouseInside = true;
-    abortControlsAutoHide( this );
-    /**
-     * Raised when the cursor enters the {@link OpenSeadragon.Viewer#container} element.
-     *
-     * @event container-enter
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
-     * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
-     * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
-     * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'container-enter', {
-        tracker: event.eventSource,
-        position: event.position,
-        buttons: event.buttons,
-        pointers: event.pointers,
-        insideElementPressed: event.insideElementPressed,
-        buttonDownAny: event.buttonDownAny,
-        originalEvent: event.originalEvent
-    });
-}
-
-function onContainerExit( event ) {
-    if ( event.pointers < 1 ) {
-        THIS[ this.hash ].mouseInside = false;
-        if ( !THIS[ this.hash ].animating ) {
-            beginControlsAutoHide( this );
-        }
-    }
-    /**
-     * Raised when the cursor leaves the {@link OpenSeadragon.Viewer#container} element.
-     *
-     * @event container-exit
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
-     * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
-     * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
-     * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent( 'container-exit', {
-        tracker: event.eventSource,
-        position: event.position,
-        buttons: event.buttons,
-        pointers: event.pointers,
-        insideElementPressed: event.insideElementPressed,
-        buttonDownAny: event.buttonDownAny,
-        originalEvent: event.originalEvent
-    });
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Page update routines ( aka Views - for future reference )
-///////////////////////////////////////////////////////////////////////////////
-
-function updateMulti( viewer ) {
-    updateOnce( viewer );
-
-    // Request the next frame, unless we've been closed
-    if ( viewer.isOpen() ) {
-        viewer._updateRequestId = scheduleUpdate( viewer, updateMulti );
-    } else {
-        viewer._updateRequestId = false;
-    }
-}
-
-function updateOnce( viewer ) {
-
-    //viewer.profiler.beginUpdate();
-
-    if (viewer._opening) {
-        return;
+        /**
+         * Raised when a pointer leaves the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-exit
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {String} pointerType - "mouse", "touch", "pen", etc.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
+         * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
+         * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-exit', {
+            tracker: event.eventSource,
+            pointerType: event.pointerType,
+            position: event.position,
+            buttons: event.buttons,
+            pointers: event.pointers,
+            insideElementPressed: event.insideElementPressed,
+            buttonDownAny: event.buttonDownAny,
+            originalEvent: event.originalEvent
+        });
     }
 
-    if (viewer.autoResize) {
-        var containerSize = _getSafeElemSize(viewer.container);
-        var prevContainerSize = THIS[viewer.hash].prevContainerSize;
-        if (!containerSize.equals(prevContainerSize)) {
-            var viewport = viewer.viewport;
-            if (viewer.preserveImageSizeOnResize) {
-                var resizeRatio = prevContainerSize.x / containerSize.x;
-                var zoom = viewport.getZoom() * resizeRatio;
-                var center = viewport.getCenter();
-                viewport.resize(containerSize, false);
-                viewport.zoomTo(zoom, null, true);
-                viewport.panTo(center, true);
-            } else {
-                // maintain image position
-                var oldBounds = viewport.getBounds();
-                viewport.resize(containerSize, true);
-                viewport.fitBoundsWithConstraints(oldBounds, true);
+    function onCanvasPress(event) {
+        /**
+         * Raised when the primary mouse button is pressed or touch starts on the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-press
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {String} pointerType - "mouse", "touch", "pen", etc.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
+         * @property {Boolean} insideElementReleased - True if the cursor still inside the tracked element when the button was released.
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-press', {
+            tracker: event.eventSource,
+            pointerType: event.pointerType,
+            position: event.position,
+            insideElementPressed: event.insideElementPressed,
+            insideElementReleased: event.insideElementReleased,
+            originalEvent: event.originalEvent
+        });
+    }
+
+    function onCanvasRelease(event) {
+        /**
+         * Raised when the primary mouse button is released or touch ends on the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-release
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {String} pointerType - "mouse", "touch", "pen", etc.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
+         * @property {Boolean} insideElementReleased - True if the cursor still inside the tracked element when the button was released.
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-release', {
+            tracker: event.eventSource,
+            pointerType: event.pointerType,
+            position: event.position,
+            insideElementPressed: event.insideElementPressed,
+            insideElementReleased: event.insideElementReleased,
+            originalEvent: event.originalEvent
+        });
+    }
+
+    function onCanvasNonPrimaryPress(event) {
+        /**
+         * Raised when any non-primary pointer button is pressed on the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-nonprimary-press
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {String} pointerType - "mouse", "touch", "pen", etc.
+         * @property {Number} button - Button which caused the event.
+         *      -1: none, 0: primary/left, 1: aux/middle, 2: secondary/right, 3: X1/back, 4: X2/forward, 5: pen eraser.
+         * @property {Number} buttons - Current buttons pressed.
+         *      Combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-nonprimary-press', {
+            tracker: event.eventSource,
+            position: event.position,
+            pointerType: event.pointerType,
+            button: event.button,
+            buttons: event.buttons,
+            originalEvent: event.originalEvent
+        });
+    }
+
+    function onCanvasNonPrimaryRelease(event) {
+        /**
+         * Raised when any non-primary pointer button is released on the {@link OpenSeadragon.Viewer#canvas} element.
+         *
+         * @event canvas-nonprimary-release
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {String} pointerType - "mouse", "touch", "pen", etc.
+         * @property {Number} button - Button which caused the event.
+         *      -1: none, 0: primary/left, 1: aux/middle, 2: secondary/right, 3: X1/back, 4: X2/forward, 5: pen eraser.
+         * @property {Number} buttons - Current buttons pressed.
+         *      Combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('canvas-nonprimary-release', {
+            tracker: event.eventSource,
+            position: event.position,
+            pointerType: event.pointerType,
+            button: event.button,
+            buttons: event.buttons,
+            originalEvent: event.originalEvent
+        });
+    }
+
+    function onCanvasPinch(event) {
+        var gestureSettings,
+            centerPt,
+            lastCenterPt,
+            panByPt;
+
+        if (!event.preventDefaultAction && this.viewport) {
+            gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
+            if (gestureSettings.pinchToZoom) {
+                centerPt = this.viewport.pointFromPixel(event.center, true);
+                lastCenterPt = this.viewport.pointFromPixel(event.lastCenter, true);
+                panByPt = lastCenterPt.minus(centerPt);
+                if (!this.panHorizontal) {
+                    panByPt.x = 0;
+                }
+                if (!this.panVertical) {
+                    panByPt.y = 0;
+                }
+                this.viewport.zoomBy(event.distance / event.lastDistance, centerPt, true);
+                this.viewport.panBy(panByPt, true);
+                this.viewport.applyConstraints();
             }
-            THIS[viewer.hash].prevContainerSize = containerSize;
-            THIS[viewer.hash].forceRedraw = true;
+            if (gestureSettings.pinchRotate) {
+                // Pinch rotate
+                var angle1 = Math.atan2(event.gesturePoints[0].currentPos.y - event.gesturePoints[1].currentPos.y,
+                    event.gesturePoints[0].currentPos.x - event.gesturePoints[1].currentPos.x);
+                var angle2 = Math.atan2(event.gesturePoints[0].lastPos.y - event.gesturePoints[1].lastPos.y,
+                    event.gesturePoints[0].lastPos.x - event.gesturePoints[1].lastPos.x);
+                this.viewport.setRotation(this.viewport.getRotation() + ((angle1 - angle2) * (180 / Math.PI)));
+            }
         }
-    }
-
-    var viewportChange = viewer.viewport.update();
-    var animated = viewer.world.update() || viewportChange;
-
-    if (viewportChange) {
         /**
-         * Raised when any spring animation update occurs (zoom, pan, etc.),
-         * before the viewer has drawn the new location.
+         * Raised when a pinch event occurs on the {@link OpenSeadragon.Viewer#canvas} element.
          *
-         * @event viewport-change
+         * @event canvas-pinch
          * @memberof OpenSeadragon.Viewer
          * @type {object}
          * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {Array.<OpenSeadragon.MouseTracker.GesturePoint>} gesturePoints - Gesture points associated with the gesture. Velocity data can be found here.
+         * @property {OpenSeadragon.Point} lastCenter - The previous center point of the two pinch contact points relative to the tracked element.
+         * @property {OpenSeadragon.Point} center - The center point of the two pinch contact points relative to the tracked element.
+         * @property {Number} lastDistance - The previous distance between the two pinch contact points in CSS pixels.
+         * @property {Number} distance - The distance between the two pinch contact points in CSS pixels.
+         * @property {Boolean} shift - True if the shift key was pressed during this event.
+         * @property {Object} originalEvent - The original DOM event.
          * @property {?Object} userData - Arbitrary subscriber-defined object.
          */
-        viewer.raiseEvent('viewport-change');
+        this.raiseEvent('canvas-pinch', {
+            tracker: event.eventSource,
+            gesturePoints: event.gesturePoints,
+            lastCenter: event.lastCenter,
+            center: event.center,
+            lastDistance: event.lastDistance,
+            distance: event.distance,
+            shift: event.shift,
+            originalEvent: event.originalEvent
+        });
+        //cancels event
+        return false;
     }
 
-    if( viewer.referenceStrip ){
-        animated = viewer.referenceStrip.update( viewer.viewport ) || animated;
+    function onCanvasScroll(event) {
+        var gestureSettings,
+            factor,
+            thisScrollTime,
+            deltaScrollTime;
+
+        /* Certain scroll devices fire the scroll event way too fast so we are injecting a simple adjustment to keep things
+         * partially normalized. If we have already fired an event within the last 'minScrollDelta' milliseconds we skip
+         * this one and wait for the next event. */
+        thisScrollTime = $.now();
+        deltaScrollTime = thisScrollTime - this._lastScrollTime;
+        if (deltaScrollTime > this.minScrollDeltaTime) {
+            this._lastScrollTime = thisScrollTime;
+
+            if (!event.preventDefaultAction && this.viewport) {
+                gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
+                if (gestureSettings.scrollToZoom) {
+                    factor = Math.pow(this.zoomPerScroll, event.scroll);
+                    this.viewport.zoomBy(
+                        factor,
+                        this.viewport.pointFromPixel(event.position, true)
+                    );
+                    this.viewport.applyConstraints();
+                }
+            }
+            /**
+             * Raised when a scroll event occurs on the {@link OpenSeadragon.Viewer#canvas} element (mouse wheel).
+             *
+             * @event canvas-scroll
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+             * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+             * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+             * @property {Number} scroll - The scroll delta for the event.
+             * @property {Boolean} shift - True if the shift key was pressed during this event.
+             * @property {Object} originalEvent - The original DOM event.
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            this.raiseEvent('canvas-scroll', {
+                tracker: event.eventSource,
+                position: event.position,
+                scroll: event.scroll,
+                shift: event.shift,
+                originalEvent: event.originalEvent
+            });
+            if (gestureSettings && gestureSettings.scrollToZoom) {
+                //cancels event
+                return false;
+            }
+        }
+        else {
+            gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
+            if (gestureSettings && gestureSettings.scrollToZoom) {
+                return false;   // We are swallowing this event
+            }
+        }
     }
 
-    if ( !THIS[ viewer.hash ].animating && animated ) {
+    function onContainerEnter(event) {
+        THIS[this.hash].mouseInside = true;
+        abortControlsAutoHide(this);
         /**
-         * Raised when any spring animation starts (zoom, pan, etc.).
+         * Raised when the cursor enters the {@link OpenSeadragon.Viewer#container} element.
          *
-         * @event animation-start
+         * @event container-enter
          * @memberof OpenSeadragon.Viewer
          * @type {object}
          * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
+         * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
+         * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
+         * @property {Object} originalEvent - The original DOM event.
          * @property {?Object} userData - Arbitrary subscriber-defined object.
          */
-        viewer.raiseEvent( "animation-start" );
-        abortControlsAutoHide( viewer );
+        this.raiseEvent('container-enter', {
+            tracker: event.eventSource,
+            position: event.position,
+            buttons: event.buttons,
+            pointers: event.pointers,
+            insideElementPressed: event.insideElementPressed,
+            buttonDownAny: event.buttonDownAny,
+            originalEvent: event.originalEvent
+        });
     }
 
-    if ( animated || THIS[ viewer.hash ].forceRedraw || viewer.world.needsDraw() ) {
-        drawWorld( viewer );
-        viewer._drawOverlays();
-        if( viewer.navigator ){
-            viewer.navigator.update( viewer.viewport );
+    function onContainerExit(event) {
+        if (event.pointers < 1) {
+            THIS[this.hash].mouseInside = false;
+            if (!THIS[this.hash].animating) {
+                beginControlsAutoHide(this);
+            }
+        }
+        /**
+         * Raised when the cursor leaves the {@link OpenSeadragon.Viewer#container} element.
+         *
+         * @event container-exit
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+         * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+         * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
+         * @property {Boolean} insideElementPressed - True if the left mouse button is currently being pressed and was initiated inside the tracked element, otherwise false.
+         * @property {Boolean} buttonDownAny - Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
+         * @property {Object} originalEvent - The original DOM event.
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent('container-exit', {
+            tracker: event.eventSource,
+            position: event.position,
+            buttons: event.buttons,
+            pointers: event.pointers,
+            insideElementPressed: event.insideElementPressed,
+            buttonDownAny: event.buttonDownAny,
+            originalEvent: event.originalEvent
+        });
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Page update routines ( aka Views - for future reference )
+    ///////////////////////////////////////////////////////////////////////////////
+
+    function updateMulti(viewer) {
+        updateOnce(viewer);
+
+        // Request the next frame, unless we've been closed
+        if (viewer.isOpen()) {
+            viewer._updateRequestId = scheduleUpdate(viewer, updateMulti);
+        } else {
+            viewer._updateRequestId = false;
+        }
+    }
+
+    function updateOnce(viewer) {
+
+        //viewer.profiler.beginUpdate();
+
+        if (viewer._opening) {
+            return;
         }
 
-        THIS[ viewer.hash ].forceRedraw = false;
+        if (viewer.autoResize) {
+            var containerSize = _getSafeElemSize(viewer.container);
+            var prevContainerSize = THIS[viewer.hash].prevContainerSize;
+            if (!containerSize.equals(prevContainerSize)) {
+                var viewport = viewer.viewport;
+                if (viewer.preserveImageSizeOnResize) {
+                    var resizeRatio = prevContainerSize.x / containerSize.x;
+                    var zoom = viewport.getZoom() * resizeRatio;
+                    var center = viewport.getCenter();
+                    viewport.resize(containerSize, false);
+                    viewport.zoomTo(zoom, null, true);
+                    viewport.panTo(center, true);
+                } else {
+                    // maintain image position
+                    var oldBounds = viewport.getBounds();
+                    viewport.resize(containerSize, true);
+                    viewport.fitBoundsWithConstraints(oldBounds, true);
+                }
+                THIS[viewer.hash].prevContainerSize = containerSize;
+                THIS[viewer.hash].forceRedraw = true;
+            }
+        }
 
-        if (animated) {
+        var viewportChange = viewer.viewport.update();
+        var animated = viewer.world.update() || viewportChange;
+
+        if (viewportChange) {
             /**
              * Raised when any spring animation update occurs (zoom, pan, etc.),
-             * after the viewer has drawn the new location.
+             * before the viewer has drawn the new location.
              *
-             * @event animation
+             * @event viewport-change
              * @memberof OpenSeadragon.Viewer
              * @type {object}
              * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            viewer.raiseEvent( "animation" );
+            viewer.raiseEvent('viewport-change');
         }
+
+        if (viewer.referenceStrip) {
+            animated = viewer.referenceStrip.update(viewer.viewport) || animated;
+        }
+
+        if (!THIS[viewer.hash].animating && animated) {
+            /**
+             * Raised when any spring animation starts (zoom, pan, etc.).
+             *
+             * @event animation-start
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            viewer.raiseEvent("animation-start");
+            abortControlsAutoHide(viewer);
+        }
+
+        if (animated || THIS[viewer.hash].forceRedraw || viewer.world.needsDraw()) {
+            drawWorld(viewer);
+            viewer._drawOverlays();
+            if (viewer.navigator) {
+                viewer.navigator.update(viewer.viewport);
+            }
+
+            THIS[viewer.hash].forceRedraw = false;
+
+            if (animated) {
+                /**
+                 * Raised when any spring animation update occurs (zoom, pan, etc.),
+                 * after the viewer has drawn the new location.
+                 *
+                 * @event animation
+                 * @memberof OpenSeadragon.Viewer
+                 * @type {object}
+                 * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+                 * @property {?Object} userData - Arbitrary subscriber-defined object.
+                 */
+                viewer.raiseEvent("animation");
+            }
+        }
+
+        if (THIS[viewer.hash].animating && !animated) {
+            /**
+             * Raised when any spring animation ends (zoom, pan, etc.).
+             *
+             * @event animation-finish
+             * @memberof OpenSeadragon.Viewer
+             * @type {object}
+             * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+             * @property {?Object} userData - Arbitrary subscriber-defined object.
+             */
+            viewer.raiseEvent("animation-finish");
+
+            if (!THIS[viewer.hash].mouseInside) {
+                beginControlsAutoHide(viewer);
+            }
+        }
+
+        THIS[viewer.hash].animating = animated;
+
+        //viewer.profiler.endUpdate();
     }
 
-    if ( THIS[ viewer.hash ].animating && !animated ) {
+    function drawWorld(viewer) {
+        viewer.imageLoader.clear();
+        viewer.drawer.clear();
+        viewer.world.draw();
+
         /**
-         * Raised when any spring animation ends (zoom, pan, etc.).
+         * <em>- Needs documentation -</em>
          *
-         * @event animation-finish
+         * @event update-viewport
          * @memberof OpenSeadragon.Viewer
          * @type {object}
-         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
          * @property {?Object} userData - Arbitrary subscriber-defined object.
          */
-        viewer.raiseEvent( "animation-finish" );
+        viewer.raiseEvent('update-viewport', {});
+    }
 
-        if ( !THIS[ viewer.hash ].mouseInside ) {
-            beginControlsAutoHide( viewer );
+    ///////////////////////////////////////////////////////////////////////////////
+    // Navigation Controls
+    ///////////////////////////////////////////////////////////////////////////////
+    function resolveUrl(prefix, url) {
+        return prefix ? prefix + url : url;
+    }
+
+
+
+    function beginZoomingIn() {
+        THIS[this.hash].lastZoomTime = $.now();
+        THIS[this.hash].zoomFactor = this.zoomPerSecond;
+        THIS[this.hash].zooming = true;
+        scheduleZoom(this);
+    }
+
+
+    function beginZoomingOut() {
+        THIS[this.hash].lastZoomTime = $.now();
+        THIS[this.hash].zoomFactor = 1.0 / this.zoomPerSecond;
+        THIS[this.hash].zooming = true;
+        scheduleZoom(this);
+    }
+
+
+    function endZooming() {
+        THIS[this.hash].zooming = false;
+    }
+
+
+    function scheduleZoom(viewer) {
+        $.requestAnimationFrame($.delegate(viewer, doZoom));
+    }
+
+
+    function doZoom() {
+        var currentTime,
+            deltaTime,
+            adjustedFactor;
+
+        if (THIS[this.hash].zooming && this.viewport) {
+            currentTime = $.now();
+            deltaTime = currentTime - THIS[this.hash].lastZoomTime;
+            adjustedFactor = Math.pow(THIS[this.hash].zoomFactor, deltaTime / 1000);
+
+            this.viewport.zoomBy(adjustedFactor);
+            this.viewport.applyConstraints();
+            THIS[this.hash].lastZoomTime = currentTime;
+            scheduleZoom(this);
         }
     }
 
-    THIS[ viewer.hash ].animating = animated;
 
-    //viewer.profiler.endUpdate();
-}
-
-function drawWorld( viewer ) {
-    viewer.imageLoader.clear();
-    viewer.drawer.clear();
-    viewer.world.draw();
-
-    /**
-     * <em>- Needs documentation -</em>
-     *
-     * @event update-viewport
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    viewer.raiseEvent( 'update-viewport', {} );
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Navigation Controls
-///////////////////////////////////////////////////////////////////////////////
-function resolveUrl( prefix, url ) {
-    return prefix ? prefix + url : url;
-}
-
-
-
-function beginZoomingIn() {
-    THIS[ this.hash ].lastZoomTime = $.now();
-    THIS[ this.hash ].zoomFactor = this.zoomPerSecond;
-    THIS[ this.hash ].zooming = true;
-    scheduleZoom( this );
-}
-
-
-function beginZoomingOut() {
-    THIS[ this.hash ].lastZoomTime = $.now();
-    THIS[ this.hash ].zoomFactor = 1.0 / this.zoomPerSecond;
-    THIS[ this.hash ].zooming = true;
-    scheduleZoom( this );
-}
-
-
-function endZooming() {
-    THIS[ this.hash ].zooming = false;
-}
-
-
-function scheduleZoom( viewer ) {
-    $.requestAnimationFrame( $.delegate( viewer, doZoom ) );
-}
-
-
-function doZoom() {
-    var currentTime,
-        deltaTime,
-        adjustedFactor;
-
-    if ( THIS[ this.hash ].zooming && this.viewport) {
-        currentTime     = $.now();
-        deltaTime       = currentTime - THIS[ this.hash ].lastZoomTime;
-        adjustedFactor  = Math.pow( THIS[ this.hash ].zoomFactor, deltaTime / 1000 );
-
-        this.viewport.zoomBy( adjustedFactor );
-        this.viewport.applyConstraints();
-        THIS[ this.hash ].lastZoomTime = currentTime;
-        scheduleZoom( this );
+    function doSingleZoomIn() {
+        if (this.viewport) {
+            THIS[this.hash].zooming = false;
+            this.viewport.zoomBy(
+                this.zoomPerClick / 1.0
+            );
+            this.viewport.applyConstraints();
+        }
     }
-}
 
 
-function doSingleZoomIn() {
-    if ( this.viewport ) {
-        THIS[ this.hash ].zooming = false;
-        this.viewport.zoomBy(
-            this.zoomPerClick / 1.0
-        );
-        this.viewport.applyConstraints();
+    function doSingleZoomOut() {
+        if (this.viewport) {
+            THIS[this.hash].zooming = false;
+            this.viewport.zoomBy(
+                1.0 / this.zoomPerClick
+            );
+            this.viewport.applyConstraints();
+        }
     }
-}
 
 
-function doSingleZoomOut() {
-    if ( this.viewport ) {
-        THIS[ this.hash ].zooming = false;
-        this.viewport.zoomBy(
-            1.0 / this.zoomPerClick
-        );
-        this.viewport.applyConstraints();
-    }
-}
-
-
-function lightUp() {
-    this.buttons.emulateEnter();
-    this.buttons.emulateExit();
-}
-
-
-function onHome() {
-    if ( this.viewport ) {
-        this.viewport.goHome();
-    }
-}
-
-
-function onFullScreen() {
-    if ( this.isFullPage() && !$.isFullScreen() ) {
-        // Is fullPage but not fullScreen
-        this.setFullPage( false );
-    } else {
-        this.setFullScreen( !this.isFullPage() );
-    }
-    // correct for no mouseout event on change
-    if ( this.buttons ) {
+    function lightUp() {
+        this.buttons.emulateEnter();
         this.buttons.emulateExit();
     }
-    this.fullPageButton.element.focus();
-    if ( this.viewport ) {
-        this.viewport.applyConstraints();
-    }
-}
 
-/**
- * Note: The current rotation feature is limited to 90 degree turns.
- */
-function onRotateLeft() {
-    if ( this.viewport ) {
-        var currRotation = this.viewport.getRotation();
-        if (currRotation === 0) {
-            currRotation = 270;
+
+    function onHome() {
+        if (this.viewport) {
+            this.viewport.goHome();
         }
-        else {
-            currRotation -= 90;
+    }
+
+
+    function onFullScreen() {
+        if (this.isFullPage() && !$.isFullScreen()) {
+            // Is fullPage but not fullScreen
+            this.setFullPage(false);
+        } else {
+            this.setFullScreen(!this.isFullPage());
         }
-        this.viewport.setRotation(currRotation);
-    }
-}
-
-/**
- * Note: The current rotation feature is limited to 90 degree turns.
- */
-function onRotateRight() {
-    if ( this.viewport ) {
-        var currRotation = this.viewport.getRotation();
-        if (currRotation === 270) {
-            currRotation = 0;
+        // correct for no mouseout event on change
+        if (this.buttons) {
+            this.buttons.emulateExit();
         }
-        else {
-            currRotation += 90;
+        this.fullPageButton.element.focus();
+        if (this.viewport) {
+            this.viewport.applyConstraints();
         }
-        this.viewport.setRotation(currRotation);
     }
-}
 
-
-function onPrevious(){
-    var previous = this._sequenceIndex - 1;
-    if(this.navPrevNextWrap && previous < 0){
-        previous += this.tileSources.length;
+    /**
+     * Note: The current rotation feature is limited to 90 degree turns.
+     */
+    function onRotateLeft() {
+        if (this.viewport) {
+            var currRotation = this.viewport.getRotation();
+            if (currRotation === 0) {
+                currRotation = 270;
+            }
+            else {
+                currRotation -= 90;
+            }
+            this.viewport.setRotation(currRotation);
+        }
     }
-    this.goToPage( previous );
-}
 
-
-function onNext(){
-    var next = this._sequenceIndex + 1;
-    if(this.navPrevNextWrap && next >= this.tileSources.length){
-        next = 0;
+    /**
+     * Note: The current rotation feature is limited to 90 degree turns.
+     */
+    function onRotateRight() {
+        if (this.viewport) {
+            var currRotation = this.viewport.getRotation();
+            if (currRotation === 270) {
+                currRotation = 0;
+            }
+            else {
+                currRotation += 90;
+            }
+            this.viewport.setRotation(currRotation);
+        }
     }
-    this.goToPage( next );
-}
 
 
-}( OpenSeadragon ));
+    function onPrevious() {
+        var previous = this._sequenceIndex - 1;
+        if (this.navPrevNextWrap && previous < 0) {
+            previous += this.tileSources.length;
+        }
+        this.goToPage(previous);
+    }
+
+
+    function onNext() {
+        var next = this._sequenceIndex + 1;
+        if (this.navPrevNextWrap && next >= this.tileSources.length) {
+            next = 0;
+        }
+        this.goToPage(next);
+    }
+
+
+}(OpenSeadragon));

--- a/test/demo/basic.html
+++ b/test/demo/basic.html
@@ -26,7 +26,8 @@
             prefixUrl: "../../build/openseadragon/images/",
             tileSources: "../data/testpattern.dzi",
             showNavigator: true,
-            refetchFailedTiles: true
+            tileRetryMax: 1,
+            tileRetryDelay: 2500,
         });
 
     </script>

--- a/test/demo/basic.html
+++ b/test/demo/basic.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <title>OpenSeadragon Basic Demo</title>
     <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
     <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
     <style type="text/css">
-
         .openseadragon1 {
             width: 800px;
             height: 600px;
         }
-
     </style>
 </head>
+
 <body>
     <div>
         Simple demo page to show a default OpenSeadragon viewer.
@@ -25,9 +25,11 @@
             id: "contentDiv",
             prefixUrl: "../../build/openseadragon/images/",
             tileSources: "../data/testpattern.dzi",
-            showNavigator:true
+            showNavigator: true,
+            refetchFailedTiles: true
         });
 
     </script>
 </body>
+
 </html>


### PR DESCRIPTION
I faced some issues with OpenSeadragon in my current project when tiles failed loading when the server is too busy. I missed a functionality to reload the failed tiles and after some research I only found an answer that it isn't possible yet to reload specific tiles. 
So I extended the ImageLoader and ImageJob class a bit. If the ImageLoader notices within completeJob that a request failed and the job didn't run more than 3 times, it will re-run the job after a timeout of 2500ms. After 3 times failing it will be handled the normal way. 
Do you think it's a good solution? 

I also know the "tile-load-failed"-event and the xhr object within the event but i wasn't able to write a suitable solution with that object 😄

btw: i used EditorConfig for formatting but why did I get so many format changes? 😄 