### PR TITLE
Fixed issue with square tile code on IE

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -367,16 +367,21 @@ $.Tile.prototype = {
         // changes as we are rendering the image
         drawingHandler({context: context, tile: this, rendered: rendered});
 
-        if (!this.sourceBounds) { // Just in case
-            this.sourceBounds = new $.Rect(0, 0, rendered.canvas.width, rendered.canvas.height);
+        var sourceWidth, sourceHeight;
+        if (this.sourceBounds) {
+            sourceWidth = Math.min(this.sourceBounds.width, rendered.canvas.width);
+            sourceHeight = Math.min(this.sourceBounds.height, rendered.canvas.height);
+        } else {
+            sourceWidth = rendered.canvas.width;
+            sourceHeight = rendered.canvas.height;
         }
 
         context.drawImage(
             rendered.canvas,
-            this.sourceBounds.x,
-            this.sourceBounds.y,
-            this.sourceBounds.width,
-            this.sourceBounds.height,
+            0,
+            0,
+            sourceWidth,
+            sourceHeight,
             position.x,
             position.y,
             size.x,

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -392,9 +392,7 @@ $.TileSource.prototype = {
         sy = Math.min( sy, dimensionsScaled.y - py );
 
         if (isSource) {
-            scale = 1;
-            px = 0;
-            py = 0;
+            return new $.Rect(0, 0, Math.floor(sx), Math.floor(sy));
         }
 
         return new $.Rect( px * scale, py * scale, sx * scale, sy * scale );

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -392,7 +392,7 @@ $.TileSource.prototype = {
         sy = Math.min( sy, dimensionsScaled.y - py );
 
         if (isSource) {
-            return new $.Rect(0, 0, Math.floor(sx), Math.floor(sy));
+            return new $.Rect(0, 0, sx, sy);
         }
 
         return new $.Rect( px * scale, py * scale, sx * scale, sy * scale );


### PR DESCRIPTION
Followup to #1426; IE doesn't like source values bigger than the source canvas, so we have to trim our numbers.