### PR TITLE
Pass down ajax configs to reference strip thumbnail viewers

### DIFF
--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -449,7 +449,9 @@ function loadPanels( strip, viewerSize, scroll ) {
                 showSequenceControl:    false,
                 immediateRender:        true,
                 blendTime:              0,
-                animationTime:          0
+                animationTime:          0,
+                loadTilesWithAjax:      strip.viewer.loadTilesWithAjax,
+                ajaxHeaders:            strip.viewer.ajaxHeaders
             } );
 
             miniViewer.displayRegion           = $.makeNeutralElement( "div" );


### PR DESCRIPTION
Addresses: https://github.com/openseadragon/openseadragon/issues/1700

Fix: Passes down the top level viewer configs, `loadTilesWithAjax` and `ajaxHeaders` to each of the thumbnail viewers on the reference strip. 