### PR TITLE
Documentation addition for viewer.world

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -152,6 +152,11 @@ $.Viewer = function( options ) {
          * @memberof OpenSeadragon.Viewer#
          */
         drawer:             null,
+        /**
+         * Keeps track of all of the tiled images in the scene.
+         * @member {OpenSeadragon.Drawer} world
+         * @memberof OpenSeadragon.Viewer#
+         */
         world:              null,
         /**
          * Handles coordinate-related functionality - zoom, pan, rotation, etc. Created for each TileSource opened.


### PR DESCRIPTION
In response to #1477

The changes in `viewer.js` were simple to find. But the equivalent documentation edits for `source` in `tiledimage.js` are a little hidden, is the `.source` member being added when merging `options` object in? If so, where should the jsdoc comments sit?

See: 
https://github.com/openseadragon/openseadragon/blob/cd0a4aee16c0435b4d4c4e98807c0d14e716d707/src/tiledimage.js#L177



 