### PR TITLE
Transparent image overlap when using Overlap=0 in dzi

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -356,10 +356,10 @@ $.Tile.prototype = {
             //clearing only the inside of the rectangle occupied
             //by the png prevents edge flikering
             context.clearRect(
-                position.x + 1,
-                position.y + 1,
-                size.x - 1,
-                size.y - 1
+                position.x,
+                position.y,
+                size.x,
+                size.y
             );
         }
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -358,8 +358,8 @@ $.Tile.prototype = {
             context.clearRect(
                 position.x + 1,
                 position.y + 1,
-                size.x - 2,
-                size.y - 2
+                size.x - 1,
+                size.y - 1
             );
         }
 


### PR DESCRIPTION
When using overlap=0 in dzi, we get a ~1px grid/border around each tile. 
![overlap_osd](https://user-images.githubusercontent.com/2477954/40217919-5ae73912-5a6f-11e8-8f0e-293d7e915482.png)

Include a zip as a test, with no changes:
[overlap_test.zip](https://github.com/openseadragon/openseadragon/files/2015591/overlap_test.zip)


Changing the clearReact size.x/y to -1 instead of -2 fixes the problem. There could be adverse effects that I'm not aware of.