### PR TITLE
[WIP] Be able to control when we cancel events.

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1963,7 +1963,7 @@
             currentTime: $.now()
         };
 
-        if ( updatePointersDown( tracker, event, [ gPoint ], getStandardizedButton( event.button ) ) ) {
+        if ( updatePointersDown( tracker, event, [ gPoint ], getStandardizedButton( event.button ) ).capture ) {
             $.stopEvent( event );
             capturePointer( tracker, 'mouse' );
         }
@@ -2139,12 +2139,15 @@
             }
         }
 
-        if ( updatePointersDown( tracker, event, gPoints, 0 ) ) { // 0 means primary button press/release or touch contact
+        var result = updatePointersDown( tracker, event, gPoints, 0 ); // 0 means primary button press/release or touch contact
+        if ( result.capture && result.cancel ) {
             $.stopEvent( event );
             capturePointer( tracker, 'touch', touchCount );
         }
 
-        $.cancelEvent( event );
+        if (result.cancel) {
+            $.cancelEvent( event );
+        }
     }
 
 
@@ -2263,9 +2266,11 @@
             } );
         }
 
-        updatePointersMove( tracker, event, gPoints );
+        var result = updatePointersMove( tracker, event, gPoints );
 
-        $.cancelEvent( event );
+        if (result.cancel) {
+            $.cancelEvent( event );
+        }
     }
 
 
@@ -2363,7 +2368,7 @@
             currentTime: $.now()
         };
 
-        if ( updatePointersDown( tracker, event, [ gPoint ], event.button ) ) {
+        if ( updatePointersDown( tracker, event, [ gPoint ], event.button ).capture ) {
             $.stopEvent( event );
             capturePointer( tracker, gPoint.type );
         }
@@ -2696,7 +2701,8 @@
      *      Note on chorded button presses (a button pressed when another button is already pressed): In the W3C Pointer Events model,
      *      only one pointerdown/pointerup event combo is fired. Chorded button state changes instead fire pointermove events.
      *
-     * @returns {Boolean} True if pointers should be captured to the tracked element, otherwise false.
+     * @returns {Object} Properties: capture: True if pointers should be captured to the tracked element, otherwise false.
+     * TODO: Document cancel
      */
     function updatePointersDown( tracker, event, gPoints, buttonChanged ) {
         var delegate = THIS[ tracker.hash ],
@@ -2706,6 +2712,11 @@
             gPointCount = gPoints.length,
             curGPoint,
             updateGPoint;
+
+        var output = {
+            capture: false,
+            cancel: true
+        };
 
         if ( typeof event.buttons !== 'undefined' ) {
             pointsList.buttons = event.buttons;
@@ -2783,7 +2794,7 @@
                 }
             }
 
-            return false;
+            return output;
         }
 
         for ( i = 0; i < gPointCount; i++ ) {
@@ -2821,20 +2832,24 @@
             if ( pointsList.contacts === 1 ) {
                 // Press
                 if ( tracker.pressHandler ) {
-                    propagate = tracker.pressHandler(
-                        {
-                            eventSource:          tracker,
-                            pointerType:          curGPoint.type,
-                            position:             getPointRelativeToAbsolute( curGPoint.contactPos, tracker.element ),
-                            buttons:              pointsList.buttons,
-                            isTouchEvent:         curGPoint.type === 'touch',
-                            originalEvent:        event,
-                            preventDefaultAction: false,
-                            userData:             tracker.userData
-                        }
-                    );
+                    var outgoingEvent = {
+                        eventSource:          tracker,
+                        pointerType:          curGPoint.type,
+                        position:             getPointRelativeToAbsolute( curGPoint.contactPos, tracker.element ),
+                        buttons:              pointsList.buttons,
+                        isTouchEvent:         curGPoint.type === 'touch',
+                        originalEvent:        event,
+                        preventDefaultAction: false,
+                        userData:             tracker.userData
+                    };
+
+                    propagate = tracker.pressHandler(outgoingEvent);
                     if ( propagate === false ) {
                         $.cancelEvent( event );
+                    }
+
+                    if (outgoingEvent.preventDefaultAction) {
+                        output.cancel = false;
                     }
                 }
             } else if ( pointsList.contacts === 2 ) {
@@ -2847,7 +2862,8 @@
             }
         }
 
