### PR TITLE
ImageJob timeout configuration debugging help

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -84,7 +84,7 @@ ImageJob.prototype = {
         };
 
         this.jobId = window.setTimeout(function(){
-            self.errorMsg = "Image load exceeded timeout";
+            self.errorMsg = "Image load exceeded timeout (" + self.timeout + " ms)";
             self.finish(false);
         }, this.timeout);
 

--- a/test/demo/timeout-certain.html
+++ b/test/demo/timeout-certain.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OpenSeadragon Demo - Timeout Certain</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+    <style type="text/css">
+
+        .openseadragon1 {
+            width: 800px;
+            height: 600px;
+        }
+
+    </style>
+</head>
+<body>
+<div>
+    <p>The ImageLoader timeout is set to 0 ms, and the tile source is remote.</p>
+    <p>In any web browser on any network connection, OpenSeadragon should not load properly, and the browser console log should show tile loading errors.</p>
+</div>
+<div id="contentDiv" class="openseadragon1"></div>
+<script type="text/javascript">
+
+    var viewer = OpenSeadragon({
+        // debugMode: true,
+        id: "contentDiv",
+        prefixUrl: "../../build/openseadragon/images/",
+        tileSources: "http://wellcomelibrary.org/iiif-img/b11768265-0/a6801943-b8b4-4674-908c-7d5b27e70569/info.json",
+        showNavigator:true,
+        timeout: 0
+    });
+
+</script>
+</body>
+</html>

--- a/test/demo/timeout-unlikely.html
+++ b/test/demo/timeout-unlikely.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OpenSeadragon Demo - Timeout Unlikely</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+    <style type="text/css">
+
+        .openseadragon1 {
+            width: 800px;
+            height: 600px;
+        }
+
+    </style>
+</head>
+<body>
+<div>
+    <p>The ImageLoader timeout is set to 24 hours, and the tile source is remote.</p>
+    <p>In any web browser on nearly any network connection, OpenSeadragon should load properly, and the browser console log should not show any tile loading errors.</p>
+</div>
+<div id="contentDiv" class="openseadragon1"></div>
+<script type="text/javascript">
+
+    var viewer = OpenSeadragon({
+        // debugMode: true,
+        id: "contentDiv",
+        prefixUrl: "../../build/openseadragon/images/",
+        tileSources: "http://wellcomelibrary.org/iiif-img/b11768265-0/a6801943-b8b4-4674-908c-7d5b27e70569/info.json",
+        showNavigator:true,
+        timeout: 1000 * 60 * 60 * 24
+    });
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
I submitted #1192 a while back, which should have taken care of #1279.

I thought it would be a good idea to add some HTML tests for the ImageJob timeout configuration so that we can have a more precise discussion about the problem.

I've opened each of the new HTML files in my latest Firefox, Chrome, and Chromium browsers on Ubuntu 16, and they behave as expected.

I also added in @jrochkind 's [suggestion to improve the error logging](https://github.com/openseadragon/openseadragon/issues/1279#issue-247793958).