### PR TITLE
Fix for #1617 and canBeTiled

### DIFF
--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -352,9 +352,12 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         } else {
             iiifQuality = "default.jpg";
         }
-
         if ( levelWidth < tileWidth && levelHeight < tileHeight ){
-            iiifSize = levelWidth + ",";
+            // max will be canonical in 3.0
+            iiifSize = "max";
+            iiifRegion = 'full';
+        } else if ( x == 0 && y == 0 && levelWidth == this.width && levelHeight == this.height ) {
+            iiifSize = "max";
             iiifRegion = 'full';
         } else {
             iiifTileX = x * iiifTileSizeWidth;

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -374,17 +374,21 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
     /**
      * Determine whether arbitrary tile requests can be made against a service with the given profile
      * @function
-     * @param {object} profile - IIIF profile object
+     * @param {object} profile - IIIF profile array
      * @throws {Error}
      */
-    function canBeTiled (profile ) {
+    function canBeTiled ( profile ) {
         var level0Profiles = [
             "http://library.stanford.edu/iiif/image-api/compliance.html#level0",
             "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level0",
             "http://iiif.io/api/image/2/level0.json"
         ];
         var isLevel0 = (level0Profiles.indexOf(profile[0]) != -1);
-        return !isLevel0 || (profile.indexOf("sizeByW") != -1);
+        var hasSizeByW = false;
+        if ( profile.length > 1 && profile[1].supports ) {
+            hasSizeByW = profile[1].supports.indexOf( "sizeByW" ) != -1;
+        }
+        return !isLevel0 || hasSizeByW;
     }
 
     /**


### PR DESCRIPTION
These two commits fix #1617 and the canBeTiled function which was not looking in the right place for `sizeByW`