### PR TITLE
Feature/1540 cropping with multiple polygons

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -167,6 +167,38 @@ $.Drawer.prototype = {
     },
 
     /**
+     * This function gets the top left point from the viewport using the pixel point
+     * @param {OpenSeadragon.Point} point - the pixel points to convert
+     */
+    viewportCoordToDrawerCoord: function(point) {
+        var topLeft = this.viewport.pixelFromPointNoRotate(point, true);
+        return new $.Point(
+            topLeft.x * $.pixelDensityRatio,
+            topLeft.y * $.pixelDensityRatio
+        );
+    },
+
+    /**
+     * This function will create multiple polygon paths on the drawing context by provided polygons,
+     * then clip the context to the paths.
+     * @param {(OpenSeadragon.Point[])[]} polygons - an array of polygons. A polygon is an array of OpenSeadragon.Point
+     * @param {Boolean} useSketch - Whether to use the sketch canvas or not.
+     */
+    clipWithPolygons: function (polygons, useSketch) {
+        if (!this.useCanvas) {
+            return;
+        }
+        var context = this._getContext(useSketch);
+        context.beginPath();
+        polygons.forEach(function (polygon) {
+            polygon.forEach(function (coord, i) {
+                context[i == 0 ? 'moveTo' : 'lineTo'](coord.x, coord.y);
+          });
+        });
+        context.clip();
+    },
+
+    /**
      * Set the opacity of the drawer.
      * @param {Number} opacity
      * @return {OpenSeadragon.Drawer} Chainable.

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -167,14 +167,17 @@ $.Drawer.prototype = {
     },
 
     /**
-     * This function gets the top left point from the viewport using the pixel point
-     * @param {OpenSeadragon.Point} point - the pixel points to convert
+     * This function converts the given point from to the drawer coordinate by
+     * multiplying it with the pixel density.
+     * This function does not take rotation into account, thus assuming provided
+     * point is at 0 degree.
+     * @param {OpenSeadragon.Point} point - the pixel point to convert
      */
     viewportCoordToDrawerCoord: function(point) {
-        var topLeft = this.viewport.pixelFromPointNoRotate(point, true);
+        var vpPoint = this.viewport.pixelFromPointNoRotate(point, true);
         return new $.Point(
-            topLeft.x * $.pixelDensityRatio,
-            topLeft.y * $.pixelDensityRatio
+            vpPoint.x * $.pixelDensityRatio,
+            vpPoint.y * $.pixelDensityRatio
         );
     },
 

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -195,7 +195,7 @@ $.Drawer.prototype = {
         context.beginPath();
         polygons.forEach(function (polygon) {
             polygon.forEach(function (coord, i) {
-                context[i == 0 ? 'moveTo' : 'lineTo'](coord.x, coord.y);
+                context[i === 0 ? 'moveTo' : 'lineTo'](coord.x, coord.y);
           });
         });
         context.clip();

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -689,9 +689,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         var isXYObject = function(obj) {
             return obj instanceof $.Point || (typeof obj.x === 'number' && typeof obj.y === 'number');
         };
-        var isArray = function(obj) {
-            return Object.prototype.toString.call(obj) === '[object Array]';
-        };
+
         var objectToSimpleXYObject = function(objs) {
             return objs.map(function(obj) {
                 try {
@@ -707,7 +705,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         };
 
         try {
-            if (!isArray(polygons)) {
+            if ($.isArray(polygons)) {
                 throw new Error('Provided cropping polygon is not an array');
             }
             this._croppingPolygons = polygons.map(function(polygon){

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -677,14 +677,12 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     /**
      * Sets an array of polygons to crop the TiledImage during draw tiles.
      * The render function will use the default non-zero winding rule.
-     * @param Polygons represented in an array of pair array or point object in pixels.
+     * @param Polygons represented in an array of point object in pixels.
      * Example format: [
-     *  [[197,172],[226,172],[226,198],[197,198]], // First polygon
-     *  [[328,200],[330,199],[332,201],[329,202]]  // Second polygon
+     *  [{x: 197, y:172}, {x: 226, y:172}, {x: 226, y:198}, {x: 197, y:198}], // First polygon
+     *  [{x: 328, y:200}, {x: 330, y:199}, {x: 332, y:201}, {x: 329, y:202}]  // Second polygon
      *  [{x: 321, y:201}, {x: 356, y:205}, {x: 341, y:250}] // Third polygon
      * ]
-     * Argument may mix array and point objects.
-     * Point objects will be convert to array.
      */
     setCroppingPolygons: function( polygons ) {
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -705,7 +705,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         };
 
         try {
-            if ($.isArray(polygons)) {
+            if (!$.isArray(polygons)) {
                 throw new Error('Provided cropping polygon is not an array');
             }
             this._croppingPolygons = polygons.map(function(polygon){

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -694,16 +694,11 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         var isArray = function(obj) {
             return Object.prototype.toString.call(obj) === '[object Array]';
         };
-        var isXYPair = function(obj) {
-            return obj && isArray(obj) && obj.length === 2;
-        };
-        var convertXYObjectsToArrayIfNeeded = function(objs) {
+        var objectToSimpleXYObject = function(objs) {
             return objs.map(function(obj) {
                 try {
                     if (isXYObject(obj)) {
-                        return [obj.x, obj.y];
-                    } else if (isXYPair(obj)) {
-                        return obj;
+                        return { x: obj.x, y: obj.y };
                     } else {
                         throw new Error();
                     }
@@ -718,7 +713,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                 throw new Error('Provided cropping polygon is not an array');
             }
             this._croppingPolygons = polygons.map(function(polygon){
-                return convertXYObjectsToArrayIfNeeded(polygon);
+                return objectToSimpleXYObject(polygon);
             });
         } catch (e) {
             $.console.error('[TiledImage.setCroppingPolygons] Cropping polygon format not supported');
@@ -1997,9 +1992,9 @@ function drawTiles( tiledImage, lastDrawn ) {
         tiledImage._drawer.saveContext(useSketch);
         try {
             var polygons = tiledImage._croppingPolygons.map(function (polygon) {
-                return polygon.map(function (pointPair) {
+                return polygon.map(function (coord) {
                     var point = tiledImage
-                        .imageToViewportCoordinates(pointPair[0], pointPair[1], true)
+                        .imageToViewportCoordinates(coord.x, coord.y, true)
                         .rotate(-tiledImage.getRotation(true), tiledImage._getRotationPoint(true));
                     var clipPoint = tiledImage._drawer.viewportCoordToDrawerCoord(point);
                     if (sketchScale) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -677,7 +677,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     /**
      * Sets an array of polygons to crop the TiledImage during draw tiles.
      * The render function will use the default non-zero winding rule.
-     * @param Polygons represented in an array of point object in pixels.
+     * @param Polygons represented in an array of point object in image coordinates.
      * Example format: [
      *  [{x: 197, y:172}, {x: 226, y:172}, {x: 226, y:198}, {x: 197, y:198}], // First polygon
      *  [{x: 328, y:200}, {x: 330, y:199}, {x: 332, y:201}, {x: 329, y:202}]  // Second polygon

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -13,7 +13,7 @@
         }
 
         textarea {
-            width: 200px;
+            width: 215px;
             height: 200px;
         }
 
@@ -22,8 +22,8 @@
             display: inline-block;
             text-align: center;
         }
-        .box-with-title button{
-            display: block;
+        .buttons {
+            width: 215px;
         }
 
         *:focus {
@@ -43,11 +43,24 @@
         <button id='exampleBtn'>Load Example</button>
     </div>
     <div class='box-with-title'>
-        <button id="addBtn">Add As Polygon</button>
-        <textarea id="polygonEl"></textarea>
+        <div class="buttons">
+            <button id="addArrayBtn">Add Array as Polygon</button>
+            <button onclick="emptyElement('polygonArrayEl')">Clear</button>
+        </div>
+        <textarea id="polygonArrayEl"></textarea>
     </div>
     <div class='box-with-title'>
-        <button id="cropBtn">Crop With Polygon</button>
+        <div class="buttons">
+            <button id="addPointBtn">Add Points as Polygon</button>
+            <button onclick="emptyElement('polygonPointEl')">Clear</button>
+        </div>
+        <textarea id="polygonPointEl"></textarea>
+    </div>
+    <div class='box-with-title'>
+        <div class="buttons">
+            <button id="cropBtn">Crop With Polygon</button>
+            <button onclick="emptyElement('previewEl')">Clear</button>
+        </div>
         <textarea id='previewEl'></textarea>
     </div>
 
@@ -68,54 +81,92 @@
     <script>
         // Global Variables
         var previewEl = document.getElementById('previewEl');
-        var polygonEl = document.getElementById('polygonEl');
+        var polygonArrayEl = document.getElementById('polygonArrayEl');
+        var polygonPointEl = document.getElementById('polygonPointEl');
+
         var examples =  [
             [[480,300],[300,420],[600,420]],            // Triangle
             [[300,550],[300,750],[600,750],[600,550]]   // Rectangle
         ];
-        var polygon = [];
-        var polygonList = [];
 
         // Load default examples
         function loadExample(){
-            polygonList = JSON.parse(JSON.stringify(examples));
-            previewEl.value = JSON.stringify(polygonList);
+            previewEl.value = JSON.stringify(examples);
         }
         loadExample();
 
+        // Set a given element's value to empty string
+        function emptyElement(elementId) {
+            document.getElementById(elementId).value = '';
+        }
+
+        // JSON parse a given object, then insert object assuming parsed value is array.
+        function insertObjectToElement(object, element) {
+            var parsed = []; // Default to empty array
+            try {
+                parsed = JSON.parse(element.value);
+            } catch(error) { }
+            parsed.push(object);
+            element.value = JSON.stringify(parsed)
+        }
+
         // Add click handler to clicked point tracker
         viewer.addHandler('canvas-click', function(event) {
-            var webPoint = event.position;
-            var viewportPoint = viewer.viewport.pointFromPixel(webPoint);
+            var viewportPoint = viewer.viewport.pointFromPixel(event.position);
             var p = viewer.viewport.viewportToImageCoordinates(viewportPoint);
             p.x = Math.round((p.x + Number.EPSILON) * 100) / 100
             p.y = Math.round((p.y + Number.EPSILON) * 100) / 100
-            polygon.push([p.x, p.y]);
-            polygonEl.value += '['+p.x+','+ p.y+']';
+            insertObjectToElement([p.x, p.y], polygonArrayEl);
+            insertObjectToElement({x:p.x, y:p.y}, polygonPointEl);
         });
 
+        // Evaluate give element in JavaScript variable, default to empty array.
+        function readElementValueDefaultToEmptyArray(elementId) {
+            try {
+                var val = document.getElementById(elementId).value;
+                if (val === '') { return []; }
+                return eval(val); // If using JSON.parse, user must put quotes [{"x": 123, "y":12}]
+            } catch (e) {
+                return [];
+            }
+        }
+
+        // Insert value from given element into preview element
+        function insertValueFromElementToPreviewElement(element) {
+            try {
+                if (element.value === '') { return; }
+                var polygon = eval(element.value);
+                var polygonList = readElementValueDefaultToEmptyArray('previewEl');
+                polygonList.push(polygon);
+                element.value = '';
+                previewEl.value = JSON.stringify(polygonList);
+            } catch(error) {
+                console.log(error);
+            }
+        }
         // Add clicked points to polygon tracker variable
-        document.getElementById('addBtn').onclick = function(){
-            if (polygon.length == 0) { return; }
-            polygonList.push(polygon);
-            polygon = [];
-            polygonEl.value = '';
-            previewEl.value = JSON.stringify(polygonList);
+        document.getElementById('addArrayBtn').onclick = function(){
+            insertValueFromElementToPreviewElement(polygonArrayEl);
         };
 
+        // Add clicked points to polygon tracker variable as point objects
+        document.getElementById('addPointBtn').onclick = function(){
+            insertValueFromElementToPreviewElement(polygonPointEl);
+        };
+
+        // Crop image with value in the preview element
         document.getElementById('cropBtn').onclick = function(){
-            polygonList = JSON.parse(previewEl.value);
-            polygonEl.value = '';
+            var polygonList = eval(previewEl.value);
             var tiledImage = viewer.world.getItemAt(0);
             tiledImage.setCroppingPolygons(polygonList);
             viewer.forceRedraw();
+            emptyElement('previewEl');
         };
 
         document.getElementById('resetBtn').onclick = function(){
-            polygonList = []
-            polygon = []
-            polygonEl.value = '';
-            previewEl.value = '';
+            emptyElement('polygonArrayEl');
+            emptyElement('polygonPointEl');
+            emptyElement('previewEl');
             var tiledImage = viewer.world.getItemAt(0);
             tiledImage.resetCroppingPolygons();
             viewer.forceRedraw();

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OpenSeadragon Cropping PolygonList Demo</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+    <style type="text/css">
+
+        .openseadragon1 {
+            width: 800px;
+            height: 600px;
+            background: lightgreen;
+        }
+
+        textarea {
+            width: 200px;
+            height: 200px;
+        }
+
+        .box-with-title {
+            padding-top: 1em;
+            display: inline-block;
+            text-align: center;
+        }
+        .box-with-title button{
+            display: block;
+        }
+
+        *:focus {
+            outline: none;
+        }
+
+    </style>
+</head>
+<body>
+    <h3>
+        Simple demo page to show cropping with polygonList in a OpenSeadragon viewer.
+    </h3>
+    <div id="contentDiv" class="openseadragon1"></div>
+    <span>Click on Viewer to save polygon points</span>
+    <div>
+        <button id='resetBtn'>Reset</button>
+        <button id='exampleBtn'>Load Example</button>
+    </div>
+    <div class='box-with-title'>
+        <button id="addBtn">Add As Polygon</button>
+        <textarea id="polygonEl"></textarea>
+    </div>
+    <div class='box-with-title'>
+        <button id="cropBtn">Crop With Polygon</button>
+        <textarea id='previewEl'></textarea>
+    </div>
+
+    <!-- Setup Viewer -->
+    <script type="text/javascript">
+        var viewer = OpenSeadragon({
+            // debugMode: true,
+            id: "contentDiv",
+            prefixUrl: "../../build/openseadragon/images/",
+            tileSources: "../data/testpattern.dzi",
+            showNavigator: false,
+            gestureSettingsMouse: {
+                clickToZoom: false
+            }
+        });
+    </script>
+
+    <script>
+        // Global Variables
+        var previewEl = document.getElementById('previewEl');
+        var polygonEl = document.getElementById('polygonEl');
+        var examples =  [
+            [[480,300],[300,420],[600,420]],            // Triangle
+            [[300,550],[300,750],[600,750],[600,550]]   // Rectangle
+        ];
+        var polygon = [];
+        var polygonList = [];
+
+        // Load default examples
+        function loadExample(){
+            polygonList = JSON.parse(JSON.stringify(examples));
+            previewEl.innerHTML = JSON.stringify(polygonList);
+        }
+        loadExample();
+
+        // Add click handler to clicked point tracker
+        viewer.addHandler('canvas-click', function(event) {
+            var webPoint = event.position;
+            var viewportPoint = viewer.viewport.pointFromPixel(webPoint);
+            var p = viewer.viewport.viewportToImageCoordinates(viewportPoint);
+            p.x = Math.round((p.x + Number.EPSILON) * 100) / 100
+            p.y = Math.round((p.y + Number.EPSILON) * 100) / 100
+            polygon.push([p.x, p.y]);
+            polygonEl.innerHTML += '['+p.x+','+ p.y+']';
+        });
+
+        // Add clicked points to polygon tracker variable
+        document.getElementById('addBtn').onclick = function(){
+            if (polygon.length == 0) { return; }
+            polygonList.push(polygon);
+            polygon = [];
+            polygonEl.innerHTML = '';
+            previewEl.innerHTML = JSON.stringify(polygonList);
+        };
+
+        document.getElementById('cropBtn').onclick = function(){
+            polygonList = JSON.parse(previewEl.innerHTML);
+            polygonEl.innerHTML = '';
+            var tiledImage = viewer.world.getItemAt(0);
+            tiledImage.setCroppingPolygons(polygonList);
+            viewer.forceRedraw();
+        };
+
+        document.getElementById('resetBtn').onclick = function(){
+            polygonList = []
+            polygon = []
+            polygonEl.innerHTML = '';
+            previewEl.innerHTML = '';
+            var tiledImage = viewer.world.getItemAt(0);
+            tiledImage.resetCroppingPolygons();
+            viewer.forceRedraw();
+        };
+
+        document.getElementById('exampleBtn').onclick = loadExample;
+    </script>
+
+</body>
+</html>

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -44,13 +44,6 @@
     </div>
     <div class='box-with-title'>
         <div class="buttons">
-            <button id="addArrayBtn">Add Array as Polygon</button>
-            <button onclick="emptyElement('polygonArrayEl')">Clear</button>
-        </div>
-        <textarea id="polygonArrayEl"></textarea>
-    </div>
-    <div class='box-with-title'>
-        <div class="buttons">
             <button id="addPointBtn">Add Points as Polygon</button>
             <button onclick="emptyElement('polygonPointEl')">Clear</button>
         </div>
@@ -81,12 +74,11 @@
     <script>
         // Global Variables
         var previewEl = document.getElementById('previewEl');
-        var polygonArrayEl = document.getElementById('polygonArrayEl');
         var polygonPointEl = document.getElementById('polygonPointEl');
 
         var examples =  [
-            [[480,300],[300,420],[600,420]],            // Triangle
-            [[300,550],[300,750],[600,750],[600,550]]   // Rectangle
+            [{x: 480, y: 300},{x: 300, y: 420},{x: 600, y: 420}],                   // Triangle
+            [{x: 300, y: 550},{x: 300, y: 750},{x: 600, y: 750},{x: 600, y: 550}]   // Rectangle
         ];
 
         // Load default examples
@@ -116,7 +108,6 @@
             var p = viewer.viewport.viewportToImageCoordinates(viewportPoint);
             p.x = Math.round((p.x + Number.EPSILON) * 100) / 100
             p.y = Math.round((p.y + Number.EPSILON) * 100) / 100
-            insertObjectToElement([p.x, p.y], polygonArrayEl);
             insertObjectToElement({x:p.x, y:p.y}, polygonPointEl);
         });
 
@@ -144,10 +135,6 @@
                 console.log(error);
             }
         }
-        // Add clicked points to polygon tracker variable
-        document.getElementById('addArrayBtn').onclick = function(){
-            insertValueFromElementToPreviewElement(polygonArrayEl);
-        };
 
         // Add clicked points to polygon tracker variable as point objects
         document.getElementById('addPointBtn').onclick = function(){
@@ -164,7 +151,6 @@
         };
 
         document.getElementById('resetBtn').onclick = function(){
-            emptyElement('polygonArrayEl');
             emptyElement('polygonPointEl');
             emptyElement('previewEl');
             var tiledImage = viewer.world.getItemAt(0);

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -79,7 +79,7 @@
         // Load default examples
         function loadExample(){
             polygonList = JSON.parse(JSON.stringify(examples));
-            previewEl.innerHTML = JSON.stringify(polygonList);
+            previewEl.value = JSON.stringify(polygonList);
         }
         loadExample();
 
@@ -91,7 +91,7 @@
             p.x = Math.round((p.x + Number.EPSILON) * 100) / 100
             p.y = Math.round((p.y + Number.EPSILON) * 100) / 100
             polygon.push([p.x, p.y]);
-            polygonEl.innerHTML += '['+p.x+','+ p.y+']';
+            polygonEl.value += '['+p.x+','+ p.y+']';
         });
 
         // Add clicked points to polygon tracker variable
@@ -99,13 +99,13 @@
             if (polygon.length == 0) { return; }
             polygonList.push(polygon);
             polygon = [];
-            polygonEl.innerHTML = '';
-            previewEl.innerHTML = JSON.stringify(polygonList);
+            polygonEl.value = '';
+            previewEl.value = JSON.stringify(polygonList);
         };
 
         document.getElementById('cropBtn').onclick = function(){
-            polygonList = JSON.parse(previewEl.innerHTML);
-            polygonEl.innerHTML = '';
+            polygonList = JSON.parse(previewEl.value);
+            polygonEl.value = '';
             var tiledImage = viewer.world.getItemAt(0);
             tiledImage.setCroppingPolygons(polygonList);
             viewer.forceRedraw();
@@ -114,8 +114,8 @@
         document.getElementById('resetBtn').onclick = function(){
             polygonList = []
             polygon = []
-            polygonEl.innerHTML = '';
-            previewEl.innerHTML = '';
+            polygonEl.value = '';
+            previewEl.value = '';
             var tiledImage = viewer.world.getItemAt(0);
             tiledImage.resetCroppingPolygons();
             viewer.forceRedraw();


### PR DESCRIPTION
Implementation using logic from [issue 1540](https://github.com/openseadragon/openseadragon/issues/1540)

Here are the changes:

- Add viewportCoordToDrawerCoord to $.Drawer
- Add clipWithPolygons to $.Drawer (Array of $.Point array)
- Add set and reset polygons to $.tileImage, supports object with `x` and `y` points
```
// Example format
[
  [{x: 197, y:172}, {x: 226, y:172}, {x: 226, y:198}, {x: 197, y:198}], // First polygon
  [{x: 328, y:200}, {x: 330, y:199}, {x: 332, y:201}, {x: 329, y:202}]  // Second polygon
  [{x: 321, y:201}, {x: 356, y:205}, {x: 341, y:250}] // Third polygon
]
```
- In draw tile process, check `x` and `y` in the polygon point, then call $.Drawer.clipWithPolygons 
- Add a demo page as following:
![SmluCuAiVx](https://user-images.githubusercontent.com/10471270/74202650-efdb9b80-4c21-11ea-84f0-ac41e081d760.gif)

