### PR TITLE
Add the ability to flip over the x or y axis

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -551,7 +551,8 @@ $.Drawer.prototype = {
             });
         }
         if (tiledImage.viewport.degrees === 0 && tiledImage.getRotation(true) % 360 === 0){
-          if(tiledImage._drawer.viewer.viewport.getFlip()) {
+          var flipped = tiledImage._drawer.viewer.viewport.getFlip();
+          if(flipped.x || flipped.y) {
               tiledImage._drawer._flip();
           }
         }
@@ -696,9 +697,11 @@ $.Drawer.prototype = {
         context.save();
 
         context.translate(point.x, point.y);
-        if(this.viewer.viewport.flipped){
+        if(this.viewer.viewport.flipped.x || this.viewer.viewport.flipped.y){
           context.rotate(Math.PI / 180 * -options.degrees);
-          context.scale(-1, 1);
+          context.scale(
+            this.viewer.viewport.flipped.x ? -1 : 1,
+            this.viewer.viewport.flipped.y ? -1 : 1);
         } else{
           context.rotate(Math.PI / 180 * options.degrees);
         }
@@ -713,9 +716,13 @@ $.Drawer.prototype = {
         this.getCanvasCenter();
       var context = this._getContext(options.useSketch);
 
-      context.translate(point.x, 0);
-      context.scale(-1, 1);
-      context.translate(-point.x, 0);
+      context.translate(this.viewer.viewport.flipped.x ? point.x : 0,
+        this.viewer.viewport.flipped.y ? point.y : 0);
+      context.scale(
+        this.viewer.viewport.flipped.x ? -1 : 1,
+        this.viewer.viewport.flipped.y ? -1 : 1);
+      context.translate(this.viewer.viewport.flipped.x ? -point.x : 0,
+        this.viewer.viewport.flipped.y ? -point.y : 0);
     },
 
     // private

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -302,8 +302,10 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
       */
     setFlip: function(state) {
       this.viewport.setFlip(state);
+      var flipped = this.viewer.viewport.getFlip();
+      var displayTransform = "scale(" + (flipped.x ? "-1" : "1") + "," + (flipped.y ? "-1" : "1") + ")";
+      this.setDisplayTransform(displayTransform);
 
-      this.setDisplayTransform(this.viewer.viewport.getFlip() ? "scale(-1,1)" : "scale(1,1)");
       return this;
     },
 
@@ -478,8 +480,11 @@ function onCanvasClick( event ) {
    this.viewer.raiseEvent('navigator-click', canvasClickEventArgs);
 
    if ( !canvasClickEventArgs.preventDefaultAction && event.quick && this.viewer.viewport && (this.panVertical || this.panHorizontal)) {
-    if(this.viewer.viewport.flipped) {
+    if (this.viewer.viewport.flipped.x) {
       event.position.x = this.viewport.getContainerSize().x - event.position.x;
+    }
+    if (this.viewer.viewport.flipped.y) {
+      event.position.y = this.viewport.getContainerSize().y - event.position.y;
     }
     var target = this.viewport.pointFromPixel(event.position);
     if (!this.panVertical) {
@@ -539,7 +544,12 @@ function onCanvasDrag( event ) {
         }
 
         if(this.viewer.viewport.flipped){
+          if (this.viewer.viewport.flipped.x) {
             event.delta.x = -event.delta.x;
+          }
+          if (this.viewer.viewport.flipped.y) {
+            event.delta.y = -event.delta.y;
+          }
         }
 
         this.viewer.viewport.panBy(

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -211,7 +211,7 @@
   * @property {Number} [degrees=0]
   *     Initial rotation.
   *
-  * @property {Boolean} [flipped=false]
+  * @property {Boolean} [flipped={x: false, y: false}]
   *     Initial flip state.
   *
   * @property {Number} [minZoomLevel=null]
@@ -1181,7 +1181,7 @@ function OpenSeadragon( options ){
             degrees:                    0,
 
             // INITIAL FLIP STATE
-            flipped:                    false,
+            flipped:                    { x: false, y: false },
 
             // APPEARANCE
             opacity:                    1,

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1910,6 +1910,7 @@ function drawTiles( tiledImage, lastDrawn ) {
 
     var zoom = tiledImage.viewport.getZoom(true);
     var imageZoom = tiledImage.viewportToImageZoom(zoom);
+    var flipped = tiledImage._drawer.viewer.viewport.getFlip();
 
     if (lastDrawn.length > 1 &&
         imageZoom > tiledImage.smoothTileEdgesMinZoom &&
@@ -1935,9 +1936,14 @@ function drawTiles( tiledImage, lastDrawn ) {
                 tiledImage.getClippedBounds(true))
                 .getIntegerBoundingBox();
 
-            if(tiledImage._drawer.viewer.viewport.getFlip()) {
+            if(flipped.x || flipped.y) {
               if (tiledImage.viewport.degrees !== 0 || tiledImage.getRotation(true) % 360 !== 0){
-                bounds.x = tiledImage._drawer.viewer.container.clientWidth - (bounds.x + bounds.width);
+                if (flipped.x) {
+                  bounds.x = tiledImage._drawer.viewer.container.clientWidth - (bounds.x + bounds.width);
+                }
+                if (flipped.y) {
+                  bounds.y = tiledImage._drawer.viewer.container.clientHeight - (bounds.y + bounds.height);
+                }
               }
             }
 
@@ -1965,7 +1971,7 @@ function drawTiles( tiledImage, lastDrawn ) {
         }
 
         if (tiledImage.viewport.degrees === 0 && tiledImage.getRotation(true) % 360 === 0){
-          if(tiledImage._drawer.viewer.viewport.getFlip()) {
+          if(flipped.x || flipped.y) {
               tiledImage._drawer._flip();
           }
         }
@@ -2104,7 +2110,7 @@ function drawTiles( tiledImage, lastDrawn ) {
 
     if (!sketchScale) {
       if (tiledImage.viewport.degrees === 0 && tiledImage.getRotation(true) % 360 === 0){
-        if(tiledImage._drawer.viewer.viewport.getFlip()) {
+        if(flipped.x || flipped.y) {
             tiledImage._drawer._flip();
         }
       }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2660,7 +2660,7 @@ function onCanvasKeyPress( event ) {
                 }
                 return false;
             case 114: //r - clockwise rotation
-              if(this.viewport.flipped){
+              if(this.viewport.flipped.x || this.viewport.flipped.y){
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees - this.rotationIncrement, 360));
               } else{
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees + this.rotationIncrement, 360));
@@ -2668,7 +2668,7 @@ function onCanvasKeyPress( event ) {
               this.viewport.applyConstraints();
               return false;
             case 82: //R - counterclockwise  rotation
-              if(this.viewport.flipped){
+              if(this.viewport.flipped.x || this.viewport.flipped.y){
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees + this.rotationIncrement, 360));
               } else{
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees - this.rotationIncrement, 360));
@@ -2696,8 +2696,11 @@ function onCanvasClick( event ) {
     if ( !haveKeyboardFocus ) {
         this.canvas.focus();
     }
-    if(this.viewport.flipped){
+    if(this.viewport.flipped.x){
         event.position.x = this.viewport.getContainerSize().x - event.position.x;
+    }
+    if(this.viewport.flipped.y){
+        event.position.y = this.viewport.getContainerSize().y - event.position.y;
     }
 
     var canvasClickEventArgs = {
@@ -2818,9 +2821,13 @@ function onCanvasDrag( event ) {
         if( !this.panVertical ){
             event.delta.y = 0;
         }
-        if(this.viewport.flipped){
+        if(this.viewport.flipped.x){
             event.delta.x = -event.delta.x;
         }
+        if(this.viewport.flipped.y){
+            event.delta.y = -event.delta.y;
+        }
+
 
         if( this.constrainDuringPan ){
             var delta = this.viewport.deltaPointsFromPixels( event.delta.negate() );
@@ -3146,8 +3153,12 @@ function onCanvasScroll( event ) {
     if (deltaScrollTime > this.minScrollDeltaTime) {
         this._lastScrollTime = thisScrollTime;
 
-        if(this.viewport.flipped){
+        if(this.viewport.flipped.x){
           event.position.x = this.viewport.getContainerSize().x - event.position.x;
+        }
+
+        if(this.viewport.flipped.y){
+          event.position.y = this.viewport.getContainerSize().y - event.position.y;
         }
 
         if ( !event.preventDefaultAction && this.viewport ) {
@@ -3515,7 +3526,7 @@ function onRotateLeft() {
     if ( this.viewport ) {
         var currRotation = this.viewport.getRotation();
 
-        if ( this.viewport.flipped ){
+        if ( this.viewport.flipped.x || this.viewport.flipped.y ){
           currRotation = $.positiveModulo(currRotation + this.rotationIncrement, 360);
         } else {
           currRotation = $.positiveModulo(currRotation - this.rotationIncrement, 360);
@@ -3528,7 +3539,7 @@ function onRotateRight() {
     if ( this.viewport ) {
         var currRotation = this.viewport.getRotation();
 
-        if ( this.viewport.flipped ){
+        if ( this.viewport.flipped.x || this.viewport.flipped.y ){
           currRotation = $.positiveModulo(currRotation - this.rotationIncrement, 360);
         } else {
           currRotation = $.positiveModulo(currRotation + this.rotationIncrement, 360);

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1526,8 +1526,13 @@ $.Viewport.prototype = {
      * @function
      * @return {OpenSeadragon.Viewport} Chainable.
      */
-    toggleFlip: function() {
-      this.setFlip(!this.getFlip());
+    toggleFlip: function( dir ) {
+      if (!dir) {
+        dir = { x: true, y: false };
+      }
+
+      var flip = this.getFlip();
+      this.setFlip({ x: dir.x ? !flip.x : flip.x, y: dir.y ? !flip.y : flip.y });
       return this;
     },
 
@@ -1537,6 +1542,10 @@ $.Viewport.prototype = {
      * @return {Boolean} Flip state.
      */
     getFlip: function() {
+      if (this.flipped === true) {
+        return { x: true, y: false };
+      }
+
       return this.flipped;
     },
 
@@ -1547,7 +1556,11 @@ $.Viewport.prototype = {
      * @return {OpenSeadragon.Viewport} Chainable.
      */
     setFlip: function( state ) {
-      if ( this.flipped === state ) {
+      if ( state === true ) {
+        state = { x: true, y: false };
+      }
+
+      if ( this.flipped === state || (this.flipped.x === state.x && this.flipped.y === state.y) ) {
         return this;
       }
 


### PR DESCRIPTION
We'd like the ability to flip the viewer across the x-axis (the use case is.. something about scholars studying piano rolls and, I gather, a lack of conventions about which way is "up") .

In this PR, I extended the viewport `flipped` property from a structure that allows you to flip across each axis independently. I tried to address some backwards compatibility concerns, but perhaps a separate property for each axis would be preferable?

If this feature is desirable (and I get some guidance on an approach) I'm happy to update any tests, docs, etc. 

Thanks.