### PR TITLE
prevents multi-touch issue on ipad

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2959,7 +2959,7 @@
         }
 
         // OS-specific gestures (e.g. swipe up with four fingers in iPadOS 13)
-        if (gPoints[ 0 ].type === "touch" && typeof gPoints[ 0 ].currentPos === "undefined") {
+        if (typeof gPoints[ 0 ].currentPos === "undefined") {
             abortContacts(tracker, event, pointsList);
 
             return false;


### PR DESCRIPTION
iPad gestures with pen input can raise error even after https://github.com/openseadragon/openseadragon/pull/1754. This PR fix it.