### PR TITLE
Add missing space between sentences in error message

### DIFF
--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -239,7 +239,7 @@ $.TileSource.prototype = {
 
     getTileSize: function( level ) {
         $.console.error(
-            "[TileSource.getTileSize] is deprecated." +
+            "[TileSource.getTileSize] is deprecated. " +
             "Use TileSource.getTileWidth() and TileSource.getTileHeight() instead"
         );
         return this._tileWidth;


### PR DESCRIPTION
This fixes an issue reported by LGTM:

    This string appears to be missing a space after 'deprecated.'.

Signed-off-by: Stefan Weil <sw@weilnetz.de>