### PR TITLE
Addressing problems with seams by removing overlap when rendering

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -351,21 +351,6 @@ $.Tile.prototype = {
             position = position.plus(translate);
         }
 
-        //if we are supposed to be rendering fully opaque rectangle,
-        //ie its done fading or fading is turned off, and if we are drawing
-        //an image with an alpha channel, then the only way
-        //to avoid seeing the tile underneath is to clear the rectangle
-        if (context.globalAlpha === 1 && this._hasTransparencyChannel()) {
-            //clearing only the inside of the rectangle occupied
-            //by the png prevents edge flikering
-            context.clearRect(
-                position.x,
-                position.y,
-                size.x,
-                size.y
-            );
-        }
-
         // This gives the application a chance to make image manipulation
         // changes as we are rendering the image
         drawingHandler({context: context, tile: this, rendered: rendered});

--- a/src/tile.js
+++ b/src/tile.js
@@ -308,8 +308,11 @@ $.Tile.prototype = {
      * where <code>rendered</code> is the context with the pre-drawn image.
      * @param {Number} [scale=1] - Apply a scale to position and size
      * @param {OpenSeadragon.Point} [translate] - A translation vector
+     * @param {Number} overlap - Overlap in pixels between tiles.
+     * If greater than 0, tile position and size will be rounded to avoid
+     * problems with sub-pixel rendering.
      */
-    drawCanvas: function( context, drawingHandler, scale, translate ) {
+    drawCanvas: function( context, drawingHandler, scale, translate, overlap) {
 
         var position = this.position.times($.pixelDensityRatio),
             size     = this.size.times($.pixelDensityRatio),
@@ -367,19 +370,23 @@ $.Tile.prototype = {
         // changes as we are rendering the image
         drawingHandler({context: context, tile: this, rendered: rendered});
 
-        var sourceWidth, sourceHeight;
+        var sourceX, sourceY, sourceWidth, sourceHeight;
         if (this.sourceBounds) {
+            sourceX = this.sourceBounds.x;
+            sourceY = this.sourceBounds.y;
             sourceWidth = Math.min(this.sourceBounds.width, rendered.canvas.width);
             sourceHeight = Math.min(this.sourceBounds.height, rendered.canvas.height);
         } else {
+            sourceX = 0;
+            sourceY = 0;
             sourceWidth = rendered.canvas.width;
             sourceHeight = rendered.canvas.height;
         }
 
         context.drawImage(
             rendered.canvas,
-            0,
-            0,
+            sourceX,
+            sourceY,
             sourceWidth,
             sourceHeight,
             position.x,

--- a/src/tile.js
+++ b/src/tile.js
@@ -383,6 +383,24 @@ $.Tile.prototype = {
             sourceHeight = rendered.canvas.height;
         }
 
+        // If tiles have overlap, round position and size of tile to avoid
+        // incorrect color and/or alpha for pixels with overlap.
+        // If tiles don't have overlap, rounding may cause visible seams since
+        // the destination box may becomme extend outsinde of the source.
+        if (overlap > 0) {
+            sourceWidth = Math.round(sourceX + sourceWidth) - Math.round(sourceX);
+            sourceHeight = Math.round(sourceY + sourceHeight) - Math.round(sourceY);
+
+            sourceX = Math.round(sourceX);
+            sourceY = Math.round(sourceY);
+
+            size.x = Math.round(position.x + size.x) - Math.round(position.x);
+            size.y = Math.round(position.y + size.y) - Math.round(position.y);
+
+            position.x = Math.round(position.x);
+            position.y = Math.round(position.y);
+        }
+
         context.drawImage(
             rendered.canvas,
             sourceX,

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1624,14 +1624,6 @@ function positionTile( tile, overlap, viewport, viewportCenter, levelVisibility,
         sizeC = sizeC.plus( new $.Point( 1, 1 ) );
     }
 
-    if (tile.isRightMost && tiledImage.wrapHorizontal) {
-        sizeC.x += 0.75; // Otherwise Firefox and Safari show seams
-    }
-
-    if (tile.isBottomMost && tiledImage.wrapVertical) {
-        sizeC.y += 0.75; // Otherwise Firefox and Safari show seams
-    }
-
     tile.position   = positionC;
     tile.size       = sizeC;
     tile.squaredDistance   = tileSquaredDistance;

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -382,17 +382,19 @@ $.TileSource.prototype = {
         var dimensionsScaled = this.dimensions.times( this.getLevelScale( level ) ),
             tileWidth = this.getTileWidth(level),
             tileHeight = this.getTileHeight(level),
-            px = ( x === 0 ) ? 0 : tileWidth * x - this.tileOverlap,
-            py = ( y === 0 ) ? 0 : tileHeight * y - this.tileOverlap,
-            sx = tileWidth + ( x === 0 ? 1 : 2 ) * this.tileOverlap,
-            sy = tileHeight + ( y === 0 ? 1 : 2 ) * this.tileOverlap,
+            px = tileWidth * x,
+            py = tileHeight * y,
+            sx = tileWidth,
+            sy = tileHeight,
             scale = 1.0 / dimensionsScaled.x;
 
         sx = Math.min( sx, dimensionsScaled.x - px );
         sy = Math.min( sy, dimensionsScaled.y - py );
 
         if (isSource) {
-            return new $.Rect(0, 0, sx, sy);
+            var pxSource = (x === 0) ? 0 : this.tileOverlap,
+                pySource = (y === 0) ? 0 : this.tileOverlap;
+            return new $.Rect(pxSource, pySource, sx, sy);
         }
 
         return new $.Rect( px * scale, py * scale, sx * scale, sy * scale );


### PR DESCRIPTION
Suggestion of solution for the problem with visible seams in #1683. 

Blending the two tiles in the overlapping pixels is hard to do correctly with the blend modes of a 2D canvas that are at hand. In the overlapping pixels, the alpha value should be the same as in the tiles, but there are no such blend modes in a 2D canvas. I see two possible solutions to this. One is the path you have started on; clearing the previous tile's overlap https://github.com/openseadragon/openseadragon/blob/68e9efebe699c5c47f274b572a9409d267bafaa7/src/tile.js#L358 and the other is controlling the blending by using webGL. The simplest solution, I think, is as you are doing, avoiding rendering overlap. I removed all overlap rendering by removing the overlap borders in https://github.com/openseadragon/openseadragon/blob/68e9efebe699c5c47f274b572a9409d267bafaa7/src/tilesource.js#L381 This is effectively what you are doing with clearRect, but this way we can round the final size and position before rendering with drawImage(...). By doing that, all tiles will always lie exactly back to back with no sub-pixel rendering causing problems. Sub-pixel rendering can, in theory at least, be done correctly with blend mode 'lighter', but as discussed previously, browsers are not to be trusted in this area. This solution of rounding could also work for overlap = 0, but is't guaranteed to give a good result. If the tiles has no overlap, rounding the rendered size of the tile can result in having a render target area that is 0.5 pixels wider than the tile and I don't really trust browsers to do a good job with that. In the case of overlap > 0, having a render target that is half a pixel larger than the tile is ok, since the tile has overlap. 

If we don't render any overlap, there is no need to do clearRect of that area before rendering, hence the removed code. I think that the 0.75 pixels added when wrapping, https://github.com/openseadragon/openseadragon/blob/68e9efebe699c5c47f274b572a9409d267bafaa7/src/tiledimage.js#L1628 , can also be removed since there is no sub-pixel rendering for firefox to mess up.

I have done testing with various images in chrome and firefox, but I recommend that you test this out, especially with cases that where fixed by the code that I removed. 

I also just want to make a note that this rounding will probably not cause any wobble during zooming, since the rounding is done also on the tile coordinates. I can't see any wobble, but please tell me if you do. 

To round things off, there is one thing that still bugs me. We might get visible seams if we're unlucky with floating point precision. Rounding of the seam position might give different results for the tile to the left of the seam, compared to the tile to the right. I have not seen such issues ... yet. There is a way of getting round that, but if we go forward with this change I can explore that in a separate PR. I've been going on for long enough.

So this is just a suggestion. There are many ways of achieving the same result and may ways of structuring the code. Let me know what you think.