### PR TITLE
Remove deprecated imageSmoothingEnabled prefixes

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -633,8 +633,6 @@ $.Drawer.prototype = {
 
     // private
     _updateImageSmoothingEnabled: function(context){
-        context.mozImageSmoothingEnabled = this._imageSmoothingEnabled;
-        context.webkitImageSmoothingEnabled = this._imageSmoothingEnabled;
         context.msImageSmoothingEnabled = this._imageSmoothingEnabled;
         context.imageSmoothingEnabled = this._imageSmoothingEnabled;
     },


### PR DESCRIPTION
### Changes

Remove `moz` and `webkit` prefix from  `context.ImageSmoothingEnabled` updates

### Fixes
Use of mozImageSmoothingEnabled is deprecated #1739