### PR TITLE
apply pixelDensityRatio after flip

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1929,14 +1929,15 @@ function drawTiles( tiledImage, lastDrawn ) {
             // sketch canvas we are going to use for performance reasons.
             bounds = tiledImage.viewport.viewportToViewerElementRectangle(
                 tiledImage.getClippedBounds(true))
-                .getIntegerBoundingBox()
-                .times($.pixelDensityRatio);
+                .getIntegerBoundingBox();
 
             if(tiledImage._drawer.viewer.viewport.getFlip()) {
               if (tiledImage.viewport.degrees !== 0 || tiledImage.getRotation(true) % 360 !== 0){
                 bounds.x = tiledImage._drawer.viewer.container.clientWidth - (bounds.x + bounds.width);
               }
             }
+
+            bounds = bounds.times($.pixelDensityRatio);
         }
         tiledImage._drawer._clear(true, bounds);
     }


### PR DESCRIPTION
I have a super specific scenario that was failing, but looking at some of the open issues maybe there is a wider audience for this. Possibly #1695  

In my case, a flipped and rotated image with `compositeOperation='lighter'` was rendering improperly when on high pixel density monitors. (Retina displays). It was fine otherwise.

The issue seems to have been with the order of operations between applying a multiplier for pixel density, and reversing the x-coordinate polarity. Before this patch, the numbers shoot off in the wrong direction.

Happy to discuss, if you see issues or I am completely off the mark, as it's my first PR here!