### PR TITLE
Fixed: window resize was resetting image smoothing.

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -253,12 +253,13 @@ $.Drawer.prototype = {
                 this.canvas.height != viewportSize.y ) {
                 this.canvas.width = viewportSize.x;
                 this.canvas.height = viewportSize.y;
+                this._updateImageSmoothingEnabled(this.context);
                 if ( this.sketchCanvas !== null ) {
                     var sketchCanvasSize = this._calculateSketchCanvasSize();
                     this.sketchCanvas.width = sketchCanvasSize.x;
                     this.sketchCanvas.height = sketchCanvasSize.y;
+                    this._updateImageSmoothingEnabled(this.sketchContext);
                 }
-                this._updateImageSmoothingEnabled(this.context);
             }
             this._clear();
         }


### PR DESCRIPTION
Fixed a case in `drawer.js` where the window is resized when useSketch is true causing an unintended reset of imageSmoothingEnabled to true. Closes #1646 (second bug case: https://github.com/openseadragon/openseadragon/issues/1646#issuecomment-484746023), as a follow up to #1647.

Apologies for the bug in my previous patch. Although it was implied by the existing code, I didn't realise that resizing a canvas creates a new context.