### PR TITLE
Pass useCanvas value down to reference strip viewers.

### DIFF
--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -451,7 +451,8 @@ function loadPanels( strip, viewerSize, scroll ) {
                 blendTime:              0,
                 animationTime:          0,
                 loadTilesWithAjax:      strip.viewer.loadTilesWithAjax,
-                ajaxHeaders:            strip.viewer.ajaxHeaders
+                ajaxHeaders:            strip.viewer.ajaxHeaders,
+                useCanvas:              strip.useCanvas
             } );
 
             miniViewer.displayRegion           = $.makeNeutralElement( "div" );

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2227,6 +2227,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     width:       this.referenceStripWidth,
                     tileSources: this.tileSources,
                     prefixUrl:   this.prefixUrl,
+                    useCanvas:   this.useCanvas,
                     viewer:      this
                 });
 


### PR DESCRIPTION
The `useCanvas` configuration option is not currently passed to the `ReferenceStrip` implementation and then `Viewer`s it generates.  This appears to have been an oversight.  