### PR TITLE
Replace v2 iiifSize max with full

### DIFF
--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -398,7 +398,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         }
         if ( levelWidth < tileWidth && levelHeight < tileHeight ){
             if ( this.version === 2 && levelWidth === this.width ) {
-                iiifSize = "max";
+                iiifSize = "full";
             } else if ( this.version === 3 && levelWidth === this.width && levelHeight === this.height ) {
                 iiifSize = "max";
             } else if ( this.version === 3 ) {
@@ -420,7 +420,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             iiifSizeW = Math.ceil( iiifTileW * scale );
             iiifSizeH = Math.ceil( iiifTileH * scale );
             if ( this.version === 2 && iiifSizeW === this.width ) {
-                iiifSize = "max";
+                iiifSize = "full";
             } else if ( this.version === 3 && iiifSizeW === this.width && iiifSizeH === this.height ) {
                 iiifSize = "max";
             } else if (this.version === 3) {


### PR DESCRIPTION
Fixes https://github.com/openseadragon/openseadragon/issues/1870

Size parameter is set to max when the tile width and image width are same. But, in version 2, max is not required to be supported by IIIF v2 services on any compliance level.