### PR TITLE
Don't insert label element until this feature is fully implemented.

### DIFF
--- a/src/buttongroup.js
+++ b/src/buttongroup.js
@@ -70,11 +70,11 @@ $.ButtonGroup = function( options ) {
 
     // TODO What if there IS an options.group specified?
     if( !options.group ){
-        this.label   = $.makeNeutralElement( "label" );
+        this.element.style.display = "inline-block";
+        //this.label   = $.makeNeutralElement( "label" );
         //TODO: support labels for ButtonGroups
         //this.label.innerHTML = this.labelText;
-        this.element.style.display = "inline-block";
-        this.element.appendChild( this.label );
+        //this.element.appendChild( this.label );
         for ( i = 0; i < buttons.length; i++ ) {
             this.element.appendChild( buttons[ i ].element );
         }


### PR DESCRIPTION
This probably isn't a huge deal, but some accessibility tools (WAVE, in this instance), are complaining about the presence of an empty label element. I was curious about the cause of this and after I found it I couldn't think of a reason not to remove the empty tag as it seems to be dust from a partially completed feature. (Element created, inserted, never assigned labelText?)

I wasn't too clear on what the final desired outcome was here. So for now I've group these lines together and left them commented out.

Now it could be that this should only get inserted if `this.labelText` is not an empty string and if that's about the sum of it, I'm happy to also implement that change while I'm here.