-        return true;
+        output.capture = true;
+        return output;
     }
 
 
@@ -3156,6 +3172,10 @@
             delta,
             propagate;
 
+        var output = {
+            cancel: true
+        };
+
         if ( typeof event.buttons !== 'undefined' ) {
             pointsList.buttons = event.buttons;
         }
@@ -3234,24 +3254,26 @@
             if ( tracker.dragHandler ) {
                 updateGPoint = pointsList.asArray()[ 0 ];
                 delta = updateGPoint.currentPos.minus( updateGPoint.lastPos );
-                propagate = tracker.dragHandler(
-                    {
-                        eventSource:          tracker,
-                        pointerType:          updateGPoint.type,
-                        position:             getPointRelativeToAbsolute( updateGPoint.currentPos, tracker.element ),
-                        buttons:              pointsList.buttons,
-                        delta:                delta,
-                        speed:                updateGPoint.speed,
-                        direction:            updateGPoint.direction,
-                        shift:                event.shiftKey,
-                        isTouchEvent:         updateGPoint.type === 'touch',
-                        originalEvent:        event,
-                        preventDefaultAction: false,
-                        userData:             tracker.userData
-                    }
-                );
+                var outgoingEvent = {
+                    eventSource:          tracker,
+                    pointerType:          updateGPoint.type,
+                    position:             getPointRelativeToAbsolute( updateGPoint.currentPos, tracker.element ),
+                    buttons:              pointsList.buttons,
+                    delta:                delta,
+                    speed:                updateGPoint.speed,
+                    direction:            updateGPoint.direction,
+                    shift:                event.shiftKey,
+                    isTouchEvent:         updateGPoint.type === 'touch',
+                    originalEvent:        event,
+                    preventDefaultAction: false,
+                    userData:             tracker.userData
+                };
+                propagate = tracker.dragHandler(outgoingEvent);
                 if ( propagate === false ) {
                     $.cancelEvent( event );
+                }
+                if (outgoingEvent.preventDefaultAction) {
+                    output.cancel = false;
                 }
             }
         } else if ( pointsList.contacts === 2 ) {
@@ -3304,6 +3326,8 @@
                 }
             }
         }
+
+        return output;
     }
 
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2790,6 +2790,7 @@ function onCanvasDrag( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'canvas-drag', canvasDragEventArgs);
+    event.preventDefaultAction = canvasDragEventArgs.preventDefaultAction;
 
     if ( !canvasDragEventArgs.preventDefaultAction && this.viewport ) {
         gestureSettings = this.gestureSettingsByDeviceType( event.pointerType );
@@ -2942,6 +2943,15 @@ function onCanvasExit( event ) {
 }
 
 function onCanvasPress( event ) {
+    var canvasPressEventArgs = {
+        tracker: event.eventSource,
+        pointerType: event.pointerType,
+        position: event.position,
+        insideElementPressed: event.insideElementPressed,
+        insideElementReleased: event.insideElementReleased,
+        originalEvent: event.originalEvent
+    };
+
     /**
      * Raised when the primary mouse button is pressed or touch starts on the {@link OpenSeadragon.Viewer#canvas} element.
      *
@@ -2957,14 +2967,9 @@ function onCanvasPress( event ) {
      * @property {Object} originalEvent - The original DOM event.
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
-    this.raiseEvent( 'canvas-press', {
-        tracker: event.eventSource,
-        pointerType: event.pointerType,
-        position: event.position,
-        insideElementPressed: event.insideElementPressed,
-        insideElementReleased: event.insideElementReleased,
-        originalEvent: event.originalEvent
-    });
+    this.raiseEvent( 'canvas-press', canvasPressEventArgs);
+
+    event.preventDefaultAction = canvasPressEventArgs.preventDefaultAction;
 }
 
 function onCanvasRelease( event ) {


### PR DESCRIPTION
As part of our event processing in MouseTracker, we cancel events sometimes. In some cases, we need to be able to turn that off and let the events go through to the browser. This patch is a work in progress to explore how to do that; it's specifically focused around being able to let the touch drag events through to the browser so it does its normal scrolling. I think something similar is needed to allow the browser to do its normal zooming for #1534. 

@msalsbery Any thoughts?