### PR TITLE
fix for OSD 'unload' before is has time to bootstrap

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -240,6 +240,11 @@ $.Viewer = function( options ) {
     }
 
     this.element              = this.element || document.getElementById( this.id );
+
+    if (!this.element) {
+        return;
+    }
+
     this.canvas               = $.makeNeutralElement( "div" );
 
     this.canvas.className = "openseadragon-canvas";


### PR DESCRIPTION
Hi,

I'm building an app where instances of OSD need to be able to be created/replaced in quick succession.

A simplified example would be if you had two buttons on a page. Whenever Button A is clicked OSD is used to load an image, whenever Button B is clicked a 3D model is loaded in Google model-viewer.

If both of these viewers inhabit the same container div whose contents are being emptied, and you click between Button A and Button B rapidly, you occasionally get an error [here](https://github.com/edsilv/openseadragon/blob/master/src/viewer.js#L272) where it's trying to append to a null `this.element` reference.

I've simply introduced a check to see if `this.element` exists when bootstrapping OSD and returning if it doesn't. This fixed the issue for me.

Thanks for all the great work!