### PR TITLE
Clear viewer and navigator listeners and nodes to avoid memory leaks

### DIFF
--- a/src/button.js
+++ b/src/button.js
@@ -396,6 +396,20 @@ $.extend( $.Button.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.
         this.element.disabled = false;
         $.setElementOpacity( this.element, 1.0, true );
         this.notifyGroupEnter();
+    },
+
+    destroy: function() {
+        this.element.removeChild(this.imgRest);
+        this.imgRest = null;
+        this.element.removeChild(this.imgGroup);
+        this.imgGroup = null;
+        this.element.removeChild(this.imgHover);
+        this.imgHover = null;
+        this.element.removeChild(this.imgDown);
+        this.imgDown = null;
+        this.removeAllHandlers();
+        this.tracker.destroy();
+        this.element = null;
     }
 
 });

--- a/src/buttongroup.js
+++ b/src/buttongroup.js
@@ -129,6 +129,16 @@ $.ButtonGroup.prototype = {
      */
     emulateExit: function() {
         this.tracker.exitHandler( { eventSource: this.tracker } );
+    },
+
+    destroy: function() {
+        while (this.buttons.length) {
+            var button = this.buttons.pop();
+            this.element.removeChild(button.element);
+            button.destroy();
+        }
+        this.tracker.destroy();
+        this.element = null;
     }
 };
 

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -406,6 +406,10 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
         return $.Viewer.prototype.addTiledImage.apply(this, [optionsClone]);
     },
 
+    destroy: function() {
+        return $.Viewer.prototype.destroy.apply(this);
+    },
+
     // private
     _getMatchingItem: function(theirItem) {
         var count = this.world.getItemCount();

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -765,7 +765,22 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             this.drawer.destroy();
         }
 
+        if ( this.navigator ) {
+            this.navigator.destroy();
+            THIS[ this.navigator.hash ] = null;
+            delete THIS[ this.navigator.hash ];
+            this.navigator = null;
+        }
+
         this.removeAllHandlers();
+
+        if (this.buttons) {
+            this.buttons.destroy();
+        }
+
+        if (this.paging) {
+            this.paging.destroy();
+        }
 
         // Go through top element (passed to us) and remove all children
         // Use removeChild to make sure it handles SVG or any non-html
@@ -775,6 +790,9 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                 this.element.removeChild(this.element.firstChild);
             }
         }
+
+        this.container.onsubmit = null;
+        this.clearControls();
 
         // destroy the mouse trackers
         if (this.innerTracker){
@@ -3261,7 +3279,7 @@ function updateOnce( viewer ) {
 
     //viewer.profiler.beginUpdate();
 
-    if (viewer._opening) {
+    if (viewer._opening || !THIS[viewer.hash]) {
         return;
     }
 


### PR DESCRIPTION
Dedicated PR for #1721 with integration of @iangilman's suggestion regarding cleanup for `return $.Viewer.prototype.destroy.apply(this);` inside of .