### PR TITLE
tileSize is no longer hard corded in Zoomify Tile Source

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ OPENSEADRAGON CHANGELOG
 * Documentation fix (#1814 @kenanchristian)
 * Better cleanup on destruction, to avoid memory leaks (#1832 @JoFrMueller)
 * Miscellaneous code cleanup (#1840 @msalsbery)
+* tileSize is no longer hard corded in Zoomify Tile Source (#1704)
 
 2.4.2:
 

--- a/src/zoomifytilesource.js
+++ b/src/zoomifytilesource.js
@@ -44,7 +44,7 @@
      * @param {String} tilesUrl
      */
     $.ZoomifyTileSource = function(options) {
-        if(options.tileSize === undefined){
+        if(typeof options.tileSize === 'undefined'){
             options.tileSize = 256;
         }
 

--- a/src/zoomifytilesource.js
+++ b/src/zoomifytilesource.js
@@ -18,7 +18,7 @@
      *      tilesUrl: "/test/data/zoomify/"
      * }
      *
-     * The tileSize is currently hardcoded to 256 (the usual Zoomify default). The tileUrl must the path to the image _directory_.
+     * The tileSize is set to 256 (the usual Zoomify default) when it is not defined. The tileUrl must the path to the image _directory_.
      *
      * 2) Loading image metadata from xml file: (CURRENTLY NOT SUPPORTED)
      *
@@ -44,7 +44,9 @@
      * @param {String} tilesUrl
      */
     $.ZoomifyTileSource = function(options) {
-        options.tileSize = 256;
+        if(options.tileSize === undefined){
+            options.tileSize = 256;
+        }
 
         var currentImageSize = {
             x: options.width,


### PR DESCRIPTION
minor fix as per this issue:
https://github.com/openseadragon/openseadragon/issues/1704#issuecomment-529580041