### PR TITLE
[WIP] Fixing "imageSmoothingEnabled" resetting to 'True' (should fix #1593)

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -686,8 +686,9 @@ $.Drawer.prototype = {
         var pixelDensityRatio = $.pixelDensityRatio;
         var viewportSize = this.viewport.getContainerSize();
         return {
-            x: viewportSize.x * pixelDensityRatio,
-            y: viewportSize.y * pixelDensityRatio
+            // canvas width and height are integers
+            x: Math.floor(viewportSize.x * pixelDensityRatio),
+            y: Math.floor(viewportSize.y * pixelDensityRatio)
         };
     },
 

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -247,6 +247,7 @@ $.Drawer.prototype = {
             var viewportSize = this._calculateCanvasSize();
             if( this.canvas.width != viewportSize.x ||
                 this.canvas.height != viewportSize.y ) {
+                var imageSmoothingEnabled = this.canvas.getContext('2d').imageSmoothingEnabled;
                 this.canvas.width = viewportSize.x;
                 this.canvas.height = viewportSize.y;
                 if ( this.sketchCanvas !== null ) {
@@ -254,6 +255,7 @@ $.Drawer.prototype = {
                     this.sketchCanvas.width = sketchCanvasSize.x;
                     this.sketchCanvas.height = sketchCanvasSize.y;
                 }
+                this.setImageSmoothingEnabled(imageSmoothingEnabled);
             }
             this._clear();
         }

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -247,7 +247,6 @@ $.Drawer.prototype = {
             var viewportSize = this._calculateCanvasSize();
             if( this.canvas.width != viewportSize.x ||
                 this.canvas.height != viewportSize.y ) {
-                var imageSmoothingEnabled = this.canvas.getContext('2d').imageSmoothingEnabled;
                 this.canvas.width = viewportSize.x;
                 this.canvas.height = viewportSize.y;
                 if ( this.sketchCanvas !== null ) {
@@ -255,7 +254,7 @@ $.Drawer.prototype = {
                     this.sketchCanvas.width = sketchCanvasSize.x;
                     this.sketchCanvas.height = sketchCanvasSize.y;
                 }
-                this.setImageSmoothingEnabled(imageSmoothingEnabled);
+                this._setImageSmoothingEnabled();
             }
             this._clear();
         }
@@ -611,6 +610,9 @@ $.Drawer.prototype = {
     },
 
 
+    // private
+    _imageSmoothingEnabled: true,
+
     /**
      * Turns image smoothing on or off for this viewer. Note: Ignored in some (especially older) browsers that do not support this property.
      *
@@ -621,14 +623,19 @@ $.Drawer.prototype = {
      */
     setImageSmoothingEnabled: function(imageSmoothingEnabled){
         if ( this.useCanvas ) {
-            var context = this.context;
-            context.mozImageSmoothingEnabled = imageSmoothingEnabled;
-            context.webkitImageSmoothingEnabled = imageSmoothingEnabled;
-            context.msImageSmoothingEnabled = imageSmoothingEnabled;
-            context.imageSmoothingEnabled = imageSmoothingEnabled;
-
+            this._imageSmoothingEnabled = imageSmoothingEnabled;
+            this._setImageSmoothingEnabled();
             this.viewer.forceRedraw();
         }
+    },
+
+    // private
+    _setImageSmoothingEnabled: function(){
+        var context = this.context;
+        context.mozImageSmoothingEnabled = this._imageSmoothingEnabled;
+        context.webkitImageSmoothingEnabled = this._imageSmoothingEnabled;
+        context.msImageSmoothingEnabled = this._imageSmoothingEnabled;
+        context.imageSmoothingEnabled = this._imageSmoothingEnabled;
     },
 
     /**
@@ -689,8 +696,8 @@ $.Drawer.prototype = {
         var viewportSize = this.viewport.getContainerSize();
         return {
             // canvas width and height are integers
-            x: Math.floor(viewportSize.x * pixelDensityRatio),
-            y: Math.floor(viewportSize.y * pixelDensityRatio)
+            x: Math.round(viewportSize.x * pixelDensityRatio),
+            y: Math.round(viewportSize.y * pixelDensityRatio)
         };
     },
 

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -130,6 +130,10 @@ $.Drawer = function( options ) {
     // explicit left-align
     this.container.style.textAlign = "left";
     this.container.appendChild( this.canvas );
+
+    // Image smoothing for canvas rendering (only if canvas is used).
+    // Canvas default is "true", so this will only be changed if user specified "false".
+    this._imageSmoothingEnabled = true;
 };
 
 /** @lends OpenSeadragon.Drawer.prototype */
@@ -254,7 +258,7 @@ $.Drawer.prototype = {
                     this.sketchCanvas.width = sketchCanvasSize.x;
                     this.sketchCanvas.height = sketchCanvasSize.y;
                 }
-                this._setImageSmoothingEnabled();
+                this._updateImageSmoothingEnabled();
             }
             this._clear();
         }
@@ -609,10 +613,6 @@ $.Drawer.prototype = {
         }
     },
 
-
-    // private
-    _imageSmoothingEnabled: true,
-
     /**
      * Turns image smoothing on or off for this viewer. Note: Ignored in some (especially older) browsers that do not support this property.
      *
@@ -624,13 +624,13 @@ $.Drawer.prototype = {
     setImageSmoothingEnabled: function(imageSmoothingEnabled){
         if ( this.useCanvas ) {
             this._imageSmoothingEnabled = imageSmoothingEnabled;
-            this._setImageSmoothingEnabled();
+            this._updateImageSmoothingEnabled();
             this.viewer.forceRedraw();
         }
     },
 
     // private
-    _setImageSmoothingEnabled: function(){
+    _updateImageSmoothingEnabled: function(){
         var context = this.context;
         context.mozImageSmoothingEnabled = this._imageSmoothingEnabled;
         context.webkitImageSmoothingEnabled = this._imageSmoothingEnabled;


### PR DESCRIPTION
As explained in #1593, the main issue is that the property imageSmoothingEnabled of a canvas is being reset to "True" each time the canvas is resized (probably by design), while we only set it once on initialization.

This revealed another issue - when window.devicePixelRatio is > 1 and not an integer (this depends on the display type and browser's **zoom** and not IE vs Chrome as I thought before), _calculateCanvasSize often returns non-integer values.
As canvas width/height are always integers, this if in "clear" function will be evaluated to true on some window sizes:
( this.canvas.width != viewportSize.x || this.canvas.height != viewportSize.y )
which will "resize" the canvas to its current size, and will reset imageSmoothingEnabled as explained before.

In this commit I "floored" _calculateCanvasSize return values.
Regarding the main issue, we should set imageSmoothingEnabled after every resize. I will appreciate some help figuring out the best place to call setImageSmoothingEnabled(). 
It should be deep enough so it will happen after every resize, but we still need access to the user-defined value.

BTW, from what I see ([here](https://bugs.chromium.org/p/chromium/issues/detail?id=277205#c9) for instance), BackingStorePixelRatio is deprecated and always returns 1, so maybe we can get rid of it?

(Sorry for the long msg, and I hope this pull request was done correctly, it's my first one!)