### PR TITLE
MouseTracker Overhaul 2020

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -202,7 +202,7 @@ module.exports = function(grunt) {
             target: sources
         },
         "git-describe": {
-            "options": {
+            options: {
                 failOnError: false
             },
             build: {}

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,16 @@ OPENSEADRAGON CHANGELOG
 * Documentation fix (#1814 @kenanchristian)
 * Better cleanup on destruction, to avoid memory leaks (#1832 @JoFrMueller)
 * Miscellaneous code cleanup (#1840 @msalsbery)
+* Improved browser sniffing - detect EDGE and CHROMEEDGE browsers
+* Improved DOM event model feature detection
+* Added support for options parameter on addEvent()/removeEvent (to support passive option)
+* Added OpenSeadragon.eventIsCanceled() function for defaultPrevented detection on DOM events
+* MouseTracker: better PointerEvent model detection - removed use of deprecated window.navigator.pointerEnabled
+* MouseTracker: added overHandler/outHandler options for handling corresponding pointerover/pointerout events
+* MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout
+* DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names
+* Added missing Button event object properties (were listed in documentation but not implemented)
+* Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers
 
 2.4.2:
 
@@ -54,7 +64,7 @@ OPENSEADRAGON CHANGELOG
 * You can now prevent canvas-click events on the navigator (#1416)
 * The navigator can now be restricted to just horizontal or just vertical panning (#1416)
 * Fixed DziTileSource so it doesn't load levels above maxLevel or below minLevel, if set (#1492)
- 
+
 2.3.1:
 
 * Debug mode now uses different colors for different tiled images (customizable via debugGridColor) (#1271)

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,18 +9,16 @@ OPENSEADRAGON CHANGELOG
 * Miscellaneous code cleanup (#1840 @msalsbery)
 * Improved browser sniffing - detect EDGE and CHROMEEDGE browsers
 * Improved DOM event model feature detection
-* Added support for options parameter on addEvent()/removeEvent (to support passive option)
+* Added support for options parameter on addEvent()/removeEvent (to support passive option) (#1669)
 * Added OpenSeadragon.eventIsCanceled() function for defaultPrevented detection on DOM events
 * MouseTracker: better PointerEvent model detection - removed use of deprecated window.navigator.pointerEnabled
 * MouseTracker: added overHandler/outHandler options for handling corresponding pointerover/pointerout events
 * MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout
 * All internal uses of MouseTracker use pointerenter/pointerleave events instead of pointerover/pointerout events for more consistent pointer tracking
 * DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names
-* Added missing Button event object properties (were listed in documentation but not implemented)
 * Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers
 * MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut
 * MouseTracker: Simulate mouseover/mouseout on IE < 9
-* Pass missing eventSource property in Viewer canvas-enter, canvas-exit, container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
 * Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
 
 2.4.2:

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,8 +20,6 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout (#1872 @msalsbery)
 * All internal uses of MouseTracker use pointerenter/pointerleave events instead of pointerover/pointerout events for more consistent pointer tracking (#1872 @msalsbery)
 * Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers (#1872 @msalsbery)
-* MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut (#1872 @msalsbery)
-* MouseTracker: Simulate mouseover/mouseout on IE < 9 (#1872 @msalsbery)
 * Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events (#1872 @msalsbery)
 * MouseTracker: Fire dragEndHandler event even if release point same as initial contact point (#1872 @msalsbery)
 * MouseTracker: Pointer capture implemented with capture APIs where available. Only fallback to emulated capture on extremely old browsers (#1872 @msalsbery)
@@ -33,6 +31,7 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: added contextMenuHandler option for handling contextmenu events (#1872 @msalsbery)
 * Viewer: added a canvas-contextmenu event (#1872 @msalsbery)
 * Added additional documentation for the zoomPerSecond viewer option (#1872 @msalsbery)
+* MouseTracker: Per #1863, dropped support for Internet Explorer < 11 (#1872 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ OPENSEADRAGON CHANGELOG
 
 2.5.0: (In progress)
 
+* DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names (#1872 @msalsbery)
 * Now when "simple image" tile sources are removed from the viewer, they free the memory used by the pyramid they create (#1789 @TakumaKira)
 * Documentation fix (#1814 @kenanchristian)
 * Better cleanup on destruction, to avoid memory leaks (#1832 @JoFrMueller)
@@ -16,7 +17,6 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: added overHandler/outHandler options for handling corresponding pointerover/pointerout events (#1872 @msalsbery)
 * MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout (#1872 @msalsbery)
 * All internal uses of MouseTracker use pointerenter/pointerleave events instead of pointerover/pointerout events for more consistent pointer tracking (#1872 @msalsbery)
-* DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names (#1872 @msalsbery)
 * Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers (#1872 @msalsbery)
 * MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut (#1872 @msalsbery)
 * MouseTracker: Simulate mouseover/mouseout on IE < 9 (#1872 @msalsbery)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,33 +1,33 @@
 OPENSEADRAGON CHANGELOG
 =======================
 
-2.4.3: (In progress)
+2.5.0: (In progress)
 
 * Now when "simple image" tile sources are removed from the viewer, they free the memory used by the pyramid they create (#1789 @TakumaKira)
 * Documentation fix (#1814 @kenanchristian)
 * Better cleanup on destruction, to avoid memory leaks (#1832 @JoFrMueller)
 * Miscellaneous code cleanup (#1840 @msalsbery)
 * You can now specify tileSize for the Zoomify Tile Source (#1868 @abrlam)
-* Improved browser sniffing - detect EDGE and CHROMEEDGE browsers
-* Improved DOM event model feature detection
-* Added support for options parameter on addEvent()/removeEvent (to support passive option) (#1669)
-* Added OpenSeadragon.eventIsCanceled() function for defaultPrevented detection on DOM events
-* MouseTracker: better PointerEvent model detection - removed use of deprecated window.navigator.pointerEnabled
-* MouseTracker: added overHandler/outHandler options for handling corresponding pointerover/pointerout events
-* MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout
-* All internal uses of MouseTracker use pointerenter/pointerleave events instead of pointerover/pointerout events for more consistent pointer tracking
-* DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names
-* Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers
-* MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut
-* MouseTracker: Simulate mouseover/mouseout on IE < 9
-* Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
-* MouseTracker: Fire dragEndHandler event even if release point same as initial contact point (#1459)
-* MouseTracker: Pointer capture implemented with capture APIs where available. Only fallback to emulated capture on extremely old browsers
-* MouseTracker: Added preProcessEventHandler option to allow MouseTracker instances to control bubbling and default behavior of events on their associated element
-* MouseTracker: Improved handling of canceled events (#1728)
-* MouseTracker: Improved releasing of tracked pointers on destroy()/stopTracking() (#1346)
-* Updated Viewer, Button, Drawer, Navigator, ReferenceStrip DOM for proper DOM event handling
-* Added OpenSeadragon.setElementPointerEventsNone() for setting pointer-events:'none' on DOM elements
+* Improved browser sniffing - detect EDGE and CHROMEEDGE browsers (#1872 @msalsbery)
+* Improved DOM event model feature detection (#1872 @msalsbery)
+* Added support for options parameter on addEvent()/removeEvent (to support passive option) (#1872 @msalsbery)
+* Added OpenSeadragon.eventIsCanceled() function for defaultPrevented detection on DOM events (#1872 @msalsbery)
+* MouseTracker: better PointerEvent model detection - removed use of deprecated window.navigator.pointerEnabled (#1872 @msalsbery)
+* MouseTracker: added overHandler/outHandler options for handling corresponding pointerover/pointerout events (#1872 @msalsbery)
+* MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout (#1872 @msalsbery)
+* All internal uses of MouseTracker use pointerenter/pointerleave events instead of pointerover/pointerout events for more consistent pointer tracking (#1872 @msalsbery)
+* DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names (#1872 @msalsbery)
+* Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers (#1872 @msalsbery)
+* MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut (#1872 @msalsbery)
+* MouseTracker: Simulate mouseover/mouseout on IE < 9 (#1872 @msalsbery)
+* Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events (#1872 @msalsbery)
+* MouseTracker: Fire dragEndHandler event even if release point same as initial contact point (#1872 @msalsbery)
+* MouseTracker: Pointer capture implemented with capture APIs where available. Only fallback to emulated capture on extremely old browsers (#1872 @msalsbery)
+* MouseTracker: Added preProcessEventHandler option to allow MouseTracker instances to control bubbling and default behavior of events on their associated element (#1872 @msalsbery)
+* MouseTracker: Improved handling of canceled events (#1872 @msalsbery)
+* MouseTracker: Improved releasing of tracked pointers on destroy()/stopTracking() (#1872 @msalsbery)
+* Updated Viewer, Button, Drawer, Navigator, ReferenceStrip DOM for proper DOM event handling (#1872 @msalsbery)
+* Added OpenSeadragon.setElementPointerEventsNone() for setting pointer-events:'none' on DOM elements (#1872 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,8 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: Fire dragEndHandler event even if release point same as initial contact point (#1459)
 * MouseTracker: Pointer capture implemented with capture APIs where available. Only fallback to emulated capture on extremely old browsers
 * MouseTracker: Added preProcessEventHandler option to allow MouseTracker instances to control bubbling and default behavior of events on their associated element
+* MouseTracker: Improved handling of canceled events (#1728)
+* MouseTracker: Improved releasing of tracked pointers on destroy()/stopTracking() (#1346)
 * Updated Viewer, Button, Drawer, Navigator, ReferenceStrip DOM for proper DOM event handling
 * Added OpenSeadragon.setElementPointerEventsNone() for setting pointer-events:'none' on DOM elements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ OPENSEADRAGON CHANGELOG
 * Added OpenSeadragon.setElementPointerEventsNone() for setting pointer-events:'none' on DOM elements (#1872 @msalsbery)
 * MouseTracker: added contextMenuHandler option for handling contextmenu events (#1872 @msalsbery)
 * Viewer: added a canvas-contextmenu event (#1872 @msalsbery)
+* Added additional documentation for the zoomPerSecond viewer option (#1872 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,8 @@ OPENSEADRAGON CHANGELOG
 * DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names
 * Added missing Button event object properties (were listed in documentation but not implemented)
 * Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers
+* MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut
+* MouseTracker: Simulate mouseover/mouseout on IE < 9
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,8 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: Improved releasing of tracked pointers on destroy()/stopTracking() (#1872 @msalsbery)
 * Updated Viewer, Button, Drawer, Navigator, ReferenceStrip DOM for proper DOM event handling (#1872 @msalsbery)
 * Added OpenSeadragon.setElementPointerEventsNone() for setting pointer-events:'none' on DOM elements (#1872 @msalsbery)
+* MouseTracker: added contextMenuHandler option for handling contextmenu events (#1872 @msalsbery)
+* Viewer: added a canvas-contextmenu event (#1872 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,9 @@ OPENSEADRAGON CHANGELOG
 * Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
 * MouseTracker: Fire dragEndHandler event even if release point same as initial contact point (#1459)
 * MouseTracker: Pointer capture implemented with capture APIs where available. Only fallback to emulated capture on extremely old browsers
+* MouseTracker: Added preProcessEventHandler option to allow MouseTracker instances to control bubbling and default behavior of events on their associated element
+* Updated Viewer, Button, Drawer, Navigator, ReferenceStrip DOM for proper DOM event handling
+* Added OpenSeadragon.setElementPointerEventsNone() for setting pointer-events:'none' on DOM elements
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,11 +14,14 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: better PointerEvent model detection - removed use of deprecated window.navigator.pointerEnabled
 * MouseTracker: added overHandler/outHandler options for handling corresponding pointerover/pointerout events
 * MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout
+* All internal uses of MouseTracker use pointerenter/pointerleave events instead of pointerover/pointerout events for more consistent pointer tracking
 * DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names
 * Added missing Button event object properties (were listed in documentation but not implemented)
 * Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers
 * MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut
 * MouseTracker: Simulate mouseover/mouseout on IE < 9
+* Pass missing eventSource property in Viewer canvas-enter, canvas-exit, container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
+* Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,8 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: IE 10 - MSPointerEnter/MSPointerLeave didn't exist then, simulated with MSPointerOver/MSPointerOut
 * MouseTracker: Simulate mouseover/mouseout on IE < 9
 * Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
+* MouseTracker: Fire dragEndHandler event even if release point same as initial contact point (#1459)
+* MouseTracker: Pointer capture implemented with capture APIs where available. Only fallback to emulated capture on extremely old browsers
 
 2.4.2:
 

--- a/src/button.js
+++ b/src/button.js
@@ -138,6 +138,13 @@ $.Button = function( options ) {
         this.imgDown.alt  =
             this.tooltip;
 
+        // Allow pointer events to pass through the img elements so implicit
+        //   pointer capture works on touch devices
+        $.setElementPointerEventsNone( this.imgRest );
+        $.setElementPointerEventsNone( this.imgGroup );
+        $.setElementPointerEventsNone( this.imgHover );
+        $.setElementPointerEventsNone( this.imgDown );
+
         this.element.style.position = "relative";
         $.setElementTouchActionNone( this.element );
 

--- a/src/button.js
+++ b/src/button.js
@@ -223,11 +223,7 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "enter", {
-                    eventSource: _this,
-                    originalEvent: event.originalEvent,
-                    userData: _this.userData
-                } );
+                _this.raiseEvent( "enter", { originalEvent: event.originalEvent } );
             } else if ( !event.buttonDownAny ) {
                 inTo( _this, $.ButtonState.HOVER );
             }
@@ -245,11 +241,7 @@ $.Button = function( options ) {
              * @property {Object} originalEvent - The original DOM event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            _this.raiseEvent( "focus", {
-                eventSource: _this,
-                originalEvent: event.originalEvent,
-                userData: _this.userData
-            } );
+            _this.raiseEvent( "focus", { originalEvent: event.originalEvent } );
         },
 
         leaveHandler: function( event ) {
@@ -265,11 +257,7 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "exit", {
-                    eventSource: _this,
-                    originalEvent: event.originalEvent,
-                    userData: _this.userData
-                } );
+                _this.raiseEvent( "exit", { originalEvent: event.originalEvent } );
             }
         },
 
@@ -285,11 +273,7 @@ $.Button = function( options ) {
              * @property {Object} originalEvent - The original DOM event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            _this.raiseEvent( "blur", {
-                eventSource: _this,
-                originalEvent: event.originalEvent,
-                userData: _this.userData
-            } );
+            _this.raiseEvent( "blur", { originalEvent: event.originalEvent } );
         },
 
         pressHandler: function ( event ) {
@@ -304,11 +288,7 @@ $.Button = function( options ) {
              * @property {Object} originalEvent - The original DOM event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            _this.raiseEvent( "press", {
-                eventSource: _this,
-                originalEvent: event.originalEvent,
-                userData: _this.userData
-            } );
+            _this.raiseEvent( "press", { originalEvent: event.originalEvent } );
         },
 
         releaseHandler: function( event ) {
@@ -324,11 +304,7 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "release", {
-                    eventSource: _this,
-                    originalEvent: event.originalEvent,
-                    userData: _this.userData
-                } );
+                _this.raiseEvent( "release", { originalEvent: event.originalEvent } );
             } else if ( event.insideElementPressed ) {
                 outTo( _this, $.ButtonState.GROUP );
             } else {
@@ -348,11 +324,7 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent("click", {
-                    eventSource: _this,
-                    originalEvent: event.originalEvent,
-                    userData: _this.userData
-                });
+                _this.raiseEvent("click", { originalEvent: event.originalEvent });
             }
         },
 
@@ -369,11 +341,7 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "click", {
-                    eventSource: _this,
-                    originalEvent: event.originalEvent,
-                    userData: _this.userData
-                } );
+                _this.raiseEvent( "click", { originalEvent: event.originalEvent } );
                 /***
                  * Raised when the mouse button is released or touch ends in the Button element.
                  *
@@ -384,11 +352,7 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "release", {
-                    eventSource: _this,
-                    originalEvent: event.originalEvent,
-                    userData: _this.userData
-                } );
+                _this.raiseEvent( "release", { originalEvent: event.originalEvent } );
                 return false;
             }
             return true;

--- a/src/button.js
+++ b/src/button.js
@@ -77,6 +77,7 @@ $.ButtonState = {
  * @param {OpenSeadragon.EventHandler} [options.onExit=null] Event handler callback for {@link OpenSeadragon.Button.event:exit}.
  * @param {OpenSeadragon.EventHandler} [options.onFocus=null] Event handler callback for {@link OpenSeadragon.Button.event:focus}.
  * @param {OpenSeadragon.EventHandler} [options.onBlur=null] Event handler callback for {@link OpenSeadragon.Button.event:blur}.
+ * @param {Object} [options.userData=null] Arbitrary object to be passed unchanged to any attached handler methods.
  */
 $.Button = function( options ) {
 
@@ -111,7 +112,8 @@ $.Button = function( options ) {
         onEnter:            null,
         onExit:             null,
         onFocus:            null,
-        onBlur:             null
+        onBlur:             null,
+        userData:           null
 
     }, options );
 
@@ -203,6 +205,7 @@ $.Button = function( options ) {
      */
     this.tracker = new $.MouseTracker({
 
+        userData:           'Button.tracker',
         element:            this.element,
         clickTimeThreshold: this.clickTimeThreshold,
         clickDistThreshold: this.clickDistThreshold,
@@ -220,14 +223,18 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "enter", { originalEvent: event.originalEvent } );
+                _this.raiseEvent( "enter", {
+                    eventSource: _this,
+                    originalEvent: event.originalEvent,
+                    userData: _this.userData
+                } );
             } else if ( !event.buttonDownAny ) {
                 inTo( _this, $.ButtonState.HOVER );
             }
         },
 
         focusHandler: function ( event ) {
-            this.enterHandler( event );
+            _this.tracker.enterHandler( event );
             /**
              * Raised when the Button element receives focus.
              *
@@ -238,10 +245,14 @@ $.Button = function( options ) {
              * @property {Object} originalEvent - The original DOM event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            _this.raiseEvent( "focus", { originalEvent: event.originalEvent } );
+            _this.raiseEvent( "focus", {
+                eventSource: _this,
+                originalEvent: event.originalEvent,
+                userData: _this.userData
+            } );
         },
 
-        exitHandler: function( event ) {
+        leaveHandler: function( event ) {
             outTo( _this, $.ButtonState.GROUP );
             if ( event.insideElementPressed ) {
                 /**
@@ -254,12 +265,16 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "exit", { originalEvent: event.originalEvent } );
+                _this.raiseEvent( "exit", {
+                    eventSource: _this,
+                    originalEvent: event.originalEvent,
+                    userData: _this.userData
+                } );
             }
         },
 
         blurHandler: function ( event ) {
-            this.exitHandler( event );
+            _this.tracker.leaveHandler( event );
             /**
              * Raised when the Button element loses focus.
              *
@@ -270,7 +285,11 @@ $.Button = function( options ) {
              * @property {Object} originalEvent - The original DOM event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            _this.raiseEvent( "blur", { originalEvent: event.originalEvent } );
+            _this.raiseEvent( "blur", {
+                eventSource: _this,
+                originalEvent: event.originalEvent,
+                userData: _this.userData
+            } );
         },
 
         pressHandler: function ( event ) {
@@ -285,7 +304,11 @@ $.Button = function( options ) {
              * @property {Object} originalEvent - The original DOM event.
              * @property {?Object} userData - Arbitrary subscriber-defined object.
              */
-            _this.raiseEvent( "press", { originalEvent: event.originalEvent } );
+            _this.raiseEvent( "press", {
+                eventSource: _this,
+                originalEvent: event.originalEvent,
+                userData: _this.userData
+            } );
         },
 
         releaseHandler: function( event ) {
@@ -301,7 +324,11 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "release", { originalEvent: event.originalEvent } );
+                _this.raiseEvent( "release", {
+                    eventSource: _this,
+                    originalEvent: event.originalEvent,
+                    userData: _this.userData
+                } );
             } else if ( event.insideElementPressed ) {
                 outTo( _this, $.ButtonState.GROUP );
             } else {
@@ -321,7 +348,11 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent("click", { originalEvent: event.originalEvent });
+                _this.raiseEvent("click", {
+                    eventSource: _this,
+                    originalEvent: event.originalEvent,
+                    userData: _this.userData
+                });
             }
         },
 
@@ -338,7 +369,11 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "click", { originalEvent: event.originalEvent } );
+                _this.raiseEvent( "click", {
+                    eventSource: _this,
+                    originalEvent: event.originalEvent,
+                    userData: _this.userData
+                } );
                 /***
                  * Raised when the mouse button is released or touch ends in the Button element.
                  *
@@ -349,7 +384,11 @@ $.Button = function( options ) {
                  * @property {Object} originalEvent - The original DOM event.
                  * @property {?Object} userData - Arbitrary subscriber-defined object.
                  */
-                _this.raiseEvent( "release", { originalEvent: event.originalEvent } );
+                _this.raiseEvent( "release", {
+                    eventSource: _this,
+                    originalEvent: event.originalEvent,
+                    userData: _this.userData
+                } );
                 return false;
             }
             return true;
@@ -363,8 +402,8 @@ $.Button = function( options ) {
 $.extend( $.Button.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.Button.prototype */{
 
     /**
-     * TODO: Determine what this function is intended to do and if it's actually
-     * useful as an API point.
+     * Used by a button container element (e.g. a ButtonGroup) to transition the button state
+     * to ButtonState.GROUP.
      * @function
      */
     notifyGroupEnter: function() {
@@ -372,8 +411,8 @@ $.extend( $.Button.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.
     },
 
     /**
-     * TODO: Determine what this function is intended to do and if it's actually
-     * useful as an API point.
+     * Used by a button container element (e.g. a ButtonGroup) to transition the button state
+     * to ButtonState.REST.
      * @function
      */
     notifyGroupExit: function() {

--- a/src/buttongroup.js
+++ b/src/buttongroup.js
@@ -88,6 +88,7 @@ $.ButtonGroup = function( options ) {
      * @memberof OpenSeadragon.ButtonGroup#
      */
     this.tracker = new $.MouseTracker({
+        userData:           'ButtonGroup.tracker',
         element:            this.element,
         clickTimeThreshold: this.clickTimeThreshold,
         clickDistThreshold: this.clickDistThreshold,
@@ -97,7 +98,7 @@ $.ButtonGroup = function( options ) {
                 _this.buttons[ i ].notifyGroupEnter();
             }
         },
-        exitHandler: function ( event ) {
+        leaveHandler: function ( event ) {
             var i;
             if ( !event.insideElementPressed ) {
                 for ( i = 0; i < _this.buttons.length; i++ ) {
@@ -127,8 +128,8 @@ $.ButtonGroup.prototype = {
      * @function
      * @private
      */
-    emulateExit: function() {
-        this.tracker.exitHandler( { eventSource: this.tracker } );
+    emulateLeave: function() {
+        this.tracker.leaveHandler( { eventSource: this.tracker } );
     },
 
     destroy: function() {

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -126,6 +126,10 @@ $.Drawer = function( options ) {
     this.canvas.style.height    = "100%";
     this.canvas.style.position  = "absolute";
     $.setElementOpacity( this.canvas, this.opacity, true );
+    // Allow pointer events to pass through the canvas element so implicit
+    //   pointer capture works on touch devices
+    $.setElementPointerEventsNone( this.canvas );
+    $.setElementTouchActionNone( this.canvas );
 
     // explicit left-align
     this.container.style.textAlign = "left";

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2362,11 +2362,9 @@
      * @inner
      */
     function onPointerEnter( tracker, event ) {
-        var gPoint;
-
         //$.console.log('pointerenter ' + (tracker.userData ? tracker.userData.toString() : ''));
 
-        gPoint = {
+        var gPoint = {
             id: getPointerId( event ),
             type: getPointerType( event ),
             isPrimary: getIsPrimary( event ),
@@ -2397,11 +2395,9 @@
      * @inner
      */
     function onPointerLeave( tracker, event ) {
-        var gPoint;
-
         //$.console.log('pointerleave ' + (tracker.userData ? tracker.userData.toString() : ''));
 
-        gPoint = {
+        var gPoint = {
             id: getPointerId( event ),
             type: getPointerType( event ),
             isPrimary: getIsPrimary( event ),
@@ -2506,8 +2502,6 @@
      * @inner
      */
     function onPointerDown( tracker, event ) {
-        var gPoint;
-
         //$.console.log('onPointerDown ' + (tracker.userData ? tracker.userData.toString() : ''));
         // $.console.log('onPointerDown ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + event.target.tagName);
 
@@ -2524,7 +2518,7 @@
         //     $.console.log('pointerdown not implicitlyCaptured ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
         // }
 
-        gPoint = {
+        var gPoint = {
             id: getPointerId( event ),
             type: getPointerType( event ),
             isPrimary: getIsPrimary( event ),
@@ -2676,9 +2670,8 @@
      */
     function handlePointerMove( tracker, event ) {
         // Pointer changed coordinates, button state, pressure, tilt, or contact geometry (e.g. width and height)
-        var gPoint;
 
-        gPoint = {
+        var gPoint = {
             id: getPointerId( event ),
             type: getPointerType( event ),
             isPrimary: getIsPrimary( event ),

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -74,8 +74,14 @@
      *      event is fired.
      * @param {OpenSeadragon.EventHandler} [options.enterHandler=null]
      *      An optional handler for pointer enter.
+     * @param {OpenSeadragon.EventHandler} [options.leaveHandler=null]
+     *      An optional handler for pointer leave.
      * @param {OpenSeadragon.EventHandler} [options.exitHandler=null]
-     *      An optional handler for pointer exit.
+     *      An optional handler for pointer leave. <span style="color:red;">Deprecated. Use leaveHandler instead.</span>
+     * @param {OpenSeadragon.EventHandler} [options.overHandler=null]
+     *      An optional handler for pointer over.
+     * @param {OpenSeadragon.EventHandler} [options.outHandler=null]
+     *      An optional handler for pointer out.
      * @param {OpenSeadragon.EventHandler} [options.pressHandler=null]
      *      An optional handler for pointer press.
      * @param {OpenSeadragon.EventHandler} [options.nonPrimaryPressHandler=null]
@@ -165,7 +171,10 @@
         this.stopDelay             = options.stopDelay         || 50;
 
         this.enterHandler             = options.enterHandler             || null;
+        this.leaveHandler             = options.leaveHandler             || null;
         this.exitHandler              = options.exitHandler              || null;
+        this.overHandler              = options.overHandler              || null;
+        this.outHandler               = options.outHandler               || null;
         this.pressHandler             = options.pressHandler             || null;
         this.nonPrimaryPressHandler   = options.nonPrimaryPressHandler   || null;
         this.releaseHandler           = options.releaseHandler           || null;
@@ -207,10 +216,10 @@
             DOMMouseScroll:        function ( event ) { onMouseWheel( _this, event ); },
             MozMousePixelScroll:   function ( event ) { onMouseWheel( _this, event ); },
 
-            mouseenter:            function ( event ) { onMouseEnter( _this, event ); }, // Used on IE8 only
-            mouseleave:            function ( event ) { onMouseLeave( _this, event ); }, // Used on IE8 only
-            mouseover:             function ( event ) { onMouseOver( _this, event ); },
-            mouseout:              function ( event ) { onMouseOut( _this, event ); },
+            mouseover:             function ( event ) { onMouseOver( _this, event ); }, // IE9+ only
+            mouseout:              function ( event ) { onMouseOut( _this, event ); },  // IE9+ only
+            mouseenter:            function ( event ) { onMouseEnter( _this, event ); },
+            mouseleave:            function ( event ) { onMouseLeave( _this, event ); },
             mousedown:             function ( event ) { onMouseDown( _this, event ); },
             mouseup:               function ( event ) { onMouseUp( _this, event ); },
             mouseupcaptured:       function ( event ) { onMouseUpCaptured( _this, event ); },
@@ -231,6 +240,10 @@
             MSPointerOver:         function ( event ) { onPointerOver( _this, event ); },
             pointerout:            function ( event ) { onPointerOut( _this, event ); },
             MSPointerOut:          function ( event ) { onPointerOut( _this, event ); },
+            pointerenter:          function ( event ) { onPointerEnter( _this, event ); },
+            MSPointerEnter:        function ( event ) { onPointerEnter( _this, event ); },
+            pointerleave:          function ( event ) { onPointerLeave( _this, event ); },
+            MSPointerLeave:        function ( event ) { onPointerLeave( _this, event ); },
             pointerdown:           function ( event ) { onPointerDown( _this, event ); },
             MSPointerDown:         function ( event ) { onPointerDown( _this, event ); },
             pointerup:             function ( event ) { onPointerUp( _this, event ); },
@@ -403,12 +416,74 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
+         * @param {Object} event.userData
+         *      Arbitrary user-defined object.
+         */
+        enterHandler: function () { },
+
+        /**
+         * Implement or assign implementation to these handlers during or after
+         * calling the constructor.
+         * @function
+         * @deprecated Use leaveHandler instead
+         * @param {Object} event
+         * @param {OpenSeadragon.MouseTracker} event.eventSource
+         *      A reference to the tracker instance.
+         * @param {String} event.pointerType
+         *     "mouse", "touch", "pen", etc.
+         * @param {OpenSeadragon.Point} event.position
+         *      The position of the event relative to the tracked element.
+         * @param {Number} event.buttons
+         *      Current buttons pressed.
+         *      Combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @param {Number} event.pointers
+         *      Number of pointers (all types) active in the tracked element.
+         * @param {Boolean} event.insideElementPressed
+         *      True if the left mouse button is currently being pressed and was
+         *      initiated inside the tracked element, otherwise false.
+         * @param {Boolean} event.buttonDownAny
+         *      Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
+         * @param {Boolean} event.isTouchEvent
+         *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
+         * @param {Object} event.originalEvent
+         *      The original event object.
+         * @param {Object} event.userData
+         *      Arbitrary user-defined object.
+         */
+        leaveHandler: function () { },
+
+        /**
+         * Implement or assign implementation to these handlers during or after
+         * calling the constructor.
+         * @function
+         * @deprecated Use leaveHandler instead
+         * @param {Object} event
+         * @param {OpenSeadragon.MouseTracker} event.eventSource
+         *      A reference to the tracker instance.
+         * @param {String} event.pointerType
+         *     "mouse", "touch", "pen", etc.
+         * @param {OpenSeadragon.Point} event.position
+         *      The position of the event relative to the tracked element.
+         * @param {Number} event.buttons
+         *      Current buttons pressed.
+         *      Combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @param {Number} event.pointers
+         *      Number of pointers (all types) active in the tracked element.
+         * @param {Boolean} event.insideElementPressed
+         *      True if the left mouse button is currently being pressed and was
+         *      initiated inside the tracked element, otherwise false.
+         * @param {Boolean} event.buttonDownAny
+         *      Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
+         * @param {Boolean} event.isTouchEvent
+         *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
+         * @param {Object} event.originalEvent
+         *      The original event object.
          * @param {Boolean} event.preventDefaultAction
          *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
-        enterHandler: function () { },
+        exitHandler: function () { },
 
         /**
          * Implement or assign implementation to these handlers during or after
@@ -440,7 +515,39 @@
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
-        exitHandler: function () { },
+        overHandler: function () { },
+
+        /**
+         * Implement or assign implementation to these handlers during or after
+         * calling the constructor.
+         * @function
+         * @param {Object} event
+         * @param {OpenSeadragon.MouseTracker} event.eventSource
+         *      A reference to the tracker instance.
+         * @param {String} event.pointerType
+         *     "mouse", "touch", "pen", etc.
+         * @param {OpenSeadragon.Point} event.position
+         *      The position of the event relative to the tracked element.
+         * @param {Number} event.buttons
+         *      Current buttons pressed.
+         *      Combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
+         * @param {Number} event.pointers
+         *      Number of pointers (all types) active in the tracked element.
+         * @param {Boolean} event.insideElementPressed
+         *      True if the left mouse button is currently being pressed and was
+         *      initiated inside the tracked element, otherwise false.
+         * @param {Boolean} event.buttonDownAny
+         *      Was the button down anywhere in the screen during the event. <span style="color:red;">Deprecated. Use buttons instead.</span>
+         * @param {Boolean} event.isTouchEvent
+         *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
+         * @param {Object} event.originalEvent
+         *      The original event object.
+         * @param {Boolean} event.preventDefaultAction
+         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
+         * @param {Object} event.userData
+         *      Arbitrary user-defined object.
+         */
+        outHandler: function () { },
 
         /**
          * Implement or assign implementation to these handlers during or after
@@ -1020,38 +1127,37 @@
         $.MouseTracker.subscribeEvents.push( "MozMousePixelScroll" );
     }
 
-    // Note: window.navigator.pointerEnable is deprecated on IE 11 and not part of W3C spec.
-    if ( window.PointerEvent && ( window.navigator.pointerEnabled || $.Browser.vendor !== $.BROWSERS.IE ) ) {
+    if ( window.PointerEvent ) {
         // IE11 and other W3C Pointer Event implementations (see http://www.w3.org/TR/pointerevents)
         $.MouseTracker.havePointerEvents = true;
-        $.MouseTracker.subscribeEvents.push( "pointerover", "pointerout", "pointerdown", "pointerup", "pointermove", "pointercancel" );
+        $.MouseTracker.subscribeEvents.push( "pointerenter", "pointerleave", "pointerover", "pointerout", "pointerdown", "pointerup", "pointermove", "pointercancel" );
         $.MouseTracker.unprefixedPointerEvents = true;
         if( navigator.maxTouchPoints ) {
             $.MouseTracker.maxTouchPoints = navigator.maxTouchPoints;
         } else {
             $.MouseTracker.maxTouchPoints = 0;
         }
-        $.MouseTracker.haveMouseEnter = false;
+        $.MouseTracker.haveMouseOver = true;
     } else if ( window.MSPointerEvent && window.navigator.msPointerEnabled ) {
         // IE10
         $.MouseTracker.havePointerEvents = true;
-        $.MouseTracker.subscribeEvents.push( "MSPointerOver", "MSPointerOut", "MSPointerDown", "MSPointerUp", "MSPointerMove", "MSPointerCancel" );
+        $.MouseTracker.subscribeEvents.push( "MSPointerEnter", "MSPointerLeave", "MSPointerOver", "MSPointerOut", "MSPointerDown", "MSPointerUp", "MSPointerMove", "MSPointerCancel" );
         $.MouseTracker.unprefixedPointerEvents = false;
         if( navigator.msMaxTouchPoints ) {
             $.MouseTracker.maxTouchPoints = navigator.msMaxTouchPoints;
         } else {
             $.MouseTracker.maxTouchPoints = 0;
         }
-        $.MouseTracker.haveMouseEnter = false;
+        $.MouseTracker.haveMouseOver = true;
     } else {
         // Legacy W3C mouse events
         $.MouseTracker.havePointerEvents = false;
-        if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
-            $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave" );
-            $.MouseTracker.haveMouseEnter = true;
-        } else {
+        $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave" );
+        if ( $.Browser.vendor !== $.BROWSERS.IE || $.Browser.version > 8 ) {
             $.MouseTracker.subscribeEvents.push( "mouseover", "mouseout" );
-            $.MouseTracker.haveMouseEnter = false;
+            $.MouseTracker.haveMouseOver = true;
+        } else {
+            $.MouseTracker.haveMouseOver = false;
         }
         $.MouseTracker.subscribeEvents.push( "mousedown", "mouseup", "mousemove" );
         if ( 'ontouchstart' in window ) {
@@ -1832,38 +1938,12 @@
 
 
     /**
-     * Only used on IE 8
-     *
      * @private
      * @inner
      */
     function onMouseEnter( tracker, event ) {
         event = $.getEvent( event );
 
-        handleMouseEnter( tracker, event );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function onMouseOver( tracker, event ) {
-        event = $.getEvent( event );
-
-        if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
-            return;
-        }
-
-        handleMouseEnter( tracker, event );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handleMouseEnter( tracker, event ) {
         var gPoint = {
             id: $.MouseTracker.mousePointerId,
             type: 'mouse',
@@ -1873,42 +1953,21 @@
         };
 
         updatePointersEnter( tracker, event, [ gPoint ] );
+
+        //TODO simulate mouseover on IE < 9?
+        // if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
+        //     handleMouseOver( tracker, event );
+        // }
     }
 
 
     /**
-     * Only used on IE 8
-     *
      * @private
      * @inner
      */
     function onMouseLeave( tracker, event ) {
         event = $.getEvent( event );
 
-        handleMouseExit( tracker, event );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function onMouseOut( tracker, event ) {
-        event = $.getEvent( event );
-
-        if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
-            return;
-        }
-
-        handleMouseExit( tracker, event );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handleMouseExit( tracker, event ) {
         var gPoint = {
             id: $.MouseTracker.mousePointerId,
             type: 'mouse',
@@ -1917,7 +1976,76 @@
             currentTime: $.now()
         };
 
-        updatePointersExit( tracker, event, [ gPoint ] );
+        updatePointersLeave( tracker, event, [ gPoint ] );
+
+        //TODO simulate mouseoout on IE < 9?
+        // if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
+        //     handleMouseOut( tracker, event );
+        // }
+    }
+
+
+    /**
+     * IE9+ only
+     *
+     * @private
+     * @inner
+     */
+    function onMouseOver( tracker, event ) {
+        // if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
+        //     return;
+        // }
+
+        handleMouseOver( tracker, event );
+    }
+
+
+    /**
+     * @private
+     * @inner
+     */
+    function handleMouseOver( tracker, event ) {
+        var gPoint = {
+            id: $.MouseTracker.mousePointerId,
+            type: 'mouse',
+            isPrimary: true,
+            currentPos: getMouseAbsolute( event ),
+            currentTime: $.now()
+        };
+
+        updatePointersOver( tracker, event, [ gPoint ] );
+    }
+
+
+    /**
+     * IE9+ only
+     *
+     * @private
+     * @inner
+     */
+    function onMouseOut( tracker, event ) {
+        // if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
+        //     return;
+        // }
+
+        handleMouseOut( tracker, event );
+    }
+
+
+    /**
+     * @private
+     * @inner
+     */
+    function handleMouseOut( tracker, event ) {
+        var gPoint = {
+            id: $.MouseTracker.mousePointerId,
+            type: 'mouse',
+            isPrimary: true,
+            currentPos: getMouseAbsolute( event ),
+            currentTime: $.now()
+        };
+
+        updatePointersOut( tracker, event, [ gPoint ] );
     }
 
 
@@ -2083,7 +2211,7 @@
                 pointsList.captureCount = 1;
                 releasePointer( tracker, pointsList.type );
                 // simulate touchleave/mouseout
-                updatePointersExit( tracker, event, abortGPoints );
+                updatePointersLeave( tracker, event, abortGPoints );
             }
         }
     }
@@ -2199,7 +2327,7 @@
         }
 
         // simulate touchleave on our tracked element
-        updatePointersExit( tracker, event, gPoints );
+        updatePointersLeave( tracker, event, gPoints );
 
         // simulate touchleave on our tracked element's tracked ancestor elements
         for ( i = 0; i < MOUSETRACKERS.length; i++ ) {
@@ -2214,7 +2342,7 @@
                         currentTime: time
                     } );
                 }
-                updatePointersExit( MOUSETRACKERS[ i ], event, parentGPoints );
+                updatePointersLeave( MOUSETRACKERS[ i ], event, parentGPoints );
             }
         }
 
@@ -2306,12 +2434,10 @@
      * @private
      * @inner
      */
-    function onPointerOver( tracker, event ) {
+    function onPointerEnter( tracker, event ) {
         var gPoint;
 
-        if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
-            return;
-        }
+        //$.console.log('pointerenter ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
 
         gPoint = {
             id: event.pointerId,
@@ -2322,6 +2448,52 @@
         };
 
         updatePointersEnter( tracker, event, [ gPoint ] );
+}
+
+
+    /**
+     * @private
+     * @inner
+     */
+    function onPointerLeave( tracker, event ) {
+        var gPoint;
+
+        //$.console.log('pointerleave ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
+
+        gPoint = {
+            id: event.pointerId,
+            type: getPointerType( event ),
+            isPrimary: event.isPrimary,
+            currentPos: getMouseAbsolute( event ),
+            currentTime: $.now()
+        };
+
+        updatePointersLeave( tracker, event, [ gPoint ] );
+    }
+
+
+    /**
+     * @private
+     * @inner
+     */
+    function onPointerOver( tracker, event ) {
+        var gPoint;
+
+        $.console.log('pointerover ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
+
+        //if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
+        //    return;
+        //}
+
+        gPoint = {
+            id: event.pointerId,
+            type: getPointerType( event ),
+            isPrimary: event.isPrimary,
+            currentPos: getMouseAbsolute( event ),
+            currentTime: $.now()
+        };
+
+        updatePointersOver( tracker, event, [ gPoint ] );
     }
 
 
@@ -2332,9 +2504,11 @@
     function onPointerOut( tracker, event ) {
         var gPoint;
 
-        if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
-            return;
-        }
+        $.console.log('pointerout ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
+
+        //if ( event.currentTarget === event.relatedTarget || isParentChild( event.currentTarget, event.relatedTarget ) ) {
+        //    return;
+        //}
 
         gPoint = {
             id: event.pointerId,
@@ -2344,7 +2518,7 @@
             currentTime: $.now()
         };
 
-        updatePointersExit( tracker, event, [ gPoint ] );
+        updatePointersOut( tracker, event, [ gPoint ] );
     }
 
 
@@ -2568,8 +2742,7 @@
             i,
             gPointCount = gPoints.length,
             curGPoint,
-            updateGPoint,
-            propagate;
+            updateGPoint;
 
         for ( i = 0; i < gPointCount; i++ ) {
             curGPoint = gPoints[ i ];
@@ -2592,9 +2765,129 @@
                 startTrackingPointer( pointsList, curGPoint );
             }
 
-            // Enter
+            // Enter (doesn't bubble and not cancelable)
             if ( tracker.enterHandler ) {
-                propagate = tracker.enterHandler(
+                tracker.enterHandler(
+                    {
+                        eventSource:          tracker,
+                        pointerType:          curGPoint.type,
+                        position:             getPointRelativeToAbsolute( curGPoint.currentPos, tracker.element ),
+                        buttons:              pointsList.buttons,
+                        pointers:             tracker.getActivePointerCount(),
+                        insideElementPressed: curGPoint.insideElementPressed,
+                        buttonDownAny:        pointsList.buttons !== 0,
+                        isTouchEvent:         curGPoint.type === 'touch',
+                        originalEvent:        event,
+                        userData:             tracker.userData
+                    }
+                );
+            }
+        }
+    }
+
+
+    /**
+     * @function
+     * @private
+     * @inner
+     * @param {OpenSeadragon.MouseTracker} tracker
+     *     A reference to the MouseTracker instance.
+     * @param {Object} event
+     *     A reference to the originating DOM event.
+     * @param {Array.<OpenSeadragon.MouseTracker.GesturePoint>} gPoints
+     *      Gesture points associated with the event.
+     */
+    function updatePointersLeave( tracker, event, gPoints ) {
+        var pointsList = tracker.getActivePointersListByType(gPoints[0].type),
+            i,
+            gPointCount = gPoints.length,
+            curGPoint,
+            updateGPoint,
+            dispatchEventObj;
+
+        for ( i = 0; i < gPointCount; i++ ) {
+            curGPoint = gPoints[ i ];
+            updateGPoint = pointsList.getById( curGPoint.id );
+
+            if ( updateGPoint ) {
+                // Already tracking the pointer. If captured then update it, else stop tracking it
+                if ( updateGPoint.captured ) {
+                    updateGPoint.insideElement = false;
+                    updateGPoint.lastPos = updateGPoint.currentPos;
+                    updateGPoint.lastTime = updateGPoint.currentTime;
+                    updateGPoint.currentPos = curGPoint.currentPos;
+                    updateGPoint.currentTime = curGPoint.currentTime;
+                } else {
+                    stopTrackingPointer( pointsList, updateGPoint );
+                }
+
+                curGPoint = updateGPoint;
+            }
+
+            // Leave (doesn't bubble and not cancelable)
+            //   Note: exitHandler is deprecated, replaced by leaveHandler
+            if ( tracker.leaveHandler || tracker.exitHandler ) {
+                dispatchEventObj = {
+                    eventSource:          tracker,
+                    pointerType:          curGPoint.type,
+                    position:             curGPoint.currentPos && getPointRelativeToAbsolute( curGPoint.currentPos, tracker.element ),
+                    buttons:              pointsList.buttons,
+                    pointers:             tracker.getActivePointerCount(),
+                    insideElementPressed: updateGPoint ? updateGPoint.insideElementPressed : false,
+                    buttonDownAny:        pointsList.buttons !== 0,
+                    isTouchEvent:         curGPoint.type === 'touch',
+                    originalEvent:        event,
+                    userData:             tracker.userData
+                };
+
+                if ( tracker.leaveHandler ) {
+                    tracker.leaveHandler( dispatchEventObj );
+                }
+                if ( tracker.exitHandler ) {
+                    tracker.exitHandler( dispatchEventObj );
+                }
+            }
+        }
+    }
+
+
+    /**
+     * @function
+     * @private
+     * @inner
+     * @param {OpenSeadragon.MouseTracker} tracker
+     *     A reference to the MouseTracker instance.
+     * @param {Object} event
+     *     A reference to the originating DOM event.
+     * @param {Array.<OpenSeadragon.MouseTracker.GesturePoint>} gPoints
+     *      Gesture points associated with the event.
+     */
+    function updatePointersOver( tracker, event, gPoints ) {
+        var pointsList,
+            i,
+            gPointCount,
+            curGPoint,
+            updateGPoint,
+            propagate;
+
+        if ( tracker.overHandler ) {
+            pointsList = tracker.getActivePointersListByType( gPoints[ 0 ].type );
+            gPointCount = gPoints.length;
+
+            for ( i = 0; i < gPointCount; i++ ) {
+                curGPoint = gPoints[ i ];
+                updateGPoint = pointsList.getById( curGPoint.id );
+
+                if ( updateGPoint ) {
+                    curGPoint = updateGPoint;
+                } else {
+                    //curGPoint.captured = false; // Tracked by updatePointersEnter
+                    curGPoint.insideElementPressed = false;
+                    //curGPoint.insideElement = true; // Tracked by updatePointersEnter
+                }
+
+                // Over
+                propagate = tracker.overHandler(
                     {
                         eventSource:          tracker,
                         pointerType:          curGPoint.type,
@@ -2616,7 +2909,6 @@
         }
     }
 
-
     /**
      * @function
      * @private
@@ -2628,51 +2920,40 @@
      * @param {Array.<OpenSeadragon.MouseTracker.GesturePoint>} gPoints
      *      Gesture points associated with the event.
      */
-    function updatePointersExit( tracker, event, gPoints ) {
-        var pointsList = tracker.getActivePointersListByType(gPoints[0].type),
+    function updatePointersOut( tracker, event, gPoints ) {
+        var pointsList,
             i,
-            gPointCount = gPoints.length,
+            gPointCount,
             curGPoint,
             updateGPoint,
             propagate;
 
-        for ( i = 0; i < gPointCount; i++ ) {
-            curGPoint = gPoints[ i ];
-            updateGPoint = pointsList.getById( curGPoint.id );
+        if ( tracker.outHandler ) {
+            pointsList = tracker.getActivePointersListByType(gPoints[0].type);
+            gPointCount = gPoints.length;
 
-            if ( updateGPoint ) {
-                // Already tracking the pointer. If captured then update it, else stop tracking it
-                if ( updateGPoint.captured ) {
-                    updateGPoint.insideElement = false;
-                    updateGPoint.lastPos = updateGPoint.currentPos;
-                    updateGPoint.lastTime = updateGPoint.currentTime;
-                    updateGPoint.currentPos = curGPoint.currentPos;
-                    updateGPoint.currentTime = curGPoint.currentTime;
-                } else {
-                    stopTrackingPointer( pointsList, updateGPoint );
+            for ( i = 0; i < gPointCount; i++ ) {
+                curGPoint = gPoints[ i ];
+                updateGPoint = pointsList.getById( curGPoint.id );
+
+                if ( updateGPoint ) {
+                    curGPoint = updateGPoint;
                 }
 
-                curGPoint = updateGPoint;
-            }
-
-            // Exit
-            if ( tracker.exitHandler ) {
-                propagate = tracker.exitHandler(
-                    {
-                        eventSource:          tracker,
-                        pointerType:          curGPoint.type,
-                        position:             curGPoint.currentPos && getPointRelativeToAbsolute( curGPoint.currentPos, tracker.element ),
-                        buttons:              pointsList.buttons,
-                        pointers:             tracker.getActivePointerCount(),
-                        insideElementPressed: updateGPoint ? updateGPoint.insideElementPressed : false,
-                        buttonDownAny:        pointsList.buttons !== 0,
-                        isTouchEvent:         curGPoint.type === 'touch',
-                        originalEvent:        event,
-                        preventDefaultAction: false,
-                        userData:             tracker.userData
-                    }
-                );
-
+                // Out
+                propagate = tracker.outHandler( {
+                    eventSource:          tracker,
+                    pointerType:          curGPoint.type,
+                    position:             curGPoint.currentPos && getPointRelativeToAbsolute( curGPoint.currentPos, tracker.element ),
+                    buttons:              pointsList.buttons,
+                    pointers:             tracker.getActivePointerCount(),
+                    insideElementPressed: updateGPoint ? updateGPoint.insideElementPressed : false,
+                    buttonDownAny:        pointsList.buttons !== 0,
+                    isTouchEvent:         curGPoint.type === 'touch',
+                    originalEvent:        event,
+                    preventDefaultAction: false,
+                    userData:             tracker.userData
+                } );
                 if ( propagate === false ) {
                     $.cancelEvent( event );
                 }
@@ -3326,7 +3607,7 @@
      */
     function updatePointersCancel( tracker, event, gPoints ) {
         updatePointersUp( tracker, event, gPoints, 0 );
-        updatePointersExit( tracker, event, gPoints );
+        updatePointersLeave( tracker, event, gPoints );
     }
 
 
@@ -3367,7 +3648,7 @@
      * @function
      * @private
      * @inner
-     * @returns {Boolean} True if the target has access rights to events, otherwise false.
+     * @returns {Boolean} True if the target supports DOM Level 2 event subscription methods, otherwise false.
      */
     function canAccessEvents (target) {
         try {

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2355,7 +2355,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2389,7 +2390,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2423,7 +2425,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2459,7 +2462,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2495,7 +2499,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2554,7 +2559,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2565,7 +2571,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * This handler is attached to the window object (on the capture phase) to emulate mouse capture.
      * onPointerUp is still attached to the tracked element, so stop propagation to avoid processing twice.
@@ -2583,7 +2590,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2629,7 +2637,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner
@@ -2640,7 +2649,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * This handler is attached to the window object (on the capture phase) to emulate mouse capture.
      * onPointerMove is still attached to the tracked element, so stop propagation to avoid processing twice.
@@ -2658,7 +2668,8 @@
 
 
     /**
-     * Note: Called for both pointer events and legacy mouse events!
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      *
      * @private
      * @inner

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1677,6 +1677,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      * @private
      * @inner
      */
@@ -1688,6 +1690,9 @@
     /**
      * Gets a W3C Pointer Events model compatible pointer type string from a DOM pointer event.
      * IE10 used a long integer value, but the W3C specification (and IE11+) use a string "mouse", "touch", "pen", etc.
+     *
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      * @private
      * @inner
      */
@@ -1704,6 +1709,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events
+     *         ($.MouseTracker.havePointerEvents determines which)
      * @private
      * @inner
      */

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1247,7 +1247,7 @@
      * @property {Number} eventPhase
      *      0 == NONE, 1 == CAPTURING_PHASE, 2 == AT_TARGET, 3 == BUBBLING_PHASE.
      * @property {String} eventType
-     *     "contextmenu", "gotpointercapture", "lostpointercapture", "pointerenter", "pointerleave", "pointerover", "pointerout", "pointerdown", "pointerup", "pointermove", "pointercancel", "wheel".
+     *     "contextmenu", "gotpointercapture", "lostpointercapture", "pointerenter", "pointerleave", "pointerover", "pointerout", "pointerdown", "pointerup", "pointermove", "pointercancel", "wheel", "click", "dblclick".
      * @property {String} pointerType
      *     "mouse", "touch", "pen", etc.
      * @property {Boolean} isEmulated
@@ -1802,8 +1802,23 @@
      * @inner
      */
     function onClick( tracker, event ) {
-        if ( tracker.clickHandler ) {
+        event = $.getEvent( event );
+
+        //$.console.log('onClick ' + (tracker.userData ? tracker.userData.toString() : ''));
+
+        var eventInfo = {
+            originalEvent: event,
+            eventType: 'click',
+            pointerType: 'mouse',
+            isEmulated: false
+        };
+        preProcessEvent( tracker, eventInfo );
+
+        if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
             $.cancelEvent( event );
+        }
+        if ( eventInfo.stopPropagation ) {
+            $.stopEvent( event );
         }
     }
 
@@ -1813,8 +1828,23 @@
      * @inner
      */
     function onDblClick( tracker, event ) {
-        if ( tracker.dblClickHandler ) {
+        event = $.getEvent( event );
+
+        //$.console.log('onDblClick ' + (tracker.userData ? tracker.userData.toString() : ''));
+
+        var eventInfo = {
+            originalEvent: event,
+            eventType: 'dblclick',
+            pointerType: 'mouse',
+            isEmulated: false
+        };
+        preProcessEvent( tracker, eventInfo );
+
+        if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
             $.cancelEvent( event );
+        }
+        if ( eventInfo.stopPropagation ) {
+            $.stopEvent( event );
         }
     }
 
@@ -1972,7 +2002,7 @@
         preProcessEvent( tracker, eventInfo );
 
         // ContextMenu
-        if ( tracker.contextMenuHandler ) {
+        if ( tracker.contextMenuHandler && !eventInfo.preventGesture && !eventInfo.defaultPrevented ) {
             tracker.contextMenuHandler(
                 {
                     eventSource:          tracker,
@@ -3238,6 +3268,20 @@
                 eventInfo.isStopable = true;
                 eventInfo.isCancelable = false;
                 eventInfo.preventDefault = false;
+                eventInfo.preventGesture = false;
+                eventInfo.stopPropagation = false;
+                break;
+            case 'click':
+                eventInfo.isStopable = true;
+                eventInfo.isCancelable = true;
+                eventInfo.preventDefault = !!tracker.clickHandler;
+                eventInfo.preventGesture = false;
+                eventInfo.stopPropagation = false;
+                break;
+            case 'dblclick':
+                eventInfo.isStopable = true;
+                eventInfo.isCancelable = true;
+                eventInfo.preventDefault = !!tracker.dblClickHandler;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
                 break;

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1281,9 +1281,6 @@
      *      Valid on eventType "pointerdown".
      * @property {Boolean} stopPropagation
      *      Set to true prevent the event from propagating to ancestor/descendent elements on capture/bubble phase.
-     * @property {Boolean} stopImmediatePropagation
-     *      Same as stopPropagation, but also prevents any other handlers on the tracker's element for
-     *      this event from being called.
      * @property {Boolean} shouldCapture
      *      (Internal Use) Set to true if the pointer should be captured (events (re)targeted to tracker element).
      * @property {Boolean} shouldReleaseCapture
@@ -3231,7 +3228,6 @@
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
-                eventInfo.stopImmediatePropagation = false;
                 break;
             case 'pointerover':
             case 'pointerout':
@@ -3240,7 +3236,6 @@
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
-                eventInfo.stopImmediatePropagation = false;
                 break;
             case 'pointerdown':
                 eventInfo.isStopable = true;
@@ -3248,7 +3243,6 @@
                 eventInfo.preventDefault = false;//tracker.hasGestureHandlers;
                 eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
-                eventInfo.stopImmediatePropagation = false;
                 break;
             case 'pointerup':
                 eventInfo.isStopable = true;
@@ -3256,7 +3250,6 @@
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
-                eventInfo.stopImmediatePropagation = false;
                 break;
             case 'wheel':
                 eventInfo.isStopable = true;
@@ -3264,7 +3257,6 @@
                 eventInfo.preventDefault = false;//tracker.hasScrollHandler;
                 eventInfo.preventGesture = !tracker.hasScrollHandler;
                 eventInfo.stopPropagation = false;
-                eventInfo.stopImmediatePropagation = false;
                 break;
             case 'gotpointercapture':
             case 'lostpointercapture':
@@ -3274,7 +3266,6 @@
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
-                eventInfo.stopImmediatePropagation = false;
                 break;
             case 'pointerenter':
             case 'pointerleave':
@@ -3284,7 +3275,6 @@
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
-                eventInfo.stopImmediatePropagation = false;
                 break;
         }
     }

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -224,15 +224,14 @@
             MozMousePixelScroll:   function ( event ) { onMouseWheel( _this, event ); },
 
             losecapture:           function ( event ) { onLoseCapture( _this, event ); },
-            mouseenter:            function ( event ) { onMouseEnter( _this, event ); },
-            mouseleave:            function ( event ) { onMouseLeave( _this, event ); },
-            mouseover:             function ( event ) { onMouseOver( _this, event ); }, // IE9+ only
-            mouseout:              function ( event ) { onMouseOut( _this, event ); },  // IE9+ only
-            mousedown:             function ( event ) { onMouseDown( _this, event ); },
-            mouseup:               function ( event ) { onMouseUp( _this, event ); },
-            mouseupcaptured:       function ( event ) { onMouseUpCaptured( _this, event ); },
-            mousemove:             function ( event ) { onMouseMove( _this, event ); },
-            mousemovecaptured:     function ( event ) { onMouseMoveCaptured( _this, event ); },
+
+            mouseenter:            function ( event ) { onPointerEnter( _this, event ); },
+            mouseleave:            function ( event ) { onPointerLeave( _this, event ); },
+            mouseover:             function ( event ) { onPointerOver( _this, event ); },
+            mouseout:              function ( event ) { onPointerOut( _this, event ); },
+            mousedown:             function ( event ) { onPointerDown( _this, event ); },
+            mouseup:               function ( event ) { onPointerUp( _this, event ); },
+            mousemove:             function ( event ) { onPointerMove( _this, event ); },
 
             touchstart:            function ( event ) { onTouchStart( _this, event ); },
             touchend:              function ( event ) { onTouchEnd( _this, event ); },
@@ -242,27 +241,16 @@
             gesturestart:          function ( event ) { onGestureStart( _this, event ); }, // Safari/Safari iOS
             gesturechange:         function ( event ) { onGestureChange( _this, event ); }, // Safari/Safari iOS
 
-            MSGestureStart:        function ( event ) { onGestureStart( _this, event ); }, // IE10
-            MSGestureChange:       function ( event ) { onGestureChange( _this, event ); }, // IE10
-
             gotpointercapture:     function ( event ) { onGotPointerCapture( _this, event ); },
-            MSGotPointerCapture:   function ( event ) { onGotPointerCapture( _this, event ); },
             lostpointercapture:    function ( event ) { onLostPointerCapture( _this, event ); },
-            MSLostPointerCapture:  function ( event ) { onLostPointerCapture( _this, event ); },
             pointerenter:          function ( event ) { onPointerEnter( _this, event ); },
             pointerleave:          function ( event ) { onPointerLeave( _this, event ); },
             pointerover:           function ( event ) { onPointerOver( _this, event ); },
-            MSPointerOver:         function ( event ) { onPointerOver( _this, event ); },
             pointerout:            function ( event ) { onPointerOut( _this, event ); },
-            MSPointerOut:          function ( event ) { onPointerOut( _this, event ); },
             pointerdown:           function ( event ) { onPointerDown( _this, event ); },
-            MSPointerDown:         function ( event ) { onPointerDown( _this, event ); },
             pointerup:             function ( event ) { onPointerUp( _this, event ); },
-            MSPointerUp:           function ( event ) { onPointerUp( _this, event ); },
             pointermove:           function ( event ) { onPointerMove( _this, event ); },
-            MSPointerMove:         function ( event ) { onPointerMove( _this, event ); },
             pointercancel:         function ( event ) { onPointerCancel( _this, event ); },
-            MSPointerCancel:       function ( event ) { onPointerCancel( _this, event ); },
             pointerupcaptured:     function ( event ) { onPointerUpCaptured( _this, event ); },
             pointermovecaptured:   function ( event ) { onPointerMoveCaptured( _this, event ); },
 
@@ -1167,8 +1155,6 @@
         // IE11 and other W3C Pointer Event implementations (see http://www.w3.org/TR/pointerevents)
         $.MouseTracker.havePointerEvents = true;
         $.MouseTracker.subscribeEvents.push( "pointerenter", "pointerleave", "pointerover", "pointerout", "pointerdown", "pointerup", "pointermove", "pointercancel" );
-        $.MouseTracker.unprefixedPointerEvents = true;
-        $.MouseTracker.havePointerOverOut = true;
         // Pointer events capture support
         $.MouseTracker.havePointerCapture = (function () {
             var divElement = document.createElement( 'div' );
@@ -1177,33 +1163,10 @@
         if ( $.MouseTracker.havePointerCapture ) {
             $.MouseTracker.subscribeEvents.push( "gotpointercapture", "lostpointercapture" );
         }
-    } else if ( window.MSPointerEvent && window.navigator.msPointerEnabled ) {
-        // IE10 (MSPointerEnter/MSPointerLeave simulated with MSPointerOver/MSPointerOut)
-        $.MouseTracker.havePointerEvents = true;
-        $.MouseTracker.subscribeEvents.push( "MSPointerOver", "MSPointerOut", "MSPointerDown", "MSPointerUp", "MSPointerMove", "MSPointerCancel" );
-        $.MouseTracker.unprefixedPointerEvents = false;
-        $.MouseTracker.havePointerOverOut = true;
-        // Prefixed pointer events capture support
-        $.MouseTracker.havePointerCapture = (function () {
-            var divElement = document.createElement( 'div' );
-            return $.isFunction( divElement.msSetPointerCapture ) && $.isFunction( divElement.msReleasePointerCapture );
-        }());
-        if ( $.MouseTracker.havePointerCapture ) {
-            $.MouseTracker.subscribeEvents.push( "MSGotPointerCapture", "MSLostPointerCapture" );
-        }
-        $.MouseTracker.subscribeEvents.push( "MSGestureStart", "MSGestureChange" );
     } else {
         // Legacy W3C mouse events
         $.MouseTracker.havePointerEvents = false;
-        $.MouseTracker.unprefixedPointerEvents = true;
-        $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave" );
-        if ( $.Browser.vendor !== $.BROWSERS.IE || $.Browser.version > 8 ) {
-            $.MouseTracker.subscribeEvents.push( "mouseover", "mouseout" );
-            $.MouseTracker.havePointerOverOut = true;
-        } else {
-            $.MouseTracker.havePointerOverOut = false;
-        }
-        $.MouseTracker.subscribeEvents.push( "mousedown", "mouseup", "mousemove" );
+        $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave", "mouseover", "mouseout", "mousedown", "mouseup", "mousemove" );
         $.MouseTracker.mousePointerId = "legacy-mouse";
         // Legacy mouse events capture support (IE/Firefox only?)
         $.MouseTracker.havePointerCapture = (function () {
@@ -1253,7 +1216,7 @@
      * @property {Boolean} isEmulated
      *      True if this is an emulated event. If true, originalEvent is the event that caused
      *      the emulated event or null if no DOM event applies. Emulated events
-     *      can occur on eventType "pointerenter", "pointerleave", "pointerover", "pointerout".
+     *      can occur on eventType "wheel".
      * @property {Boolean} isStopable
      *      True if propagation of the event (e.g. bubbling) can be stopped with stopPropagation/stopImmediatePropagation.
      * @property {Boolean} isCancelable
@@ -1572,17 +1535,17 @@
 
         if ( pointerType === 'pointerevent' ) {
             return {
-                upName: $.MouseTracker.unprefixedPointerEvents ? 'pointerup' : 'MSPointerUp',
+                upName: 'pointerup',
                 upHandler: delegate.pointerupcaptured,
-                moveName: $.MouseTracker.unprefixedPointerEvents ? 'pointermove' : 'MSPointerMove',
+                moveName: 'pointermove',
                 moveHandler: delegate.pointermovecaptured
             };
         } else if ( pointerType === 'mouse' ) {
             return {
-                upName: 'mouseup',
-                upHandler: delegate.mouseupcaptured,
-                moveName: 'mousemove',
-                moveHandler: delegate.mousemovecaptured
+                upName: 'pointerup',
+                upHandler: delegate.pointerupcaptured,
+                moveName: 'pointermove',
+                moveHandler: delegate.pointermovecaptured
             };
         } else if ( pointerType === 'touch' ) {
             return {
@@ -1609,13 +1572,8 @@
                 // Can throw InvalidPointerId
                 //   (should never happen so we'll log a warning)
                 try {
-                    if ( $.MouseTracker.unprefixedPointerEvents ) {
-                        tracker.element.setPointerCapture( gPoint.id );
-                        //$.console.log('element.setPointerCapture() called');
-                    } else {
-                        tracker.element.msSetPointerCapture( gPoint.id );
-                        //$.console.log('element.msSetPointerCapture() called');
-                    }
+                    tracker.element.setPointerCapture( gPoint.id );
+                    //$.console.log('element.setPointerCapture() called');
                 } catch ( e ) {
                     $.console.warn('setPointerCapture() called on invalid pointer ID');
                 }
@@ -1676,13 +1634,8 @@
                 // Can throw InvalidPointerId
                 //   (should never happen, but it does on Firefox 79 touch so we won't log a warning)
                 try {
-                    if ( $.MouseTracker.unprefixedPointerEvents ) {
-                        tracker.element.releasePointerCapture( gPoint.id );
-                        //$.console.log('element.releasePointerCapture() called');
-                    } else {
-                        tracker.element.msReleasePointerCapture( gPoint.id );
-                        //$.console.log('element.msReleasePointerCapture() called');
-                    }
+                    tracker.element.releasePointerCapture( gPoint.id );
+                    //$.console.log('element.releasePointerCapture() called');
                 } catch ( e ) {
                     //$.console.warn('releasePointerCapture() called on invalid pointer ID');
                 }
@@ -1723,39 +1676,38 @@
 
 
     /**
+     * @private
+     * @inner
+     */
+    function getPointerId( event ) {
+        return ( $.MouseTracker.havePointerEvents ) ? event.pointerId : $.MouseTracker.mousePointerId;
+    }
+
+
+    /**
      * Gets a W3C Pointer Events model compatible pointer type string from a DOM pointer event.
      * IE10 used a long integer value, but the W3C specification (and IE11+) use a string "mouse", "touch", "pen", etc.
      * @private
      * @inner
      */
     function getPointerType( event ) {
-        // Note: IE pointer events bug - sends invalid pointerType on lostpointercapture events
-        //    and possibly other events. We rely on sane, valid property values in DOM events, so for
-        //    IE, when the pointerType is missing, we'll default to 'mouse'...should be right most of the time
-        var pointerTypeStr;
-        if ( $.MouseTracker.unprefixedPointerEvents ) {
-            pointerTypeStr = event.pointerType || (( $.Browser.vendor === $.BROWSERS.IE ) ? 'mouse' : '');
+        if ( $.MouseTracker.havePointerEvents ) {
+            // Note: IE pointer events bug - sends invalid pointerType on lostpointercapture events
+            //    and possibly other events. We rely on sane, valid property values in DOM events, so for
+            //    IE, when the pointerType is missing, we'll default to 'mouse'...should be right most of the time
+            return event.pointerType || (( $.Browser.vendor === $.BROWSERS.IE ) ? 'mouse' : '');
         } else {
-            // IE10
-            //  MSPOINTER_TYPE_TOUCH: 0x00000002
-            //  MSPOINTER_TYPE_PEN:   0x00000003
-            //  MSPOINTER_TYPE_MOUSE: 0x00000004
-            switch( event.pointerType )
-            {
-                case 0x00000002:
-                    pointerTypeStr = 'touch';
-                    break;
-                case 0x00000003:
-                    pointerTypeStr = 'pen';
-                    break;
-                case 0x00000004:
-                    pointerTypeStr = 'mouse';
-                    break;
-                default:
-                    pointerTypeStr = 'mouse';
-            }
+            return 'mouse';
         }
-        return pointerTypeStr;
+    }
+
+
+    /**
+     * @private
+     * @inner
+     */
+    function getIsPrimary( event ) {
+        return ( $.MouseTracker.havePointerEvents ) ? event.isPrimary : true;
     }
 
 
@@ -1802,8 +1754,6 @@
      * @inner
      */
     function onClick( tracker, event ) {
-        event = $.getEvent( event );
-
         //$.console.log('onClick ' + (tracker.userData ? tracker.userData.toString() : ''));
 
         var eventInfo = {
@@ -1828,8 +1778,6 @@
      * @inner
      */
     function onDblClick( tracker, event ) {
-        event = $.getEvent( event );
-
         //$.console.log('onDblClick ' + (tracker.userData ? tracker.userData.toString() : ''));
 
         var eventInfo = {
@@ -1857,7 +1805,6 @@
         //$.console.log( "keydown %s %s %s %s %s", event.keyCode, event.charCode, event.ctrlKey, event.shiftKey, event.altKey );
         var propagate;
         if ( tracker.keyDownHandler ) {
-            event = $.getEvent( event );
             propagate = tracker.keyDownHandler(
                 {
                     eventSource:          tracker,
@@ -1886,7 +1833,6 @@
         //$.console.log( "keyup %s %s %s %s %s", event.keyCode, event.charCode, event.ctrlKey, event.shiftKey, event.altKey );
         var propagate;
         if ( tracker.keyUpHandler ) {
-            event = $.getEvent( event );
             propagate = tracker.keyUpHandler(
                 {
                     eventSource:          tracker,
@@ -1915,7 +1861,6 @@
         //$.console.log( "keypress %s %s %s %s %s", event.keyCode, event.charCode, event.ctrlKey, event.shiftKey, event.altKey );
         var propagate;
         if ( tracker.keyHandler ) {
-            event = $.getEvent( event );
             propagate = tracker.keyHandler(
                 {
                     eventSource:          tracker,
@@ -1944,7 +1889,6 @@
         //console.log( "focus %s", event );
         var propagate;
         if ( tracker.focusHandler ) {
-            event = $.getEvent( event );
             propagate = tracker.focusHandler(
                 {
                     eventSource:          tracker,
@@ -1968,7 +1912,6 @@
         //console.log( "blur %s", event );
         var propagate;
         if ( tracker.blurHandler ) {
-            event = $.getEvent( event );
             propagate = tracker.blurHandler(
                 {
                     eventSource:          tracker,
@@ -1990,8 +1933,6 @@
      */
     function onContextMenu( tracker, event ) {
         //$.console.log('contextmenu ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
-
-        event = $.getEvent( event );
 
         var eventInfo = {
             originalEvent: event,
@@ -2040,8 +1981,6 @@
      * @inner
      */
     function onMouseWheel( tracker, event ) {
-        event = $.getEvent( event );
-
         // Simulate a 'wheel' event
         var simulatedEvent = {
             target:     event.target || event.srcElement,
@@ -2121,29 +2060,12 @@
 
 
     /**
-     * @private
-     * @inner
-     */
-    function isParentChild( parent, child )
-    {
-       if ( parent === child ) {
-           return false;
-       }
-       while ( child && child !== parent ) {
-           child = child.parentNode;
-       }
-       return child === parent;
-    }
-
-
-    /**
      * TODO Never actually seen this event fired, and documentation is tough to find
      * @private
      * @inner
      */
     function onLoseCapture( tracker, event ) {
         //$.console.log('losecapture ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
-        event = $.getEvent( event );
 
         var gPoint = {
             id: $.MouseTracker.mousePointerId,
@@ -2160,364 +2082,6 @@
 
         updatePointerCaptured( tracker, gPoint, false );
 
-        if ( eventInfo.stopPropagation ) {
-            $.stopEvent( event );
-        }
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function onMouseEnter( tracker, event ) {
-        //$.console.log('mouseenter ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
-
-        event = $.getEvent( event );
-
-        var gPoint = {
-            id: $.MouseTracker.mousePointerId,
-            type: 'mouse',
-            isPrimary: true,
-            currentPos: getMouseAbsolute( event ),
-            currentTime: $.now()
-        };
-
-        // pointerenter doesn't bubble and is not cancelable, but we call
-        //   preProcessEvent() so it's dispatched to preProcessEventHandler
-        //   if necessary
-        var eventInfo = {
-            originalEvent: event,
-            eventType: 'pointerenter',
-            pointerType: gPoint.type,
-            isEmulated: false
-        };
-        preProcessEvent( tracker, eventInfo );
-
-        updatePointerEnter( tracker, eventInfo, gPoint );
-
-        // Simulate mouseover on IE < 9
-        if ( !$.MouseTracker.havePointerOverOut ) {
-            handleMouseOver( tracker, event, true );
-        }
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function onMouseLeave( tracker, event ) {
-        //$.console.log('mouseleave ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
-
-        event = $.getEvent( event );
-
-        var gPoint = {
-            id: $.MouseTracker.mousePointerId,
-            type: 'mouse',
-            isPrimary: true,
-            currentPos: getMouseAbsolute( event ),
-            currentTime: $.now()
-        };
-
-        // pointerleave doesn't bubble and is not cancelable, but we call
-        //   preProcessEvent() so it's dispatched to preProcessEventHandler
-        //   if necessary
-        var eventInfo = {
-            originalEvent: event,
-            eventType: 'pointerleave',
-            pointerType: gPoint.type,
-            isEmulated: false
-        };
-        preProcessEvent( tracker, eventInfo );
-
-        // Simulate mouseoout on IE < 9
-        if ( !$.MouseTracker.havePointerOverOut ) {
-            handleMouseOut( tracker, event, true );
-        }
-
-        updatePointerLeave( tracker, eventInfo, gPoint );
-    }
-
-
-    /**
-     * IE9+ only
-     *
-     * @private
-     * @inner
-     */
-    function onMouseOver( tracker, event ) {
-        //$.console.log('mouseover ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
-
-        handleMouseOver( tracker, event, false );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handleMouseOver( tracker, event, isEmulated ) {
-        var gPoint = {
-            id: $.MouseTracker.mousePointerId,
-            type: 'mouse',
-            isPrimary: true,
-            currentPos: getMouseAbsolute( event ),
-            currentTime: $.now()
-        };
-
-        var eventInfo = {
-            originalEvent: event,
-            eventType: 'pointerover',
-            pointerType: gPoint.type,
-            isEmulated: isEmulated
-        };
-        preProcessEvent( tracker, eventInfo );
-
-        updatePointerOver( tracker, eventInfo, gPoint );
-
-        if ( !isEmulated ) {
-            if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
-                $.cancelEvent( event );
-            }
-            if ( eventInfo.stopPropagation ) {
-                $.stopEvent( event );
-            }
-        }
-    }
-
-
-    /**
-     * IE9+ only
-     *
-     * @private
-     * @inner
-     */
-    function onMouseOut( tracker, event ) {
-        //$.console.log('mouseout ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
-
-        handleMouseOut( tracker, event, false );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handleMouseOut( tracker, event, isEmulated ) {
-        var gPoint = {
-            id: $.MouseTracker.mousePointerId,
-            type: 'mouse',
-            isPrimary: true,
-            currentPos: getMouseAbsolute( event ),
-            currentTime: $.now()
-        };
-
-        var eventInfo = {
-            originalEvent: event,
-            eventType: 'pointerout',
-            pointerType: gPoint.type,
-            isEmulated: isEmulated
-        };
-        preProcessEvent( tracker, eventInfo );
-
-        updatePointerOut( tracker, eventInfo, gPoint );
-
-        if ( !isEmulated ) {
-            if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
-                $.cancelEvent( event );
-            }
-            if ( eventInfo.stopPropagation ) {
-                $.stopEvent( event );
-            }
-        }
-    }
-
-
-    /**
-     * Returns a W3C DOM level 3 standard button value given an event.button property:
-     *   -1 == none, 0 == primary/left, 1 == middle, 2 == secondary/right, 3 == X1/back, 4 == X2/forward, 5 == eraser (pen)
-     * @private
-     * @inner
-     */
-    function getStandardizedButton( button ) {
-        if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
-            // On IE 8, 0 == none, 1 == left, 2 == right, 3 == left and right, 4 == middle, 5 == left and middle, 6 == right and middle, 7 == all three
-            // TODO: Support chorded (multiple) button presses on IE 8?
-            if ( button === 1 ) {
-                return 0;
-            } else if ( button === 2 ) {
-                return 2;
-            } else if ( button === 4 ) {
-                return 1;
-            } else {
-                return -1;
-            }
-        } else {
-            return button;
-        }
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function onMouseDown( tracker, event ) {
-        var gPoint;
-
-        event = $.getEvent( event );
-
-        //$.console.log('onMouseDown ' + (tracker.userData ? tracker.userData.toString() : ''));
-
-        gPoint = {
-            id: $.MouseTracker.mousePointerId,
-            type: 'mouse',
-            isPrimary: true,
-            currentPos: getMouseAbsolute( event ),
-            currentTime: $.now()
-        };
-
-        var eventInfo = {
-            originalEvent: event,
-            eventType: 'pointerdown',
-            pointerType: gPoint.type,
-            isEmulated: false
-        };
-        preProcessEvent( tracker, eventInfo );
-
-        updatePointerDown( tracker, eventInfo, gPoint, getStandardizedButton( event.button ) );
-
-        if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
-            $.cancelEvent( event );
-        }
-        if ( eventInfo.stopPropagation ) {
-            $.stopEvent( event );
-        }
-        if ( eventInfo.shouldCapture ) {
-           //$.stopEvent( event );
-           //$.console.log('mousedown calling capturePointer() ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
-           capturePointer( tracker, gPoint );
-        }
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function onMouseUp( tracker, event ) {
-        handleMouseUp( tracker, event );
-    }
-
-    /**
-     * This handler is attached to the window object (on the capture phase) to emulate mouse capture.
-     * onMouseUp is still attached to the tracked element, so stop propagation to avoid processing twice.
-     *
-     * @private
-     * @inner
-     */
-    function onMouseUpCaptured( tracker, event ) {
-        handleMouseUp( tracker, event );
-        $.stopEvent( event );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handleMouseUp( tracker, event ) {
-        var gPoint;
-
-        event = $.getEvent( event );
-
-        //$.console.log('onMouseUp ' + (tracker.userData ? tracker.userData.toString() : ''));
-
-        gPoint = {
-            id: $.MouseTracker.mousePointerId,
-            type: 'mouse',
-            isPrimary: true,
-            currentPos: getMouseAbsolute( event ),
-            currentTime: $.now()
-        };
-
-        var eventInfo = {
-            originalEvent: event,
-            eventType: 'pointerup',
-            pointerType: gPoint.type,
-            isEmulated: false
-        };
-        preProcessEvent( tracker, eventInfo );
-
-        updatePointerUp( tracker, eventInfo, gPoint, getStandardizedButton( event.button ) );
-
-        if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
-            $.cancelEvent( event );
-        }
-        if ( eventInfo.stopPropagation ) {
-            $.stopEvent( event );
-        }
-
-        if ( eventInfo.shouldReleaseCapture ) {
-           //$.stopEvent( event );
-           releasePointer( tracker, gPoint );
-        }
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function onMouseMove( tracker, event ) {
-        handleMouseMove( tracker, event );
-   }
-
-
-    /**
-     * This handler is attached to the window object (on the capture phase) to emulate mouse capture.
-     * onMouseMove is still attached to the tracked element, so stop propagation to avoid processing twice.
-     *
-     * @private
-     * @inner
-     */
-    function onMouseMoveCaptured( tracker, event ) {
-        handleMouseMove( tracker, event );
-        $.stopEvent( event );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handleMouseMove( tracker, event ) {
-        var gPoint;
-
-        event = $.getEvent( event );
-
-        gPoint = {
-            id: $.MouseTracker.mousePointerId,
-            type: 'mouse',
-            isPrimary: true,
-            currentPos: getMouseAbsolute( event ),
-            currentTime: $.now()
-        };
-
-        var eventInfo = {
-            originalEvent: event,
-            eventType: 'pointermove',
-            pointerType: gPoint.type,
-            isEmulated: false
-        };
-        preProcessEvent( tracker, eventInfo );
-
-        updatePointerMove( tracker, eventInfo, gPoint );
-
-        if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
-            $.cancelEvent( event );
-        }
         if ( eventInfo.stopPropagation ) {
             $.stopEvent( event );
         }
@@ -2783,27 +2347,20 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
     function onPointerEnter( tracker, event ) {
-        handlePointerEnter( tracker, event, false );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handlePointerEnter( tracker, event, isEmulated ) {
         var gPoint;
 
         //$.console.log('pointerenter ' + (tracker.userData ? tracker.userData.toString() : ''));
 
         gPoint = {
-            id: event.pointerId,
+            id: getPointerId( event ),
             type: getPointerType( event ),
-            isPrimary: event.isPrimary,
+            isPrimary: getIsPrimary( event ),
             currentPos: getMouseAbsolute( event ),
             currentTime: $.now()
         };
@@ -2815,7 +2372,7 @@
             originalEvent: event,
             eventType: 'pointerenter',
             pointerType: gPoint.type,
-            isEmulated: isEmulated
+            isEmulated: false
         };
         preProcessEvent( tracker, eventInfo );
 
@@ -2824,27 +2381,20 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
     function onPointerLeave( tracker, event ) {
-        handlePointerLeave( tracker, event, false );
-    }
-
-
-    /**
-     * @private
-     * @inner
-     */
-    function handlePointerLeave( tracker, event, isEmulated ) {
         var gPoint;
 
         //$.console.log('pointerleave ' + (tracker.userData ? tracker.userData.toString() : ''));
 
         gPoint = {
-            id: event.pointerId,
+            id: getPointerId( event ),
             type: getPointerType( event ),
-            isPrimary: event.isPrimary,
+            isPrimary: getIsPrimary( event ),
             currentPos: getMouseAbsolute( event ),
             currentTime: $.now()
         };
@@ -2856,7 +2406,7 @@
             originalEvent: event,
             eventType: 'pointerleave',
             pointerType: gPoint.type,
-            isEmulated: isEmulated
+            isEmulated: false
         };
         preProcessEvent( tracker, eventInfo );
 
@@ -2865,6 +2415,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
@@ -2872,9 +2424,9 @@
         //$.console.log('pointerover ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
 
         var gPoint = {
-            id: event.pointerId,
+            id: getPointerId( event ),
             type: getPointerType( event ),
-            isPrimary: event.isPrimary,
+            isPrimary: getIsPrimary( event ),
             currentPos: getMouseAbsolute( event ),
             currentTime: $.now()
         };
@@ -2886,13 +2438,6 @@
             isEmulated: false
         };
         preProcessEvent( tracker, eventInfo );
-
-        // If on IE 10, simulate MSPointerEnter
-        if ( !$.MouseTracker.unprefixedPointerEvents &&
-            event.currentTarget !== event.relatedTarget &&
-            !isParentChild( event.currentTarget, event.relatedTarget ) ) {
-            handlePointerEnter( tracker, event, true );
-        }
 
         updatePointerOver( tracker, eventInfo, gPoint );
 
@@ -2906,6 +2451,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
@@ -2913,9 +2460,9 @@
         //$.console.log('pointerout ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
 
         var gPoint = {
-            id: event.pointerId,
+            id: getPointerId( event ),
             type: getPointerType( event ),
-            isPrimary: event.isPrimary,
+            isPrimary: getIsPrimary( event ),
             currentPos: getMouseAbsolute( event ),
             currentTime: $.now()
         };
@@ -2930,13 +2477,6 @@
 
         updatePointerOut( tracker, eventInfo, gPoint );
 
-        // If on IE 10, simulate MSPointerLeave
-        if ( !$.MouseTracker.unprefixedPointerEvents &&
-                event.currentTarget !== event.relatedTarget &&
-                !isParentChild( event.currentTarget, event.relatedTarget ) ) {
-            handlePointerLeave( tracker, event, true );
-        }
-
         if ( eventInfo.preventDefault && !eventInfo.defaultPrevented ) {
             $.cancelEvent( event );
         }
@@ -2947,6 +2487,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
@@ -2959,9 +2501,9 @@
         // Most browsers implicitly capture touch pointer events
         // Note no IE versions have element.hasPointerCapture() so no implicit
         //    pointer capture possible
-        var implicitlyCaptured = (tracker.element.hasPointerCapture &&
-                                 $.Browser.vendor !== $.BROWSERS.IE &&
-                                 $.MouseTracker.unprefixedPointerEvents) ?
+        var implicitlyCaptured = ($.MouseTracker.havePointerEvents &&
+                                 tracker.element.hasPointerCapture &&
+                                 $.Browser.vendor !== $.BROWSERS.IE) ?
                         tracker.element.hasPointerCapture(event.pointerId) : false;
         // if (implicitlyCaptured) {
         //     $.console.log('pointerdown implicitlyCaptured ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
@@ -2970,9 +2512,9 @@
         // }
 
         gPoint = {
-            id: event.pointerId,
+            id: getPointerId( event ),
             type: getPointerType( event ),
-            isPrimary: event.isPrimary,
+            isPrimary: getIsPrimary( event ),
             currentPos: getMouseAbsolute( event ),
             currentTime: $.now()
         };
@@ -3004,6 +2546,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
@@ -3013,6 +2557,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * This handler is attached to the window object (on the capture phase) to emulate mouse capture.
      * onPointerUp is still attached to the tracked element, so stop propagation to avoid processing twice.
      *
@@ -3029,6 +2575,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
@@ -3038,9 +2586,9 @@
         //$.console.log('onPointerUp ' + (tracker.userData ? tracker.userData.toString() : ''));
 
         gPoint = {
-            id: event.pointerId,
+            id: getPointerId( event ),
             type: getPointerType( event ),
-            isPrimary: event.isPrimary,
+            isPrimary: getIsPrimary( event ),
             currentPos: getMouseAbsolute( event ),
             currentTime: $.now()
         };
@@ -3073,6 +2621,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
@@ -3082,6 +2632,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * This handler is attached to the window object (on the capture phase) to emulate mouse capture.
      * onPointerMove is still attached to the tracked element, so stop propagation to avoid processing twice.
      *
@@ -3098,6 +2650,8 @@
 
 
     /**
+     * Note: Called for both pointer events and legacy mouse events!
+     *
      * @private
      * @inner
      */
@@ -3106,9 +2660,9 @@
         var gPoint;
 
         gPoint = {
-            id: event.pointerId,
+            id: getPointerId( event ),
             type: getPointerType( event ),
-            isPrimary: event.isPrimary,
+            isPrimary: getIsPrimary( event ),
             currentPos: getMouseAbsolute( event ),
             currentTime: $.now()
         };
@@ -3608,46 +3162,24 @@
         if ( typeof eventInfo.originalEvent.buttons !== 'undefined' ) {
             pointsList.buttons = eventInfo.originalEvent.buttons;
         } else {
-            if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
-                if ( buttonChanged === 0 ) {
-                    // Primary
-                    pointsList.buttons += 1;
-                } else if ( buttonChanged === 1 ) {
-                    // Aux
-                    pointsList.buttons += 4;
-                } else if ( buttonChanged === 2 ) {
-                    // Secondary
-                    pointsList.buttons += 2;
-                } else if ( buttonChanged === 3 ) {
-                    // X1 (Back)
-                    pointsList.buttons += 8;
-                } else if ( buttonChanged === 4 ) {
-                    // X2 (Forward)
-                    pointsList.buttons += 16;
-                } else if ( buttonChanged === 5 ) {
-                    // Pen Eraser
-                    pointsList.buttons += 32;
-                }
-            } else {
-                if ( buttonChanged === 0 ) {
-                    // Primary
-                    pointsList.buttons |= 1;
-                } else if ( buttonChanged === 1 ) {
-                    // Aux
-                    pointsList.buttons |= 4;
-                } else if ( buttonChanged === 2 ) {
-                    // Secondary
-                    pointsList.buttons |= 2;
-                } else if ( buttonChanged === 3 ) {
-                    // X1 (Back)
-                    pointsList.buttons |= 8;
-                } else if ( buttonChanged === 4 ) {
-                    // X2 (Forward)
-                    pointsList.buttons |= 16;
-                } else if ( buttonChanged === 5 ) {
-                    // Pen Eraser
-                    pointsList.buttons |= 32;
-                }
+            if ( buttonChanged === 0 ) {
+                // Primary
+                pointsList.buttons |= 1;
+            } else if ( buttonChanged === 1 ) {
+                // Aux
+                pointsList.buttons |= 4;
+            } else if ( buttonChanged === 2 ) {
+                // Secondary
+                pointsList.buttons |= 2;
+            } else if ( buttonChanged === 3 ) {
+                // X1 (Back)
+                pointsList.buttons |= 8;
+            } else if ( buttonChanged === 4 ) {
+                // X2 (Forward)
+                pointsList.buttons |= 16;
+            } else if ( buttonChanged === 5 ) {
+                // Pen Eraser
+                pointsList.buttons |= 32;
             }
         }
 
@@ -3773,46 +3305,24 @@
         if ( typeof eventInfo.originalEvent.buttons !== 'undefined' ) {
             pointsList.buttons = eventInfo.originalEvent.buttons;
         } else {
-            if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
-                if ( buttonChanged === 0 ) {
-                    // Primary
-                    pointsList.buttons -= 1;
-                } else if ( buttonChanged === 1 ) {
-                    // Aux
-                    pointsList.buttons -= 4;
-                } else if ( buttonChanged === 2 ) {
-                    // Secondary
-                    pointsList.buttons -= 2;
-                } else if ( buttonChanged === 3 ) {
-                    // X1 (Back)
-                    pointsList.buttons -= 8;
-                } else if ( buttonChanged === 4 ) {
-                    // X2 (Forward)
-                    pointsList.buttons -= 16;
-                } else if ( buttonChanged === 5 ) {
-                    // Pen Eraser
-                    pointsList.buttons -= 32;
-                }
-            } else {
-                if ( buttonChanged === 0 ) {
-                    // Primary
-                    pointsList.buttons ^= ~1;
-                } else if ( buttonChanged === 1 ) {
-                    // Aux
-                    pointsList.buttons ^= ~4;
-                } else if ( buttonChanged === 2 ) {
-                    // Secondary
-                    pointsList.buttons ^= ~2;
-                } else if ( buttonChanged === 3 ) {
-                    // X1 (Back)
-                    pointsList.buttons ^= ~8;
-                } else if ( buttonChanged === 4 ) {
-                    // X2 (Forward)
-                    pointsList.buttons ^= ~16;
-                } else if ( buttonChanged === 5 ) {
-                    // Pen Eraser
-                    pointsList.buttons ^= ~32;
-                }
+            if ( buttonChanged === 0 ) {
+                // Primary
+                pointsList.buttons ^= ~1;
+            } else if ( buttonChanged === 1 ) {
+                // Aux
+                pointsList.buttons ^= ~4;
+            } else if ( buttonChanged === 2 ) {
+                // Secondary
+                pointsList.buttons ^= ~2;
+            } else if ( buttonChanged === 3 ) {
+                // X1 (Back)
+                pointsList.buttons ^= ~8;
+            } else if ( buttonChanged === 4 ) {
+                // X2 (Forward)
+                pointsList.buttons ^= ~16;
+            } else if ( buttonChanged === 5 ) {
+                // Pen Eraser
+                pointsList.buttons ^= ~32;
             }
         }
 

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1620,12 +1620,18 @@
 
         if ( $.MouseTracker.havePointerCapture ) {
             if ( $.MouseTracker.havePointerEvents ) {
-                if ( $.MouseTracker.unprefixedPointerEvents ) {
-                    tracker.element.setPointerCapture( gPoint.id );
-                    //$.console.log('element.setPointerCapture() called');
-                } else {
-                    tracker.element.msSetPointerCapture( gPoint.id );
-                    //$.console.log('element.msSetPointerCapture() called');
+                // Can throw InvalidPointerId
+                //   (should never happen for setPointerCapture so we'll log a warning)
+                try {
+                    if ( $.MouseTracker.unprefixedPointerEvents ) {
+                        tracker.element.setPointerCapture( gPoint.id );
+                        //$.console.log('element.setPointerCapture() called');
+                    } else {
+                        tracker.element.msSetPointerCapture( gPoint.id );
+                        //$.console.log('element.msSetPointerCapture() called');
+                    }
+                } catch ( e ) {
+                    $.console.warn('setPointerCapture() called on invalid pointer ID');
                 }
             } else {
                 tracker.element.setCapture( true );
@@ -1674,12 +1680,19 @@
 
         if ( $.MouseTracker.havePointerCapture ) {
             if ( $.MouseTracker.havePointerEvents ) {
-                if ( $.MouseTracker.unprefixedPointerEvents ) {
-                    tracker.element.releasePointerCapture( gPoint.id );
-                    //$.console.log('element.releasePointerCapture() called');
-                } else {
-                    tracker.element.msReleasePointerCapture( gPoint.id );
-                    //$.console.log('element.msReleasePointerCapture() called');
+                // Can throw InvalidPointerId
+                //   (can happen depending on browser event timing (Firefox touch)
+                //   so we won't log a warning)
+                try {
+                    if ( $.MouseTracker.unprefixedPointerEvents ) {
+                        tracker.element.releasePointerCapture( gPoint.id );
+                        //$.console.log('element.releasePointerCapture() called');
+                    } else {
+                        tracker.element.msReleasePointerCapture( gPoint.id );
+                        //$.console.log('element.msReleasePointerCapture() called');
+                    }
+                } catch ( e ) {
+                    /* eslint-disable no-empty */
                 }
             } else {
                 tracker.element.releaseCapture();

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2069,7 +2069,7 @@
      * @inner
      */
     function onLoseCapture( tracker, event ) {
-        $.console.log('losecapture ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
+        //$.console.log('losecapture ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
         event = $.getEvent( event );
 
         var gPoint = {
@@ -2518,7 +2518,8 @@
             gPoint = {
                 id: event.changedTouches[ i ].identifier,
                 type: 'touch',
-                // isPrimary not set - let the updatePointers functions determine it
+                // Simulate isPrimary
+                isPrimary: pointsList.getLength() === 0,
                 currentPos: getMouseAbsolute( event.changedTouches[ i ] ),
                 currentTime: time
             };
@@ -2566,7 +2567,6 @@
             gPoint = {
                 id: event.changedTouches[ i ].identifier,
                 type: 'touch',
-                // isPrimary not set - let the updatePointers functions determine it
                 currentPos: getMouseAbsolute( event.changedTouches[ i ] ),
                 currentTime: time
             };
@@ -2612,7 +2612,6 @@
             gPoint = {
                 id: event.changedTouches[ i ].identifier,
                 type: 'touch',
-                // isPrimary not set - let the updatePointers functions determine it
                 currentPos: getMouseAbsolute( event.changedTouches[ i ] ),
                 currentTime: time
             };
@@ -2705,8 +2704,6 @@
 
         if ( event.target === tracker.element ) {
             //$.console.log('gotpointercapture ' + (tracker.userData ? tracker.userData.toString() : ''));
-            ////$.cancelEvent( event ); not cancelable!
-            //$.stopEvent( event );
             updatePointerCaptured( tracker, {
                 id: event.pointerId,
                 type: getPointerType( event )
@@ -2736,8 +2733,6 @@
 
         if ( event.target === tracker.element ) {
             //$.console.log('lostpointercapture ' + (tracker.userData ? tracker.userData.toString() : ''));
-            ////$.cancelEvent( event ); not cancelable!
-            //$.stopEvent( event );
             updatePointerCaptured( tracker, {
                 id: event.pointerId,
                 type: getPointerType( event )
@@ -2923,7 +2918,6 @@
 
         //$.console.log('onPointerDown ' + (tracker.userData ? tracker.userData.toString() : ''));
         // $.console.log('onPointerDown ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + event.target.tagName);
-        // event.target.style.background = '#F0F';
 
         // Most browsers implicitly capture touch pointer events
         // Note no IE versions have element.hasPointerCapture() so no implicit
@@ -2963,17 +2957,12 @@
             $.stopEvent( event );
         }
         if ( eventInfo.shouldCapture && !implicitlyCaptured ) {
-           //$.stopEvent( event );
            //$.console.log('pointerdown calling capturePointer() ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
            capturePointer( tracker, gPoint );
         } else if ( !eventInfo.shouldCapture && implicitlyCaptured ) {
-           //$.stopEvent( event );
            //$.console.log('pointerdown calling releasePointer() ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.target === tracker.element ? 'tracker.element' : ''));
            releasePointer( tracker, gPoint ); //TODO should we do this? Investigate when implementing bubble handling
         }
-        // else if ( eventInfo.shouldCapture && implicitlyCaptured ) {
-        //     //$.stopEvent( event );
-        // }
     }
 
 
@@ -3111,7 +3100,7 @@
      * @inner
      */
     function onPointerCancel( tracker, event ) {
-        //$.console.log('pointercancel ' + (tracker.userData ? tracker.userData.toString() : '') + ' ' + (event.isPrimary ? 'isPrimary' : ''));
+        //$.console.log('pointercancel ' + (tracker.userData ? tracker.userData.toString() : ''));
 
         var gPoint = {
             id: event.pointerId,
@@ -3150,16 +3139,6 @@
      * @returns {Number} Number of gesture points in pointsList.
      */
     function startTrackingPointer( pointsList, gPoint ) {
-
-        // If isPrimary is not known for the pointer then set it according to our rules:
-        //    true if the first pointer in the gesture, otherwise false
-        if ( !Object.prototype.hasOwnProperty.call( gPoint, 'isPrimary' ) ) {
-            if ( pointsList.getLength() === 0 ) {
-                gPoint.isPrimary = true;
-            } else {
-                gPoint.isPrimary = false;
-            }
-        }
         gPoint.speed = 0;
         gPoint.direction = 0;
         gPoint.contactPos = gPoint.currentPos;
@@ -3195,18 +3174,6 @@
             }
 
             listLength = pointsList.removeById( gPoint.id );
-
-            //TODO Browsers don't re-assign primary pointers so this is probably incorrect
-            // // If isPrimary is not known for the pointer and we just removed the primary pointer from the list then we need to set another pointer as primary
-            // if ( !Object.prototype.hasOwnProperty.call( gPoint, 'isPrimary' ) ) {
-            //     primaryPoint = pointsList.getPrimary();
-            //     if ( !primaryPoint ) {
-            //         primaryPoint = pointsList.getByIndex( 0 );
-            //         if ( primaryPoint ) {
-            //             primaryPoint.isPrimary = true;
-            //         }
-            //     }
-            // }
         } else {
             listLength = pointsList.getLength();
         }
@@ -4047,9 +4014,6 @@
 
         if ( updateGPoint ) {
             // Already tracking the pointer...update it
-            if ( Object.prototype.hasOwnProperty.call( gPoint, 'isPrimary' ) ) {
-                updateGPoint.isPrimary = gPoint.isPrimary;
-            }
             updateGPoint.lastPos = updateGPoint.currentPos;
             updateGPoint.lastTime = updateGPoint.currentTime;
             updateGPoint.currentPos = gPoint.currentPos;
@@ -4198,10 +4162,6 @@
         if ( updateGPoint ) {
             stopTrackingPointer( tracker, pointsList, updateGPoint );
         }
-        //else {
-        //    // should never get here?
-        //    $.console.warn('updatePointerCancel(): pointercancel on untracked gPoint');
-        //}
     }
 
 

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -4218,10 +4218,11 @@
 
         if ( updateGPoint ) {
             stopTrackingPointer( pointsList, updateGPoint );
-        } else {
-            // should never get here?
-            $.console.warn('updatePointerUp(): pointerup on untracked gPoint');
         }
+        //else {
+        //    // should never get here?
+        //    $.console.warn('updatePointerCancel(): pointercancel on untracked gPoint');
+        //}
     }
 
 

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1621,7 +1621,7 @@
         if ( $.MouseTracker.havePointerCapture ) {
             if ( $.MouseTracker.havePointerEvents ) {
                 // Can throw InvalidPointerId
-                //   (should never happen for setPointerCapture so we'll log a warning)
+                //   (should never happen so we'll log a warning)
                 try {
                     if ( $.MouseTracker.unprefixedPointerEvents ) {
                         tracker.element.setPointerCapture( gPoint.id );
@@ -1677,12 +1677,18 @@
      */
     function releasePointer( tracker, gPoint ) {
         var eventParams;
+        var pointsList;
+        var cachedGPoint;
 
         if ( $.MouseTracker.havePointerCapture ) {
             if ( $.MouseTracker.havePointerEvents ) {
+                pointsList = tracker.getActivePointersListByType( gPoint.type );
+                cachedGPoint = pointsList.getById( gPoint.id );
+                if ( !cachedGPoint || !cachedGPoint.captured ) {
+                    return;
+                }
                 // Can throw InvalidPointerId
-                //   (can happen depending on browser event timing (Firefox touch)
-                //   so we won't log a warning)
+                //   (should never happen so we'll log a warning)
                 try {
                     if ( $.MouseTracker.unprefixedPointerEvents ) {
                         tracker.element.releasePointerCapture( gPoint.id );
@@ -1692,7 +1698,7 @@
                         //$.console.log('element.msReleasePointerCapture() called');
                     }
                 } catch ( e ) {
-                    /* eslint-disable no-empty */
+                    $.console.warn('releasePointerCapture() called on invalid pointer ID');
                 }
             } else {
                 tracker.element.releaseCapture();

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -3240,8 +3240,8 @@
             case 'contextmenu':
                 eventInfo.isStopable = true;
                 eventInfo.isCancelable = true;
-                eventInfo.preventDefault = tracker.hasContextMenuHandler;
-                eventInfo.preventGesture = !tracker.hasContextMenuHandler;
+                eventInfo.preventDefault = false;//tracker.hasContextMenuHandler;
+                eventInfo.preventGesture = true;//!tracker.hasContextMenuHandler;
                 eventInfo.stopPropagation = false;
                 break;
             case 'pointerenter':

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1214,9 +1214,10 @@
      * @property {String} pointerType
      *     "mouse", "touch", "pen", etc.
      * @property {Boolean} isEmulated
-     *      True if this is an emulated event. If true, originalEvent is the event that caused
-     *      the emulated event or null if no DOM event applies. Emulated events
-     *      can occur on eventType "wheel".
+     *      True if this is an emulated event. If true, originalEvent is either the event that caused
+     *      the emulated event, a synthetic event object created with values from the actual DOM event,
+     *      or null if no DOM event applies. Emulated events can occur on eventType "wheel" on legacy mouse-scroll
+     *      event emitting user agents.
      * @property {Boolean} isStopable
      *      True if propagation of the event (e.g. bubbling) can be stopped with stopPropagation/stopImmediatePropagation.
      * @property {Boolean} isCancelable

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -349,27 +349,6 @@
             return this;
         },
 
-        // //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-        // //   like the issue this code attempts to fix.
-        // /**
-        //  * Returns the {@link OpenSeadragon.MouseTracker.GesturePointList|GesturePointList} for all but the given pointer device type.
-        //  * @function
-        //  * @param {String} type - The pointer device type: "mouse", "touch", "pen", etc.
-        //  * @returns {Array.<OpenSeadragon.MouseTracker.GesturePointList>}
-        //  */
-        // getActivePointersListsExceptType: function ( type ) {
-        //     var delegate = THIS[ this.hash ];
-        //     var listArray = [];
-
-        //     for (var i = 0; i < delegate.activePointersLists.length; ++i) {
-        //         if (delegate.activePointersLists[i].type !== type) {
-        //             listArray.push(delegate.activePointersLists[i]);
-        //         }
-        //     }
-
-        //     return listArray;
-        // },
-
         /**
          * Returns the {@link OpenSeadragon.MouseTracker.GesturePointList|GesturePointList} for the given pointer device type,
          * creating and caching a new {@link OpenSeadragon.MouseTracker.GesturePointList|GesturePointList} if one doesn't already exist for the type.
@@ -1064,24 +1043,6 @@
             return false;
         }
     }
-
-    //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-    //   like the issue this code attempts to fix.
-    // /**
-    //  * Resets all active mousetrakers. (Added to patch issue #697 "Mouse up outside map will cause "canvas-drag" event to stick")
-    //  *
-    //  * @private
-    //  * @member resetAllMouseTrackers
-    //  * @memberof OpenSeadragon.MouseTracker
-    //  */
-    // $.MouseTracker.resetAllMouseTrackers = function(){
-    //     for(var i = 0; i < MOUSETRACKERS.length; i++){
-    //         if (MOUSETRACKERS[i].isTracking()){
-    //             MOUSETRACKERS[i].setTracking(false);
-    //             MOUSETRACKERS[i].setTracking(true);
-    //         }
-    //     }
-    // };
 
     /**
      * Provides continuous computation of velocity (speed and direction) of active pointers.
@@ -2529,36 +2490,6 @@
     }
 
 
-    //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-    //   like the issue this code attempts to fix.
-    // /**
-    //  * @private
-    //  * @inner
-    //  */
-    // function abortContacts( tracker, event, pointsList ) {
-    //     var i,
-    //         gPointCount = pointsList.getLength(),
-    //         abortGPoints = [];
-
-    //     // Check contact count for hoverable pointer types before aborting
-    //     if (pointsList.type === 'touch' || pointsList.contacts > 0) {
-    //         for ( i = 0; i < gPointCount; i++ ) {
-    //             abortGPoints.push( pointsList.getByIndex( i ) );
-    //         }
-
-    //         if ( abortGPoints.length > 0 ) {
-    //             // simulate touchend/mouseup
-    //             updatePointerUp( tracker, eventInfo, , 0 ); // 0 means primary button press/release or touch contact
-    //             // release pointer capture
-    //             pointsList.captureCount = 1;
-    //             //releasePointer( tracker, pointsList.type );
-    //             // simulate touchleave/mouseout
-    //             updatePointerLeave( tracker, eventInfo,  );
-    //         }
-    //     }
-    // }
-
-
     /**
      * @private
      * @inner
@@ -2574,12 +2505,6 @@
 
         //$.console.log('touchstart ' + (tracker.userData ? tracker.userData.toString() : ''));
 
-        //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-        //   like the issue this code attempts to fix.
-        // if ( pointsList.getLength() > event.touches.length - touchCount ) {
-        //     $.console.warn('Tracked touch contact count doesn\'t match event.touches.length. Removing all tracked touch pointers.');
-        //     abortContacts( tracker, event, pointsList );
-        // }
         if ( pointsList.getLength() > event.touches.length - touchCount ) {
             $.console.warn('Tracked touch contact count doesn\'t match event.touches.length');
         }
@@ -3678,16 +3603,6 @@
             }
         }
 
-        //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-        //   like the issue this code attempts to fix.
-        // // Some pointers may steal control from another pointer without firing the appropriate release events
-        // // e.g. Touching a screen while click-dragging with certain mice.
-        // var otherPointsLists = tracker.getActivePointersListsExceptType(gPoint.type);
-        // for (i = 0; i < otherPointsLists.length; i++) {
-        //     //If another pointer has contact, simulate the release
-        //     abortContacts(tracker, event, otherPointsLists[i]); // No-op if no active pointer
-        // }
-
         // Only capture and track primary button, pen, and touch contacts
         if ( buttonChanged !== 0 ) {
             eventInfo.shouldCapture = false;
@@ -3880,26 +3795,8 @@
                 );
             }
 
-            //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-            //   like the issue this code attempts to fix.
-            // // A primary mouse button may have been released while the non-primary button was down
-            // var otherPointsList = tracker.getActivePointersListByType("mouse");
-            // // Stop tracking the mouse; see https://github.com/openseadragon/openseadragon/pull/1223
-            // abortContacts(tracker, event, otherPointsList); // No-op if no active pointer
-
             return;
         }
-
-        //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-        //   like the issue this code attempts to fix.
-        // GitHub PR: https://github.com/openseadragon/openseadragon/pull/1754
-        // // OS-specific gestures (e.g. swipe up with four fingers in iPadOS 13)
-        // if (typeof gPoint.currentPos === "undefined") {
-        //     $.console.log('typeof gPoint.currentPos === "undefined" ' + (tracker.userData ? tracker.userData.toString() : ''));
-        //     abortContacts(tracker, event, pointsList);
-
-        //     return false;
-        // }
 
         updateGPoint = pointsList.getById( gPoint.id );
 

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -175,7 +175,7 @@
         this.preProcessEventHandler   = options.preProcessEventHandler   || null;
         this.enterHandler             = options.enterHandler             || null;
         this.leaveHandler             = options.leaveHandler             || null;
-        this.exitHandler              = options.exitHandler              || null; // Deprecated v2.4.3
+        this.exitHandler              = options.exitHandler              || null; // Deprecated v2.5.0
         this.overHandler              = options.overHandler              || null;
         this.outHandler               = options.outHandler               || null;
         this.pressHandler             = options.pressHandler             || null;
@@ -449,7 +449,7 @@
          * Implement or assign implementation to these handlers during or after
          * calling the constructor.
          * @function
-         * @since v2.4.3
+         * @since v2.5.0
          * @param {Object} event
          * @param {OpenSeadragon.MouseTracker} event.eventSource
          *      A reference to the tracker instance.
@@ -480,7 +480,7 @@
          * Implement or assign implementation to these handlers during or after
          * calling the constructor.
          * @function
-         * @deprecated v2.4.3 Use leaveHandler instead
+         * @deprecated v2.5.0 Use leaveHandler instead
          * @param {Object} event
          * @param {OpenSeadragon.MouseTracker} event.eventSource
          *      A reference to the tracker instance.
@@ -513,7 +513,7 @@
          * Implement or assign implementation to these handlers during or after
          * calling the constructor.
          * @function
-         * @since v2.4.3
+         * @since v2.5.0
          * @param {Object} event
          * @param {OpenSeadragon.MouseTracker} event.eventSource
          *      A reference to the tracker instance.
@@ -546,7 +546,7 @@
          * Implement or assign implementation to these handlers during or after
          * calling the constructor.
          * @function
-         * @since v2.4.3
+         * @since v2.5.0
          * @param {Object} event
          * @param {OpenSeadragon.MouseTracker} event.eventSource
          *      A reference to the tracker instance.
@@ -1252,6 +1252,7 @@
      *
      * @typedef {Object} EventProcessInfo
      * @memberof OpenSeadragon.MouseTracker
+     * @since v2.5.0
      *
      * @property {OpenSeadragon.MouseTracker} eventSource
      *      A reference to the tracker instance.

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -294,6 +294,10 @@
         this.hasScrollHandler = !!this.scrollHandler;
         this.hasContextMenuHandler = !!this.contextMenuHandler;
 
+        if (this.exitHandler) {
+            $.console.error("MouseTracker.exitHandler is deprecated. Use MouseTracker.leaveHandler instead.");
+        }
+
         if ( !options.startDisabled ) {
             this.setTracking( true );
         }
@@ -3417,7 +3421,7 @@
         }
 
         // Leave (doesn't bubble and not cancelable)
-        //   Note: exitHandler is deprecated, replaced by leaveHandler
+        //   Note: exitHandler is deprecated (v2.5.0), replaced by leaveHandler
         if ( tracker.leaveHandler || tracker.exitHandler ) {
             dispatchEventObj = {
                 eventSource:          tracker,

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -167,12 +167,16 @@ $.Navigator = function( options ){
         style.zIndex        = 999999999;
         style.cursor        = 'default';
     }( this.displayRegion.style, this.borderWidth ));
+    $.setElementPointerEventsNone( this.displayRegion );
+    $.setElementTouchActionNone( this.displayRegion );
 
     this.displayRegionContainer = $.makeNeutralElement("div");
     this.displayRegionContainer.id = this.element.id + '-displayregioncontainer';
     this.displayRegionContainer.className = "displayregioncontainer";
     this.displayRegionContainer.style.width = "100%";
     this.displayRegionContainer.style.height = "100%";
+    $.setElementPointerEventsNone( this.displayRegionContainer );
+    $.setElementTouchActionNone( this.displayRegionContainer );
 
     viewer.addControl(
         this.element,
@@ -222,12 +226,21 @@ $.Navigator = function( options ){
     this.innerTracker.destroy();
     this.innerTracker = new $.MouseTracker({
         userData:        'Navigator.innerTracker',
-        element:         this.element,
+        element:         this.element, //this.canvas,
         dragHandler:     $.delegate( this, onCanvasDrag ),
         clickHandler:    $.delegate( this, onCanvasClick ),
         releaseHandler:  $.delegate( this, onCanvasRelease ),
         scrollHandler:   $.delegate( this, onCanvasScroll )
     });
+    this.outerTracker.userData = 'Navigator.outerTracker';
+
+    // this.innerTracker is attached to this.element...we need to allow pointer
+    //   events to pass through this Viewer's canvas/container elements so implicit
+    //   pointer capture works on touch devices
+    //TODO an alternative is to attach the new MouseTracker to this.canvas...not
+    //   sure why it isn't already (see MouseTracker constructor call above)
+    $.setElementPointerEventsNone( this.canvas );
+    $.setElementPointerEventsNone( this.container );
 
     this.addHandler("reset-size", function() {
         if (_this.viewport) {

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -540,7 +540,7 @@ function onCanvasDrag( event ) {
      * @property {Boolean} shift - True if the shift key was pressed during this event.
      * @property {Object} originalEvent - The original DOM event.
      * @property {?Object} userData - Arbitrary subscriber-defined object.
-     * @property {Boolean} preventDefaultAction - Set to true to prevent default click to zoom behaviour. Default: false.
+     * @property {Boolean} preventDefaultAction - Set to true to prevent default drag to pan behaviour. Default: false.
      */
      this.viewer.raiseEvent('navigator-drag', canvasDragEventArgs);
 

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -221,6 +221,7 @@ $.Navigator = function( options ){
     // Remove the base class' (Viewer's) innerTracker and replace it with our own
     this.innerTracker.destroy();
     this.innerTracker = new $.MouseTracker({
+        userData:        'Navigator.innerTracker',
         element:         this.element,
         dragHandler:     $.delegate( this, onCanvasDrag ),
         clickHandler:    $.delegate( this, onCanvasClick ),

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1950,6 +1950,19 @@ function OpenSeadragon( options ){
 
 
         /**
+         * Sets the specified element's pointer-events style attribute to 'none'.
+         * @function
+         * @param {Element|String} element
+         */
+        setElementPointerEventsNone: function( element ) {
+            element = $.getElement( element );
+            if ( typeof element.style.pointerEvents !== 'undefined' ) {
+                element.style.pointerEvents = 'none';
+            }
+        },
+
+
+        /**
          * Add the specified CSS class to the element if not present.
          * @function
          * @param {Element|String} element

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -918,7 +918,7 @@ function OpenSeadragon( options ){
     };
 
     /**
-     * True if the browser supports the EventTarget.removeEventListener() method
+     * True if the browser supports the EventTarget.addEventListener() method
      * @member {Boolean} supportsAddEventListener
      * @memberof OpenSeadragon
      */
@@ -2087,9 +2087,6 @@ function OpenSeadragon( options ){
          * @param {Boolean} [options.passive]
          * @param {Boolean} [options.once]
          */
-        // undefined - false or {capture: false}
-        // bool - bool or (capture: bool}
-        // obje - obje.capture or obje
         addEvent: (function () {
             if ( $.supportsAddEventListener ) {
                 return function ( element, eventName, handler, options ) {

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -381,7 +381,11 @@
   *     The "zoom distance" per mouse scroll or touch pinch. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the mouse-wheel zoom feature (also see gestureSettings[Mouse|Touch|Pen].scrollToZoom}).</em>
   *
   * @property {Number} [zoomPerSecond=1.0]
-  *     The number of seconds to animate a single zoom event over.
+  *     Sets the zoom amount per second when zoomIn/zoomOut buttons are pressed and held.
+  *     The value is a factor of the current zoom, so 1.0 (the default) disables zooming when the zoomIn/zoomOut buttons
+  *     are held. Higher values will increase the rate of zoom when the zoomIn/zoomOut buttons are held. Note that values
+  *     < 1.0 will reverse the operation of the zoomIn/zoomOut buttons (zoomIn button will decrease the zoom, zoomOut will
+  *     increase the zoom).
   *
   * @property {Boolean} [showNavigator=false]
   *     Set to true to make the navigator minimap appear.

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2048,7 +2048,7 @@ function OpenSeadragon( options ){
         },
 
         /**
-         * COnvert passed addEventListener() options to boolean or options object,
+         * Convert passed addEventListener() options to boolean or options object,
          * depending on browser support.
          * @function
          * @param {Boolean|Object} [options] Boolean useCapture, or if [supportsEventListenerOptions]{@link OpenSeadragon.supportsEventListenerOptions}, can be an object

--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -120,11 +120,12 @@ $.ReferenceStrip = function ( options ) {
 
     this.viewer = viewer;
     this.innerTracker = new $.MouseTracker( {
+        userData:       'ReferenceStrip.innerTracker',
         element:        this.element,
         dragHandler:    $.delegate( this, onStripDrag ),
         scrollHandler:  $.delegate( this, onStripScroll ),
         enterHandler:   $.delegate( this, onStripEnter ),
-        exitHandler:    $.delegate( this, onStripExit ),
+        leaveHandler:   $.delegate( this, onStripLeave ),
         keyDownHandler: $.delegate( this, onKeyDown ),
         keyHandler:     $.delegate( this, onKeyPress )
     } );
@@ -196,6 +197,7 @@ $.ReferenceStrip = function ( options ) {
         $.setElementTouchActionNone( element );
 
         element.innerTracker = new $.MouseTracker( {
+            userData:           'ReferenceStrip.TileSource.innerTracker',
             element:            element,
             clickTimeThreshold: this.clickTimeThreshold,
             clickDistThreshold: this.clickDistThreshold,
@@ -475,7 +477,8 @@ function loadPanels( strip, viewerSize, scroll ) {
 
             // TODO: What is this for? Future keyboard navigation support?
             miniViewer.displayRegion.innerTracker = new $.MouseTracker( {
-                element: miniViewer.displayRegion,
+                userData:     'ReferenceStrip.miniViewer.innerTracker',
+                element:       miniViewer.displayRegion,
                 startDisabled: true
             } );
 
@@ -524,7 +527,7 @@ function onStripEnter( event ) {
  * @inner
  * @function
  */
-function onStripExit( event ) {
+function onStripLeave( event ) {
     var element = event.eventSource.element;
 
     if ( 'horizontal' === this.scroll ) {

--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -85,14 +85,7 @@ $.ReferenceStrip = function ( options ) {
         scroll:     $.DEFAULT_SETTINGS.referenceStripScroll,
         clickTimeThreshold:  $.DEFAULT_SETTINGS.clickTimeThreshold
     }, options, {
-        //required overrides
-        element:                this.element,
-        //These need to be overridden to prevent recursion since
-        //the navigator is a viewer and a viewer has a navigator
-        showNavigator:          false,
-        mouseNavEnabled:        false,
-        showNavigationControl:  false,
-        showSequenceControl:    false
+        element:                this.element
     } );
 
     $.extend( this, options );
@@ -119,9 +112,10 @@ $.ReferenceStrip = function ( options ) {
     $.setElementOpacity( this.element, 0.8 );
 
     this.viewer = viewer;
-    this.innerTracker = new $.MouseTracker( {
-        userData:       'ReferenceStrip.innerTracker',
+    this.tracker = new $.MouseTracker( {
+        userData:       'ReferenceStrip.tracker',
         element:        this.element,
+        clickHandler:   $.delegate( this, onStripClick ),
         dragHandler:    $.delegate( this, onStripDrag ),
         scrollHandler:  $.delegate( this, onStripScroll ),
         enterHandler:   $.delegate( this, onStripEnter ),
@@ -190,35 +184,12 @@ $.ReferenceStrip = function ( options ) {
         element.style.width         = _this.panelWidth + 'px';
         element.style.height        = _this.panelHeight + 'px';
         element.style.display       = 'inline';
-        element.style.float         = 'left'; //Webkit
+        element.style['float']      = 'left'; //Webkit
         element.style.cssFloat      = 'left'; //Firefox
         element.style.styleFloat    = 'left'; //IE
         element.style.padding       = '2px';
         $.setElementTouchActionNone( element );
-
-        element.innerTracker = new $.MouseTracker( {
-            userData:           'ReferenceStrip.TileSource.innerTracker',
-            element:            element,
-            clickTimeThreshold: this.clickTimeThreshold,
-            clickDistThreshold: this.clickDistThreshold,
-            pressHandler: function ( event ) {
-                event.eventSource.dragging = $.now();
-            },
-            releaseHandler: function ( event ) {
-                var tracker = event.eventSource,
-                    id      = tracker.element.id,
-                    page    = Number( id.split( '-' )[2] ),
-                    now     = $.now();
-
-                if ( event.insideElementPressed &&
-                     event.insideElementReleased &&
-                     tracker.dragging &&
-                     ( now - tracker.dragging ) < tracker.clickTimeThreshold ) {
-                    tracker.dragging = null;
-                    viewer.goToPage( page );
-                }
-            }
-        } );
+        $.setElementPointerEventsNone( element );
 
         this.element.appendChild( element );
 
@@ -232,7 +203,8 @@ $.ReferenceStrip = function ( options ) {
 
 };
 
-$.extend( $.ReferenceStrip.prototype, $.EventSource.prototype, $.Viewer.prototype, /** @lends OpenSeadragon.ReferenceStrip.prototype */{
+/** @lends OpenSeadragon.ReferenceStrip.prototype */
+$.ReferenceStrip.prototype = {
 
     /**
      * @function
@@ -279,7 +251,7 @@ $.extend( $.ReferenceStrip.prototype, $.EventSource.prototype, $.Viewer.prototyp
             }
 
             this.currentPage = page;
-            onStripEnter.call( this, { eventSource: this.innerTracker } );
+            onStripEnter.call( this, { eventSource: this.tracker } );
         }
     },
 
@@ -294,7 +266,6 @@ $.extend( $.ReferenceStrip.prototype, $.EventSource.prototype, $.Viewer.prototyp
         return false;
     },
 
-    // Overrides Viewer.destroy
     destroy: function() {
         if (this.miniViewers) {
           for (var key in this.miniViewers) {
@@ -302,14 +273,34 @@ $.extend( $.ReferenceStrip.prototype, $.EventSource.prototype, $.Viewer.prototyp
           }
         }
 
+        this.tracker.destroy();
+
         if (this.element) {
             this.element.parentNode.removeChild(this.element);
         }
     }
 
-} );
+};
 
 
+/**
+ * @private
+ * @inner
+ * @function
+ */
+function onStripClick( event ) {
+    if ( event.quick ) {
+        var page;
+
+        if ( 'horizontal' === this.scroll ) {
+            page = Math.floor(event.position.x / this.panelWidth);
+        } else {
+            page = Math.floor(event.position.y / this.panelHeight);
+        }
+
+        this.viewer.goToPage( page );
+    }
+}
 
 
 /**
@@ -319,13 +310,14 @@ $.extend( $.ReferenceStrip.prototype, $.EventSource.prototype, $.Viewer.prototyp
  */
 function onStripDrag( event ) {
 
-    var offsetLeft   = Number( this.element.style.marginLeft.replace( 'px', '' ) ),
+    this.dragging = true;
+    if ( this.element ) {
+        var offsetLeft   = Number( this.element.style.marginLeft.replace( 'px', '' ) ),
         offsetTop    = Number( this.element.style.marginTop.replace( 'px', '' ) ),
         scrollWidth  = Number( this.element.style.width.replace( 'px', '' ) ),
         scrollHeight = Number( this.element.style.height.replace( 'px', '' ) ),
         viewerSize   = $.getElementSize( this.viewer.canvas );
-    this.dragging = true;
-    if ( this.element ) {
+
         if ( 'horizontal' === this.scroll ) {
             if ( -event.delta.x > 0 ) {
                 //forward
@@ -368,12 +360,13 @@ function onStripDrag( event ) {
  * @function
  */
 function onStripScroll( event ) {
-    var offsetLeft   = Number( this.element.style.marginLeft.replace( 'px', '' ) ),
+    if ( this.element ) {
+        var offsetLeft   = Number( this.element.style.marginLeft.replace( 'px', '' ) ),
         offsetTop    = Number( this.element.style.marginTop.replace( 'px', '' ) ),
         scrollWidth  = Number( this.element.style.width.replace( 'px', '' ) ),
         scrollHeight = Number( this.element.style.height.replace( 'px', '' ) ),
         viewerSize   = $.getElementSize( this.viewer.canvas );
-    if ( this.element ) {
+
         if ( 'horizontal' === this.scroll ) {
             if ( event.scroll > 0 ) {
                 //forward
@@ -414,7 +407,6 @@ function loadPanels( strip, viewerSize, scroll ) {
         activePanelsStart,
         activePanelsEnd,
         miniViewer,
-        style,
         i,
         element;
     if ( 'horizontal' === strip.scroll ) {
@@ -456,35 +448,14 @@ function loadPanels( strip, viewerSize, scroll ) {
                 ajaxHeaders:            strip.viewer.ajaxHeaders,
                 useCanvas:              strip.useCanvas
             } );
-
-            miniViewer.displayRegion           = $.makeNeutralElement( "div" );
-            miniViewer.displayRegion.id        = element.id + '-displayregion';
-            miniViewer.displayRegion.className = 'displayregion';
-
-            style               = miniViewer.displayRegion.style;
-            style.position      = 'relative';
-            style.top           = '0px';
-            style.left          = '0px';
-            style.fontSize      = '0px';
-            style.overflow      = 'hidden';
-            style.float         = 'left'; //Webkit
-            style.cssFloat      = 'left'; //Firefox
-            style.styleFloat    = 'left'; //IE
-            style.zIndex        = 999999999;
-            style.cursor        = 'default';
-            style.width         = ( strip.panelWidth - 4 ) + 'px';
-            style.height        = ( strip.panelHeight - 4 ) + 'px';
-
-            // TODO: What is this for? Future keyboard navigation support?
-            miniViewer.displayRegion.innerTracker = new $.MouseTracker( {
-                userData:     'ReferenceStrip.miniViewer.innerTracker',
-                element:       miniViewer.displayRegion,
-                startDisabled: true
-            } );
-
-            element.getElementsByTagName( 'div' )[0].appendChild(
-                miniViewer.displayRegion
-            );
+            // Allow pointer events to pass through miniViewer's canvas/container
+            //   elements so implicit pointer capture works on touch devices
+            $.setElementPointerEventsNone( miniViewer.canvas );
+            $.setElementPointerEventsNone( miniViewer.container );
+            // We'll use event delegation from the reference strip element instead of
+            //   handling events on every miniViewer
+            miniViewer.innerTracker.setTracking( false );
+            miniViewer.outerTracker.setTracking( false );
 
             strip.miniViewers[element.id] = miniViewer;
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -267,6 +267,7 @@ $.Viewer = function( options ) {
         style.top       = "0px";
         style.textAlign = "left";  // needed to protect against
     }( this.container.style ));
+    $.setElementTouchActionNone( this.container );
 
     this.container.insertBefore( this.canvas, this.container.firstChild );
     this.element.appendChild( this.container );
@@ -405,6 +406,8 @@ $.Viewer = function( options ) {
 
     // Overlay container
     this.overlaysContainer    = $.makeNeutralElement( "div" );
+    $.setElementPointerEventsNone( this.overlaysContainer );
+    $.setElementTouchActionNone( this.overlaysContainer );
     this.canvas.appendChild( this.overlaysContainer );
 
     // Now that we have a drawer, see if it supports rotate. If not we need to remove the rotate buttons

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -288,6 +288,7 @@ $.Viewer = function( options ) {
         clickDistThreshold:       this.clickDistThreshold,
         dblClickTimeThreshold:    this.dblClickTimeThreshold,
         dblClickDistThreshold:    this.dblClickDistThreshold,
+        contextMenuHandler:       $.delegate( this, onCanvasContextMenu ),
         keyDownHandler:           $.delegate( this, onCanvasKeyDown ),
         keyHandler:               $.delegate( this, onCanvasKeyPress ),
         clickHandler:             $.delegate( this, onCanvasClick ),
@@ -2536,6 +2537,26 @@ function onFocus(){
 function onBlur(){
     beginControlsAutoHide( this );
 
+}
+
+function onCanvasContextMenu( event ) {
+    /**
+     * Raised when a contextmenu event occurs in the {@link OpenSeadragon.Viewer#canvas} element.
+     *
+     * @event canvas-contextmenu
+     * @memberof OpenSeadragon.Viewer
+     * @type {object}
+     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+     * @property {Object} originalEvent - The original DOM event.
+     * @property {?Object} userData - Arbitrary subscriber-defined object.
+     */
+    this.raiseEvent( 'canvas-contextmenu', {
+        tracker: event.eventSource,
+        position: event.position,
+        originalEvent: event.originalEvent
+    });
 }
 
 function onCanvasKeyDown( event ) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2956,13 +2956,6 @@ function onCanvasEnter( event ) {
 }
 
 function onCanvasLeave( event ) {
-
-    //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
-    //   like the issue this code attempts to fix.
-    // if (window.location !== window.parent.location){
-    //     $.MouseTracker.resetAllMouseTrackers();
-    // }
-
     /**
      * Raised when a pointer leaves the {@link OpenSeadragon.Viewer#canvas} element.
      *

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2783,7 +2783,6 @@ function onCanvasDrag( event ) {
     var gestureSettings;
 
     var canvasDragEventArgs = {
-        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,
@@ -2892,7 +2891,6 @@ function onCanvasDragEnd( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent('canvas-drag-end', {
-        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,
@@ -2922,7 +2920,6 @@ function onCanvasEnter( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'canvas-enter', {
-        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,
@@ -2958,7 +2955,6 @@ function onCanvasLeave( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'canvas-exit', {
-        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,
@@ -3130,7 +3126,6 @@ function onCanvasPinch( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent('canvas-pinch', {
-        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         gesturePoints: event.gesturePoints,
@@ -3231,7 +3226,6 @@ function onContainerEnter( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'container-enter', {
-        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,
@@ -3268,7 +3262,6 @@ function onContainerLeave( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'container-exit', {
-        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2783,7 +2783,9 @@ function onCanvasDrag( event ) {
     var gestureSettings;
 
     var canvasDragEventArgs = {
+        eventSource: this,
         tracker: event.eventSource,
+        pointerType: event.pointerType,
         position: event.position,
         delta: event.delta,
         speed: event.speed,
@@ -2801,6 +2803,7 @@ function onCanvasDrag( event ) {
      * @type {object}
      * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
      * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+     * @property {String} pointerType - "mouse", "touch", "pen", etc.
      * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
      * @property {OpenSeadragon.Point} delta - The x,y components of the difference between start drag and end drag.
      * @property {Number} speed - Current computed speed, in pixels per second.
@@ -2880,6 +2883,7 @@ function onCanvasDragEnd( event ) {
      * @type {object}
      * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
      * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+     * @property {String} pointerType - "mouse", "touch", "pen", etc.
      * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
      * @property {Number} speed - Speed at the end of a drag gesture, in pixels per second.
      * @property {Number} direction - Direction at the end of a drag gesture, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
@@ -2888,7 +2892,9 @@ function onCanvasDragEnd( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent('canvas-drag-end', {
+        eventSource: this,
         tracker: event.eventSource,
+        pointerType: event.pointerType,
         position: event.position,
         speed: event.speed,
         direction: event.direction,
@@ -2916,6 +2922,7 @@ function onCanvasEnter( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'canvas-enter', {
+        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,
@@ -2951,6 +2958,7 @@ function onCanvasLeave( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'canvas-exit', {
+        eventSource: this,
         tracker: event.eventSource,
         pointerType: event.pointerType,
         position: event.position,
@@ -3111,6 +3119,7 @@ function onCanvasPinch( event ) {
      * @type {object}
      * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
      * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+     * @property {String} pointerType - "mouse", "touch", "pen", etc.
      * @property {Array.<OpenSeadragon.MouseTracker.GesturePoint>} gesturePoints - Gesture points associated with the gesture. Velocity data can be found here.
      * @property {OpenSeadragon.Point} lastCenter - The previous center point of the two pinch contact points relative to the tracked element.
      * @property {OpenSeadragon.Point} center - The center point of the two pinch contact points relative to the tracked element.
@@ -3121,7 +3130,9 @@ function onCanvasPinch( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent('canvas-pinch', {
+        eventSource: this,
         tracker: event.eventSource,
+        pointerType: event.pointerType,
         gesturePoints: event.gesturePoints,
         lastCenter: event.lastCenter,
         center: event.center,
@@ -3210,6 +3221,7 @@ function onContainerEnter( event ) {
      * @type {object}
      * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
      * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+     * @property {String} pointerType - "mouse", "touch", "pen", etc.
      * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
      * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
      * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
@@ -3219,7 +3231,9 @@ function onContainerEnter( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'container-enter', {
+        eventSource: this,
         tracker: event.eventSource,
+        pointerType: event.pointerType,
         position: event.position,
         buttons: event.buttons,
         pointers: event.pointers,
@@ -3244,6 +3258,7 @@ function onContainerLeave( event ) {
      * @type {object}
      * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
      * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+     * @property {String} pointerType - "mouse", "touch", "pen", etc.
      * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
      * @property {Number} buttons - Current buttons pressed. A combination of bit flags 0: none, 1: primary (or touch contact), 2: secondary, 4: aux (often middle), 8: X1 (often back), 16: X2 (often forward), 32: pen eraser.
      * @property {Number} pointers - Number of pointers (all types) active in the tracked element.
@@ -3253,7 +3268,9 @@ function onContainerLeave( event ) {
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'container-exit', {
+        eventSource: this,
         tracker: event.eventSource,
+        pointerType: event.pointerType,
         position: event.position,
         buttons: event.buttons,
         pointers: event.pointers,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2933,9 +2933,11 @@ function onCanvasEnter( event ) {
 
 function onCanvasLeave( event ) {
 
-    if (window.location !== window.parent.location){
-        $.MouseTracker.resetAllMouseTrackers();
-    }
+    //TODO Revisit this if there's still an issue. The PointerEvent model should have no problems
+    //   like the issue this code attempts to fix.
+    // if (window.location !== window.parent.location){
+    //     $.MouseTracker.resetAllMouseTrackers();
+    // }
 
     /**
      * Raised when a pointer leaves the {@link OpenSeadragon.Viewer#canvas} element.

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2812,7 +2812,7 @@ function onCanvasDrag( event ) {
      * @property {Number} direction - Current computed direction, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
      * @property {Boolean} shift - True if the shift key was pressed during this event.
      * @property {Object} originalEvent - The original DOM event.
-     * @property {Boolean} preventDefaultAction - Set to true to prevent default drag behaviour. Default: false.
+     * @property {Boolean} preventDefaultAction - Set to true to prevent default drag to pan behaviour. Default: false.
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
     this.raiseEvent( 'canvas-drag', canvasDragEventArgs);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -280,6 +280,7 @@ $.Viewer = function( options ) {
     this.docOverflow    = document.documentElement.style.overflow;
 
     this.innerTracker = new $.MouseTracker({
+        userData:                 'Viewer.innerTracker',
         element:                  this.canvas,
         startDisabled:            !this.mouseNavEnabled,
         clickTimeThreshold:       this.clickTimeThreshold,
@@ -293,7 +294,7 @@ $.Viewer = function( options ) {
         dragHandler:              $.delegate( this, onCanvasDrag ),
         dragEndHandler:           $.delegate( this, onCanvasDragEnd ),
         enterHandler:             $.delegate( this, onCanvasEnter ),
-        exitHandler:              $.delegate( this, onCanvasExit ),
+        leaveHandler:             $.delegate( this, onCanvasLeave ),
         pressHandler:             $.delegate( this, onCanvasPress ),
         releaseHandler:           $.delegate( this, onCanvasRelease ),
         nonPrimaryPressHandler:   $.delegate( this, onCanvasNonPrimaryPress ),
@@ -303,6 +304,7 @@ $.Viewer = function( options ) {
     });
 
     this.outerTracker = new $.MouseTracker({
+        userData:              'Viewer.outerTracker',
         element:               this.container,
         startDisabled:         !this.mouseNavEnabled,
         clickTimeThreshold:    this.clickTimeThreshold,
@@ -310,7 +312,7 @@ $.Viewer = function( options ) {
         dblClickTimeThreshold: this.dblClickTimeThreshold,
         dblClickDistThreshold: this.dblClickDistThreshold,
         enterHandler:          $.delegate( this, onContainerEnter ),
-        exitHandler:           $.delegate( this, onContainerExit )
+        leaveHandler:          $.delegate( this, onContainerLeave )
     });
 
     if( this.toolbar ){
@@ -1099,7 +1101,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             THIS[ this.hash ].fullPage = false;
 
             // mouse will likely be outside now
-            $.delegate( this, onContainerExit )( { } );
+            $.delegate( this, onContainerLeave )( { } );
 
         }
 
@@ -2925,7 +2927,7 @@ function onCanvasEnter( event ) {
     });
 }
 
-function onCanvasExit( event ) {
+function onCanvasLeave( event ) {
 
     if (window.location !== window.parent.location){
         $.MouseTracker.resetAllMouseTrackers();
@@ -3227,7 +3229,7 @@ function onContainerEnter( event ) {
     });
 }
 
-function onContainerExit( event ) {
+function onContainerLeave( event ) {
     if ( event.pointers < 1 ) {
         THIS[ this.hash ].mouseInside = false;
         if ( !THIS[ this.hash ].animating ) {
@@ -3483,7 +3485,7 @@ function doSingleZoomOut() {
 
 function lightUp() {
     this.buttons.emulateEnter();
-    this.buttons.emulateExit();
+    this.buttons.emulateLeave();
 }
 
 
@@ -3503,7 +3505,7 @@ function onFullScreen() {
     }
     // correct for no mouseout event on change
     if ( this.buttons ) {
-        this.buttons.emulateExit();
+        this.buttons.emulateLeave();
     }
     this.fullPageButton.element.focus();
     if ( this.viewport ) {

--- a/test/helpers/legacy.mouse.shim.js
+++ b/test/helpers/legacy.mouse.shim.js
@@ -12,12 +12,12 @@
     }
 
     $.MouseTracker.havePointerEvents = false;
-    if ( $.Browser.vendor === $.BROWSERS.IE && $.Browser.version < 9 ) {
-        $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave" );
-        $.MouseTracker.haveMouseEnter = true;
-    } else {
+    $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave" );
+    if ( $.Browser.vendor !== $.BROWSERS.IE || $.Browser.version > 8 ) {
         $.MouseTracker.subscribeEvents.push( "mouseover", "mouseout" );
-        $.MouseTracker.haveMouseEnter = false;
+        $.MouseTracker.haveMouseOver = true;
+    } else {
+        $.MouseTracker.haveMouseOver = false;
     }
     $.MouseTracker.subscribeEvents.push( "mousedown", "mouseup", "mousemove" );
     if ( 'ontouchstart' in window ) {

--- a/test/helpers/legacy.mouse.shim.js
+++ b/test/helpers/legacy.mouse.shim.js
@@ -12,6 +12,7 @@
     }
 
     $.MouseTracker.havePointerEvents = false;
+    $.MouseTracker.unprefixedPointerEvents = true;
     $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave" );
     if ( $.Browser.vendor !== $.BROWSERS.IE || $.Browser.version > 8 ) {
         $.MouseTracker.subscribeEvents.push( "mouseover", "mouseout" );
@@ -20,6 +21,15 @@
         $.MouseTracker.havePointerOverOut = false;
     }
     $.MouseTracker.subscribeEvents.push( "mousedown", "mouseup", "mousemove" );
+    $.MouseTracker.mousePointerId = "legacy-mouse";
+    // Legacy mouse events capture support (IE/Firefox only?)
+    $.MouseTracker.havePointerCapture = (function () {
+        var divElement = document.createElement( 'div' );
+        return $.isFunction( divElement.setCapture ) && $.isFunction( divElement.releaseCapture );
+    }());
+    if ( $.MouseTracker.havePointerCapture ) {
+        $.MouseTracker.subscribeEvents.push( "losecapture" );
+    }
     if ( 'ontouchstart' in window ) {
         // iOS, Android, and other W3c Touch Event implementations
         //    (see http://www.w3.org/TR/touch-events/)
@@ -32,6 +42,5 @@
         //   Subscribe to these to prevent default gesture handling
         $.MouseTracker.subscribeEvents.push( "gesturestart", "gesturechange" );
     }
-    $.MouseTracker.mousePointerId = "legacy-mouse";
 
 }(OpenSeadragon));

--- a/test/helpers/legacy.mouse.shim.js
+++ b/test/helpers/legacy.mouse.shim.js
@@ -15,9 +15,9 @@
     $.MouseTracker.subscribeEvents.push( "mouseenter", "mouseleave" );
     if ( $.Browser.vendor !== $.BROWSERS.IE || $.Browser.version > 8 ) {
         $.MouseTracker.subscribeEvents.push( "mouseover", "mouseout" );
-        $.MouseTracker.haveMouseOver = true;
+        $.MouseTracker.havePointerOverOut = true;
     } else {
-        $.MouseTracker.haveMouseOver = false;
+        $.MouseTracker.havePointerOverOut = false;
     }
     $.MouseTracker.subscribeEvents.push( "mousedown", "mouseup", "mousemove" );
     if ( 'ontouchstart' in window ) {
@@ -33,7 +33,5 @@
         $.MouseTracker.subscribeEvents.push( "gesturestart", "gesturechange" );
     }
     $.MouseTracker.mousePointerId = "legacy-mouse";
-    $.MouseTracker.maxTouchPoints = 10;
-
 
 }(OpenSeadragon));

--- a/test/helpers/test.js
+++ b/test/helpers/test.js
@@ -37,7 +37,7 @@
             };
 
             $canvas
-                .simulate( OpenSeadragon.MouseTracker.haveMouseEnter ? 'mouseenter' : 'mouseover', event )
+                .simulate( 'mouseenter', event )
                 .simulate( 'mousedown', event );
             for ( var i = 0; i < args.dragCount; i++ ) {
                 event.clientX += args.dragDx;
@@ -47,7 +47,7 @@
             }
             $canvas
                 .simulate( 'mouseup', event )
-                .simulate( OpenSeadragon.MouseTracker.haveMouseEnter ? 'mouseleave' : 'mouseout', event );
+                .simulate( 'mouseleave', event );
         },
 
         // ----------

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -32,7 +32,7 @@
             offset = $canvas.offset(),
             tracker = viewer.innerTracker,
             origEnterHandler,
-            origExitHandler,
+            origLeaveHandler,
             origPressHandler,
             origReleaseHandler,
             origNonPrimaryPressHandler,
@@ -43,7 +43,7 @@
             origDragHandler,
             origDragEndHandler,
             enterCount,
-            exitCount,
+            leaveCount,
             pressCount,
             releaseCount,
             rightPressCount,
@@ -71,11 +71,11 @@
                     return true;
                 }
             };
-            origExitHandler = tracker.exitHandler;
-            tracker.exitHandler = function ( event ) {
-                exitCount++;
-                if (origExitHandler) {
-                    return origExitHandler( event );
+            origLeaveHandler = tracker.leaveHandler;
+            tracker.leaveHandler = function ( event ) {
+                leaveCount++;
+                if (origLeaveHandler) {
+                    return origLeaveHandler( event );
                 } else {
                     return true;
                 }
@@ -182,7 +182,7 @@
 
         var unhookViewerHandlers = function () {
             tracker.enterHandler = origEnterHandler;
-            tracker.exitHandler = origExitHandler;
+            tracker.leaveHandler = origLeaveHandler;
             tracker.pressHandler = origPressHandler;
             tracker.releaseHandler = origReleaseHandler;
             tracker.moveHandler = origMoveHandler;
@@ -195,21 +195,21 @@
         var simulateEnter = function (x, y) {
             simEvent.clientX = offset.left + x;
             simEvent.clientY = offset.top  + y;
-            $canvas.simulate( OpenSeadragon.MouseTracker.haveMouseEnter ? 'mouseenter' : 'mouseover', simEvent );
+            $canvas.simulate( 'mouseenter', simEvent );
         };
 
         var simulateLeave = function (x, y) {
             simEvent.clientX = offset.left + x;
             simEvent.clientY = offset.top  + y;
             simEvent.relatedTarget = document.body;
-            $canvas.simulate( OpenSeadragon.MouseTracker.haveMouseEnter ? 'mouseleave' : 'mouseout', simEvent );
+            $canvas.simulate( 'mouseleave', simEvent );
         };
 
         //var simulateLeaveFrame = function (x, y) {
         //    simEvent.clientX = offset.left + x;
         //    simEvent.clientY = offset.top  + y;
         //    simEvent.relatedTarget = document.getElementsByTagName("html")[0];
-        //    $canvas.simulate( OpenSeadragon.MouseTracker.haveMouseEnter ? 'mouseleave' : 'mouseout', simEvent );
+        //    $canvas.simulate( 'mouseleave', simEvent );
         //};
 
         var simulateDown = function (x, y) {
@@ -256,7 +256,7 @@
                 clientY: offset.top
             };
             enterCount = 0;
-            exitCount = 0;
+            leaveCount = 0;
             pressCount = 0;
             releaseCount = 0;
             rightPressCount = 0;
@@ -280,8 +280,8 @@
             if ('enterCount' in expected) {
                 assert.equal( enterCount, expected.enterCount, expected.description + 'enterHandler event count matches expected (' + expected.enterCount + ')' );
             }
-            if ('exitCount' in expected) {
-                assert.equal( exitCount, expected.exitCount, expected.description + 'exitHandler event count matches expected (' + expected.exitCount + ')' );
+            if ('leaveCount' in expected) {
+                assert.equal( leaveCount, expected.leaveCount, expected.description + 'leaveHandler event count matches expected (' + expected.leaveCount + ')' );
             }
             if ('pressCount' in expected) {
                 assert.equal( pressCount, expected.pressCount, expected.description + 'pressHandler event count matches expected (' + expected.pressCount + ')' );
@@ -355,7 +355,7 @@
             assessGestureExpectations({
                 description:           'enter-move-release (release in tracked element, press in unknown element):  ',
                 enterCount:            1,
-                exitCount:             0,
+                leaveCount:            0,
                 pressCount:            0,
                 releaseCount:          1,
                 rightPressCount:       0,
@@ -375,16 +375,16 @@
             });
             simulateLeave(-1, -1); // flush tracked pointer
 
-            // enter-move-exit (fly-over)
+            // enter-move-leave (fly-over)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateMove(1, 1, 10);
             simulateMove(-1, -1, 10);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-move-exit (fly-over):  ',
+                description:           'enter-move-leave (fly-over):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            0,
                 releaseCount:          0,
                 rightPressCount:       0,
@@ -403,15 +403,15 @@
                 //quickClick:            false
             });
 
-            // move-exit (fly-over, no enter event)
+            // move-leave (fly-over, no enter event)
             resetForAssessment();
             simulateMove(1, 1, 10);
             simulateMove(-1, -1, 10);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'move-exit (fly-over, no enter event):  ',
+                description:           'move-leave (fly-over, no enter event):  ',
                 enterCount:            0,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            0,
                 releaseCount:          0,
                 rightPressCount:       0,
@@ -430,7 +430,7 @@
                 //quickClick:            false
             });
 
-            // enter-press-release-press-release-exit (primary/left double click)
+            // enter-press-release-press-release-leave (primary/left double click)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateDown(0, 0);
@@ -439,9 +439,9 @@
             simulateUp(0, 0);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-press-release-press-release-exit (primary/left double click):  ',
+                description:           'enter-press-release-press-release-leave (primary/left double click):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            2,
                 releaseCount:          2,
                 rightPressCount:       0,
@@ -460,16 +460,16 @@
                 //quickClick:            true
             });
 
-            // enter-press-release-exit (primary/left click)
+            // enter-press-release-leave (primary/left click)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateDown(0, 0);
             simulateUp(0, 0);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-press-release-exit (primary/left click):  ',
+                description:           'enter-press-release-leave (primary/left click):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            1,
                 releaseCount:          1,
                 rightPressCount:       0,
@@ -488,16 +488,16 @@
                 quickClick:            true
             });
 
-            // enter-nonprimarypress-nonprimaryrelease-exit (secondary/right click)
+            // enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateNonPrimaryDown(0, 0, 2);
             simulateNonPrimaryUp(0, 0, 2);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-nonprimarypress-nonprimaryrelease-exit (secondary/right click):  ',
+                description:           'enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            0,
                 releaseCount:          0,
                 rightPressCount:       1,
@@ -516,16 +516,16 @@
                 //quickClick:            true
             });
 
-            // enter-nonprimarypress-nonprimaryrelease-exit (aux/middle click)
+            // enter-nonprimarypress-nonprimaryrelease-leave (aux/middle click)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateNonPrimaryDown(0, 0, 1);
             simulateNonPrimaryUp(0, 0, 1);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-nonprimarypress-nonprimaryrelease-exit (aux/middle click):  ',
+                description:           'enter-nonprimarypress-nonprimaryrelease-leave (aux/middle click):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            0,
                 releaseCount:          0,
                 rightPressCount:       0,
@@ -544,7 +544,7 @@
                 //quickClick:            true
             });
 
-            // enter-nonprimarypress-move-nonprimaryrelease-move-exit (secondary/right button drag, release in tracked element)
+            // enter-nonprimarypress-move-nonprimaryrelease-move-leave (secondary/right button drag, release in tracked element)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateNonPrimaryDown(0, 0, 2);
@@ -553,9 +553,9 @@
             simulateMove(-1, -1, 100);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-nonprimarypress-move-nonprimaryrelease-move-exit (secondary/right button drag, release in tracked element):  ',
+                description:           'enter-nonprimarypress-move-nonprimaryrelease-move-leave (secondary/right button drag, release in tracked element):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            0,
                 releaseCount:          0,
                 rightPressCount:       1,
@@ -574,7 +574,7 @@
                 //quickClick:            false
             });
 
-            // enter-press-move-release-move-exit (drag, release in tracked element)
+            // enter-press-move-release-move-leave (drag, release in tracked element)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateDown(0, 0);
@@ -583,9 +583,9 @@
             simulateMove(-1, -1, 100);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-press-move-release-move-exit (drag, release in tracked element):  ',
+                description:           'enter-press-move-release-move-leave (drag, release in tracked element):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            1,
                 releaseCount:          1,
                 rightPressCount:       0,
@@ -604,7 +604,7 @@
                 quickClick:            false
             });
 
-            // enter-press-move-exit-move-release (drag, release outside tracked element)
+            // enter-press-move-leave-move-release (drag, release outside tracked element)
             resetForAssessment();
             simulateEnter(0, 0);
             simulateDown(0, 0);
@@ -614,9 +614,9 @@
             simulateMove(-1, -1, 5);
             simulateUp(-5, -5);
             assessGestureExpectations({
-                description:           'enter-press-move-exit-move-release (drag, release outside tracked element):  ',
+                description:           'enter-press-move-leave-move-release (drag, release outside tracked element):  ',
                 enterCount:            1,
-                exitCount:             1,
+                leaveCount:            1,
                 pressCount:            1,
                 releaseCount:          1,
                 rightPressCount:       0,
@@ -635,7 +635,7 @@
                 quickClick:            false
             });
 
-            //// enter-press-move-exit-move-release-outside (drag, release outside iframe)
+            //// enter-press-move-leave-move-release-outside (drag, release outside iframe)
             //resetForAssessment();
             //simulateEnter(0, 0);
             //simulateDown(0, 0);
@@ -644,9 +644,9 @@
             //simulateLeaveFrame(-1, -1);
             //// you don't actually receive the mouseup if you mouseup outside of the document
             //assessGestureExpectations({
-            //    description:           'enter-press-move-exit-move-release-outside (drag, release outside iframe):  ',
-            //    enterCount:            1,
-            //    exitCount:             1,
+            //    description:           'enter-press-move-leave-move-release-outside (drag, release outside iframe):  ',
+            //    enterCount:             1,
+            //    leaveCount:              1,
             //    pressCount:            1,
             //    releaseCount:          1,
             //    rightPressCount:       0,
@@ -953,7 +953,7 @@
                 dragEndHandler: onMouseTrackerDragEnd,
                 releaseHandler: onMouseTrackerRelease,
                 clickHandler: onMouseTrackerClick,
-                exitHandler: onMouseTrackerExit
+                leaveHandler: onMouseTrackerLeave
             } );
 
             var event = {
@@ -1050,7 +1050,7 @@
             checkOriginalEventReceived( event );
         };
 
-        var onMouseTrackerExit = function ( event ) {
+        var onMouseTrackerLeave = function ( event ) {
             checkOriginalEventReceived( event );
 
             mouseTracker.destroy();

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -452,7 +452,7 @@
                 clickCount:            2,
                 dblClickCount:         1,
                 dragCount:             0,
-                dragEndCount:          0,
+                dragEndCount:          2, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
                 insideElementPressed:  true,
                 insideElementReleased: true,
                 contacts:              0,
@@ -480,7 +480,7 @@
                 clickCount:            1,
                 dblClickCount:         0,
                 dragCount:             0,
-                dragEndCount:          0,
+                dragEndCount:          1, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
                 insideElementPressed:  true,
                 insideElementReleased: true,
                 contacts:              0,

--- a/test/modules/navigator.js
+++ b/test/modules/navigator.js
@@ -216,7 +216,7 @@
                 clientY: offset.top + locationY
             };
         $canvas
-            .simulate(OpenSeadragon.MouseTracker.haveMouseEnter ? 'mouseenter' : 'mouseover', event)
+            .simulate('mouseenter', event)
             .simulate('mousedown', event)
             .simulate('mouseup', event);
     };


### PR DESCRIPTION
## MouseTracker Overhaul 2020
Finally finishing up this major MouseTracker overhaul! This should fix many of the mouse/touch/pen device issues we've seen over the past several years! Also added improved capabilities for controlling event traversal through the DOM tree, and support for using OpenSeadragon viewers in iframe and shadow DOM should be much improved!

### Main Goals
* Use native pointer capture whenever available. This is less prone to issues and makes handling native events in shadow DOM and frames much simpler
* Add a hook handler for pre-processing native events and allowing finer-grained control over the disposition of the events (bubbling, default handling). This should make element layering above/below OpenSeadragon viewers much simpler
* Adjusting the rest of the library to use the new event processing properly, eliminating tweaks/hacks that were necessary before
* Properly maintain/clean up internal gesture tracking objects

### Change Log
* Improved browser sniffing - detect EDGE and CHROMEEDGE browsers
* Improved DOM event model feature detection
* Added support for options parameter on addEvent()/removeEvent (to support passive option) (#1669)
* Added OpenSeadragon.eventIsCanceled() function for defaultPrevented detection on DOM events
* MouseTracker: better PointerEvent model detection - removed use of deprecated window.navigator.pointerEnabled
* MouseTracker: added overHandler/outHandler options for handling corresponding pointerover/pointerout events
* MouseTracker: changed enterHandler/leaveHandler to use DOM pointerenter/pointerleave events instead of simulating using pointerover/pointerout
* All internal uses of MouseTracker use pointerenter/pointerleave events instead of pointerover/pointerout events for more consistent pointer tracking
* DEPRECATION: MouseTracker exitHandler deprecated for name change to leaveHandler for consistency with DOM event names
* Fixed bug in Button class where two MouseTracker event handlers used an invalid "this" causing issues in some browsers
* Added pointerType property to Viewer container-enter, container-exit, canvas-drag, canvas-drag-end, canvas-pinch events
* MouseTracker: Fire dragEndHandler event even if release point same as initial contact point (#1459)
* MouseTracker: Pointer capture implemented with capture APIs where available. Only fallback to emulated capture on extremely old browsers
* MouseTracker: Added preProcessEventHandler option to allow MouseTracker instances to control bubbling and default behavior of events on their associated element
* MouseTracker: Improved handling of canceled events (#1728)
* MouseTracker: Improved releasing of tracked pointers on destroy()/stopTracking() (#1346)
* Updated Viewer, Button, Drawer, Navigator, ReferenceStrip DOM for proper DOM event handling
* Added OpenSeadragon.setElementPointerEventsNone() for setting pointer-events:'none' on DOM elements
* MouseTracker: added contextMenuHandler option for handling contextmenu events
* Viewer: added a canvas-contextmenu event
* MouseTracker: Per #1863, dropped support for Internet Explorer < 11
