### PR TITLE
Removing forced overlap for tile sources with no overlap

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -337,6 +337,10 @@ $.Tile.prototype = {
 
         context.globalAlpha = this.opacity;
 
+        // Gives correct (additive) blending and composition
+        // for sub-pixel rendering.
+        context.globalCompositeOperation = 'lighter';
+
         if (typeof scale === 'number' && scale !== 1) {
             // draw tile at a different scale
             position = position.times(scale);

--- a/src/tile.js
+++ b/src/tile.js
@@ -337,10 +337,6 @@ $.Tile.prototype = {
 
         context.globalAlpha = this.opacity;
 
-        // Gives correct (additive) blending and composition
-        // for sub-pixel rendering.
-        context.globalCompositeOperation = 'lighter';
-
         if (typeof scale === 'number' && scale !== 1) {
             // draw tile at a different scale
             position = position.times(scale);

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1620,10 +1620,6 @@ function positionTile( tile, overlap, viewport, viewportCenter, levelVisibility,
         tileCenter = positionT.plus( sizeT.divide( 2 ) ),
         tileSquaredDistance = viewportCenter.squaredDistanceTo( tileCenter );
 
-    if ( !overlap ) {
-        sizeC = sizeC.plus( new $.Point( 1, 1 ) );
-    }
-
     if (tile.isRightMost && tiledImage.wrapHorizontal) {
         sizeC.x += 0.75; // Otherwise Firefox and Safari show seams
     }


### PR DESCRIPTION
Here is a PR fixing the forced overlap mentioned in #1722. I also changed to blend mode 'lighter' for correct blending of the seams when overlap=0. 

I ran the tests (grunt test) which logged a bunch of 404 errors, but at the end told me that all tests where ok with no failed and no skipped. Are the 404s expected?