### PR TITLE
Feature/1778 Path cropping

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -202,6 +202,30 @@ $.Drawer.prototype = {
     },
 
     /**
+     * This function will create multiple polygon paths on the drawing context by provided polygons,
+     * then clip the context to the paths.
+     * @param {Path2D} - path objects to clip with.
+     * A path is a string represented in the Path Data notation.
+     * @param {Boolean} useSketch - Whether to use the sketch canvas or not.
+     * @see https://www.w3.org/TR/SVG/paths.html#PathData
+     */
+    clipWithPaths: function (paths, useSketch) {
+        if (!this.useCanvas) {
+            return;
+        }
+        var context = this._getContext(useSketch);
+        context.beginPath();
+        var path2Ds = paths.map(function (path) {
+            return new Path2D(path.getAttribute('d'));
+        });
+        var combinedPath = new Path2D();
+        path2Ds.forEach(function(path2D) {
+            combinedPath.addPath(path2D);
+        });
+        context.clip(combinedPath, "evenodd");
+    },
+
+    /**
      * Set the opacity of the drawer.
      * @param {Number} opacity
      * @return {OpenSeadragon.Drawer} Chainable.

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -207,9 +207,11 @@ $.Drawer.prototype = {
      * @param {Path2D} - path objects to clip with.
      * A path is a string represented in the Path Data notation.
      * @param {Boolean} useSketch - Whether to use the sketch canvas or not.
+     * @param {string} useRule - a string to determine the fill rule of the clipping. Available options
+     * are 'nonzero' and 'evenodd'. Default to 'evenodd'
      * @see https://www.w3.org/TR/SVG/paths.html#PathData
      */
-    clipWithPaths: function (paths, useSketch) {
+    clipWithPaths: function (paths, useSketch, useRule) {
         if (!this.useCanvas) {
             return;
         }
@@ -222,7 +224,12 @@ $.Drawer.prototype = {
         path2Ds.forEach(function(path2D) {
             combinedPath.addPath(path2D);
         });
-        context.clip(combinedPath, "evenodd");
+        if (useRule === "evenodd" || useRule === "nonzero") {
+            context.clip(combinedPath, useRule);
+        } else {
+            context.clip(combinedPath, "evenodd");
+        }
+
     },
 
     /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2020,6 +2020,13 @@ function drawTiles( tiledImage, lastDrawn ) {
     }
 
     if (tiledImage._croppingPaths) {
+        tiledImage._drawer.saveContext(useSketch);
+        var context = tiledImage._drawer._getContext(useSketch);
+        var oldMatrix = context.getTransform();
+        var viewport = tiledImage._drawer.viewport;
+        var scale = 1 / (viewport._contentSizeNoRotate.x * viewport._contentBoundsNoRotate.width);
+        context.scale(scale, scale);
+        context.translate(viewport._contentBoundsNoRotate.x, viewport._contentBoundsNoRotate.y);
         try {
             tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch);
         } catch (e) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1941,7 +1941,6 @@ function cropContextWithCroppingPaths(tiledImage, useSketch) {
         var point = tiledImage.getOriginPixelCoordinate(true, true);
         context.translate(point.x, point.y);
         context.scale(scale, scale);
-        context.rotate(Math.PI / 180 * -viewport.degrees);
         tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch);
         context.setTransform(oldMatrix);
     } catch (e) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1211,7 +1211,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     },
 
     /**
-     * This function converts the {0, 0} viewport coordinates to pixels coordinates
+     * This function converts the top left viewport coordinates to pixels coordinates
      * @param {Boolean} current Pass true for the current location; defaults to false (target location).
      * @returns {OpenSeadragon.Point}
      */

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1911,6 +1911,23 @@ function isCroppingPathReady(tiledImage, usedClip) {
     return flag;
 }
 function cropContextWithCroppingPaths(tiledImage, tile, useSketch) {
+    try {
+        var context = tiledImage._drawer._getContext(useSketch);
+        var viewport  = tiledImage._drawer.viewport;
+        var oldMatrix = context.getTransform();
+        var zoomLevel = viewport.getZoom(true);
+        context.translate(
+            (tile.position.x ) * $.pixelDensityRatio,
+            (tile.position.y ) * $.pixelDensityRatio
+        );
+        context.scale(zoomLevel, zoomLevel);
+        context.rotate(Math.PI / 180 * -viewport.degrees);
+        tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch);
+        context.setTransform(oldMatrix);
+    } catch (e) {
+        $.console.error("Cropping with Path failed: ");
+        $.console.error(e);
+    }
 }
 
 /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -690,9 +690,11 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * use the sketch canvas default to true.
      * @param preventSketchTransform - optional - indicate that the cropping path
      * transformation is applied thus sketch transform can be skip.
+     * @param fillRule - optional - indicate the rule used for filling. Options
+     * are 'nonzero' and 'evenodd'. Default to 'evenodd'
      * @see https://en.wikipedia.org/wiki/Even%E2%80%93odd_rule
      */
-    setCroppingPaths: function( paths, cropWithoutSketch, preventSketchTransform) {
+    setCroppingPaths: function( paths, cropWithoutSketch, preventSketchTransform, fillRule) {
         this._croppingPaths = paths;
         if (cropWithoutSketch === undefined || cropWithoutSketch === null) {
             this._cropWithoutSketch = true;
@@ -700,6 +702,11 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         } else {
             this._cropWithoutSketch = cropWithoutSketch;
             this._preventSketchTransform = preventSketchTransform;
+        }
+        if (fillRule === 'nonzero' || fillRule === 'evenodd') {
+            this._croppingFillRule = fillRule;
+        } else {
+            this._croppingFillRule = 'evenodd';
         }
     },
 
@@ -1974,7 +1981,7 @@ function cropContextWithCroppingPaths(tiledImage, useSketch) {
         var point = tiledImage.getOriginPixelCoordinate(true, true);
         context.translate(point.x, point.y);
         context.scale(scale, scale);
-        tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch);
+        tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch, tiledImage._croppingFillRule);
         context.setTransform(oldMatrix);
     } catch (e) {
         $.console.error("Cropping with Path failed: ");

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -678,6 +678,16 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         this._setScale(height / this.normHeight, immediately);
     },
 
+    /**
+     * Sets an array of paths to crop the TiledImage during draw tiles.
+     * The render function will use the even-odd winding rule.
+     * @param paths - an array of path objects to crop the tileImage
+     * Example path object:
+     * var pathData = "M 500,500 h 200 v 200 h -200 z";
+     * var pathObj = document.createElementNS("http://www.w3.org/2000/svg", "path");
+     * pathObj.setAttribute('d', pathData);
+     * @see https://en.wikipedia.org/wiki/Even%E2%80%93odd_rule
+     */
     setCroppingPaths: function( paths ) {
         this._croppingPaths = paths;
     },
@@ -734,6 +744,10 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         this._croppingPolygons = null;
     },
 
+    /**
+     * Resets the cropping path, thus next render will remove all cropping
+     * path effects.
+     */
     resetCroppingPaths: function() {
         this._croppingPaths = null;
     },
@@ -1906,6 +1920,13 @@ function compareTiles( previousBest, tile ) {
     return previousBest;
 }
 
+/**
+ * This function checks if the path cropping is ready.
+ * @param {OpenSeadragon.TiledImage} tiledImage - tiledImage to check the cropping
+ * properties: _croppingPolygons, _croppingPaths.
+ * @param {boolean} usedClip - indicates that the canvas used clip already
+ * @return true if no condition failed, false otherwise.
+ */
 function isCroppingPathReady(tiledImage, usedClip) {
     var flag = true;
     // Skip checking if _croppingPath is falsely

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -678,6 +678,10 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         this._setScale(height / this.normHeight, immediately);
     },
 
+    setCroppingPaths: function( paths ) {
+        this._croppingPaths = paths;
+    },
+
     /**
      * Sets an array of polygons to crop the TiledImage during draw tiles.
      * The render function will use the default non-zero winding rule.
@@ -728,6 +732,10 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      */
     resetCroppingPolygons: function() {
         this._croppingPolygons = null;
+    },
+
+    resetCroppingPaths: function() {
+        this._croppingPaths = null;
     },
 
     /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1216,8 +1216,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * @returns {OpenSeadragon.Point}
      */
     getOriginPixelCoordinate: function(current, withPixelDensityRatio) {
+        var bounds = this.getBoundsNoRotate();
         var topLeft = this.viewport.pixelFromPointNoRotate(
-            new $.Point(0, 0),
+            new $.Point(bounds.x, bounds.y),
             current === true
         );
         var multiplier = withPixelDensityRatio ? $.pixelDensityRatio : 1;
@@ -1958,7 +1959,7 @@ function cropContextWithCroppingPaths(tiledImage) {
         var context = tiledImage._drawer._getContext();
         var viewport  = tiledImage._drawer.viewport;
         var oldMatrix = context.getTransform();
-        var scale = viewport.viewportToImageZoom(viewport.getZoom(true)) * $.pixelDensityRatio;
+        var scale = tiledImage.viewportToImageZoom(viewport.getZoom(true)) * $.pixelDensityRatio;
         var point = tiledImage.getOriginPixelCoordinate(true, true);
         context.translate(point.x, point.y);
         context.scale(scale, scale);

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1953,16 +1953,16 @@ function isCroppingPathReady(tiledImage, usedClip) {
  * @param {OpenSeadragon.TiledImage} tiledImage - tiledImage with _croppingPaths.
  * @see isCroppingPathReady
  */
-function cropContextWithCroppingPaths(tiledImage, useSketch) {
+function cropContextWithCroppingPaths(tiledImage) {
     try {
-        var context = tiledImage._drawer._getContext(useSketch);
+        var context = tiledImage._drawer._getContext();
         var viewport  = tiledImage._drawer.viewport;
         var oldMatrix = context.getTransform();
         var scale = viewport.viewportToImageZoom(viewport.getZoom(true)) * $.pixelDensityRatio;
         var point = tiledImage.getOriginPixelCoordinate(true, true);
         context.translate(point.x, point.y);
         context.scale(scale, scale);
-        tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch);
+        tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths);
         context.setTransform(oldMatrix);
     } catch (e) {
         $.console.error("Cropping with Path failed: ");
@@ -2001,11 +2001,13 @@ function drawTiles( tiledImage, lastDrawn ) {
     if (lastDrawn.length > 1 &&
         imageZoom > tiledImage.smoothTileEdgesMinZoom &&
         !tiledImage.iOSDevice &&
+        !tiledImage._croppingPaths &&
         tiledImage.getRotation(true) % 360 === 0 && // TODO: support tile edge smoothing with tiled image rotation.
         $.supportsCanvas) {
         // When zoomed in a lot (>100%) the tile edges are visible.
         // So we have to composite them at ~100% and scale them up together.
         // Note: Disabled on iOS devices per default as it causes a native crash
+        // Node: Disabled when _croppingPaths are provided because stacking translation
         useSketch = true;
         sketchScale = tile.getScaleForEdgeSmoothing();
         sketchTranslate = tile.getTranslationForEdgeSmoothing(sketchScale,
@@ -2101,7 +2103,7 @@ function drawTiles( tiledImage, lastDrawn ) {
     if (isCroppingPathReady(tiledImage, usedClip)) {
         tiledImage._drawer.saveContext(useSketch);
         usedClip = true; // Marks context for restore later.
-        cropContextWithCroppingPaths(tiledImage, useSketch);
+        cropContextWithCroppingPaths(tiledImage);
     }
 
     if ( tiledImage.placeholderFillStyle && tiledImage._hasOpaqueTile === false ) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2019,6 +2019,15 @@ function drawTiles( tiledImage, lastDrawn ) {
         usedClip = true;
     }
 
+    if (tiledImage._croppingPaths) {
+        try {
+            tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch);
+        } catch (e) {
+            $.console.error(e);
+        }
+        usedClip = true;
+        context.setTransform(oldMatrix);
+    }
     if ( tiledImage.placeholderFillStyle && tiledImage._hasOpaqueTile === false ) {
         var placeholderRect = tiledImage._drawer.viewportToDrawerRectangle(tiledImage.getBounds(true));
         if (sketchScale) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -688,14 +688,18 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * pathObj.setAttribute('d', pathData);
      * @param cropWithoutSketch - optional - indicate that cropping path should not
      * use the sketch canvas default to true.
+     * @param preventSketchTransform - optional - indicate that the cropping path
+     * transformation is applied thus sketch transform can be skip.
      * @see https://en.wikipedia.org/wiki/Even%E2%80%93odd_rule
      */
-    setCroppingPaths: function( paths, cropWithoutSketch ) {
+    setCroppingPaths: function( paths, cropWithoutSketch, preventSketchTransform) {
         this._croppingPaths = paths;
         if (cropWithoutSketch === undefined || cropWithoutSketch === null) {
             this._cropWithoutSketch = true;
+            this._preventSketchTransform = true;
         } else {
             this._cropWithoutSketch = cropWithoutSketch;
+            this._preventSketchTransform = preventSketchTransform;
         }
     },
 
@@ -2010,6 +2014,7 @@ function drawTiles( tiledImage, lastDrawn ) {
         imageZoom > tiledImage.smoothTileEdgesMinZoom &&
         !tiledImage.iOSDevice &&
         !tiledImage._cropWithoutSketch &&
+        !tiledImage._preventSketchTransform &&
         tiledImage.getRotation(true) % 360 === 0 && // TODO: support tile edge smoothing with tiled image rotation.
         $.supportsCanvas) {
         // When zoomed in a lot (>100%) the tile edges are visible.

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1915,12 +1915,12 @@ function cropContextWithCroppingPaths(tiledImage, tile, useSketch) {
         var context = tiledImage._drawer._getContext(useSketch);
         var viewport  = tiledImage._drawer.viewport;
         var oldMatrix = context.getTransform();
-        var zoomLevel = viewport.getZoom(true);
+        var scale = viewport.viewportToImageZoom(viewport.getZoom()) * $.pixelDensityRatio;
         context.translate(
             (tile.position.x ) * $.pixelDensityRatio,
             (tile.position.y ) * $.pixelDensityRatio
         );
-        context.scale(zoomLevel, zoomLevel);
+        context.scale(scale, scale);
         context.rotate(Math.PI / 180 * -viewport.degrees);
         tiledImage._drawer.clipWithPaths(tiledImage._croppingPaths, useSketch);
         context.setTransform(oldMatrix);

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -41,6 +41,9 @@
     <div>
         <button id='resetBtn'>Reset</button>
         <button id='exampleBtn'>Load Example</button>
+        <button id="rotateLeft">Rotate - 10</button>
+        <button id="rotateRight">Rotate + 10</button>
+        <button id="rotateZero">Rotate to 0</button>
     </div>
     <div class='box-with-title'>
         <div class="buttons">
@@ -204,6 +207,17 @@
             emptyElement('pathDEl');
         }
 
+        document.getElementById('rotateRight').onclick = function() {
+            var degree = viewer.world.getItemAt(0).getRotation();
+            viewer.world.getItemAt(0).setRotation(degree + 10);
+        }
+        document.getElementById('rotateLeft').onclick = function() {
+            var degree = viewer.world.getItemAt(0).getRotation();
+            viewer.world.getItemAt(0).setRotation(degree - 10);
+        }
+        document.getElementById('rotateZero').onclick = function() {
+            viewer.world.getItemAt(0).setRotation(0);
+        }
     </script>
 
 </body>

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -56,6 +56,13 @@
         </div>
         <textarea id='previewEl'></textarea>
     </div>
+    <div class='box-with-title'>
+        <div class="buttons">
+            <button id="pathBtn">Crop With Path</button>
+            <button onclick="emptyElement('pathDEl')">Clear</button>
+        </div>
+        <textarea id='pathDEl'></textarea>
+    </div>
 
     <!-- Setup Viewer -->
     <script type="text/javascript">
@@ -75,11 +82,32 @@
         // Global Variables
         var previewEl = document.getElementById('previewEl');
         var polygonPointEl = document.getElementById('polygonPointEl');
+        var pathDEl = document.getElementById('pathDEl');
 
         var examples =  [
             [{x: 480, y: 300},{x: 300, y: 420},{x: 600, y: 420}],                   // Triangle
             [{x: 300, y: 550},{x: 300, y: 750},{x: 600, y: 750},{x: 600, y: 550}]   // Rectangle
         ];
+        var pathWithExclusion = [
+            'M 300,300',  // Move to x: 500, y: 500
+            'h 200',      // Draw a box of size 100
+            'v 200',
+            'h -200',
+            'z',          // Close path
+            'M 350,350',  // Move to x: 600, y:600
+            'h 30',       // Draw a polygon as exclusion (evenodd rule)
+            'l 30,40',
+            'h -30',
+            'z'           // Close Path
+        ].join('');       // Join to make as a Path d string
+        var heartShapePath = [
+            'M 10,30',            // Move to x: 500, y: 500
+            'A 20,20 0,0,1 50,30',  // Draw a heart shape
+            'A 20,20 0,0,1 90,30',
+            'Q 90,60 50,90',
+            'Q 10,60 10,30',
+            'z'                     // Close Path
+        ].join('');                 // Join to make as a Path d string
 
         // Load default examples
         function loadExample(){
@@ -153,12 +181,24 @@
         document.getElementById('resetBtn').onclick = function(){
             emptyElement('polygonPointEl');
             emptyElement('previewEl');
+            emptyElement('pathDEl');
             var tiledImage = viewer.world.getItemAt(0);
             tiledImage.resetCroppingPolygons();
             viewer.forceRedraw();
         };
 
         document.getElementById('exampleBtn').onclick = loadExample;
+
+        document.getElementById('pathBtn').onclick = function() {
+            var pathList = eval(pathDEl.value);
+            var paths = pathList.map(function(path) {
+                var svg = document.createElementNS("http://www.w3.org/2000/svg", "path");
+                svg.setAttribute('d', path);
+                return svg;
+            });
+            var tiledImage = viewer.world.getItemAt(0);
+        }
+
     </script>
 
 </body>

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -44,6 +44,10 @@
         <button id="rotateLeft">Rotate - 10</button>
         <button id="rotateRight">Rotate + 10</button>
         <button id="rotateZero">Rotate to 0</button>
+        <select id="selectedImage">
+            <option>Index 0</option>
+            <option>Index 1</option>
+        </select>
     </div>
     <div class='box-with-title'>
         <div class="buttons">
@@ -71,6 +75,7 @@
     <script type="text/javascript">
         var viewer = OpenSeadragon({
             // debugMode: true,
+            // animationTime: 0,
             id: "contentDiv",
             prefixUrl: "../../build/openseadragon/images/",
             tileSources: "../data/testpattern.dzi",
@@ -78,6 +83,11 @@
             gestureSettingsMouse: {
                 clickToZoom: false
             }
+        });
+        viewer.addTiledImage({
+            tileSource: "../data/tall.dzi",
+            x: 2,
+            y: 0,
         });
     </script>
 
@@ -168,6 +178,11 @@
             }
         }
 
+        function getSelectedTiledImage() {
+            var index = document.getElementById('selectedImage').selectedIndex;
+            return viewer.world.getItemAt(index);
+        }
+
         // Add clicked points to polygon tracker variable as point objects
         document.getElementById('addPointBtn').onclick = function(){
             insertValueFromElementToPreviewElement(polygonPointEl);
@@ -176,7 +191,7 @@
         // Crop image with value in the preview element
         document.getElementById('polygonCropBtn').onclick = function(){
             var polygonList = eval(previewEl.value);
-            var tiledImage = viewer.world.getItemAt(0);
+            var tiledImage = getSelectedTiledImage();
             tiledImage.setCroppingPolygons(polygonList);
             viewer.forceRedraw();
             emptyElement('previewEl');
@@ -186,7 +201,7 @@
             emptyElement('polygonPointEl');
             emptyElement('previewEl');
             emptyElement('pathDEl');
-            var tiledImage = viewer.world.getItemAt(0);
+            var tiledImage = getSelectedTiledImage();
             tiledImage.resetCroppingPolygons();
             tiledImage.resetCroppingPaths();
             viewer.forceRedraw();
@@ -201,22 +216,22 @@
                 svg.setAttribute('d', path);
                 return svg;
             });
-            var tiledImage = viewer.world.getItemAt(0);
+            var tiledImage = getSelectedTiledImage();
             tiledImage.setCroppingPaths(paths);
             viewer.forceRedraw();
             emptyElement('pathDEl');
         }
 
         document.getElementById('rotateRight').onclick = function() {
-            var degree = viewer.world.getItemAt(0).getRotation();
-            viewer.world.getItemAt(0).setRotation(degree + 10);
+            var degree = getSelectedTiledImage().getRotation();
+            getSelectedTiledImage().setRotation(degree + 10);
         }
         document.getElementById('rotateLeft').onclick = function() {
-            var degree = viewer.world.getItemAt(0).getRotation();
-            viewer.world.getItemAt(0).setRotation(degree - 10);
+            var degree = getSelectedTiledImage().getRotation();
+            getSelectedTiledImage().setRotation(degree - 10);
         }
         document.getElementById('rotateZero').onclick = function() {
-            viewer.world.getItemAt(0).setRotation(0);
+            getSelectedTiledImage().setRotation(0);
         }
     </script>
 

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -51,14 +51,14 @@
     </div>
     <div class='box-with-title'>
         <div class="buttons">
-            <button id="cropBtn">Crop With Polygon</button>
+            <button id="polygonCropBtn">Crop With Polygon</button>
             <button onclick="emptyElement('previewEl')">Clear</button>
         </div>
         <textarea id='previewEl'></textarea>
     </div>
     <div class='box-with-title'>
         <div class="buttons">
-            <button id="pathBtn">Crop With Path</button>
+            <button id="pathCropBtn">Crop With Path</button>
             <button onclick="emptyElement('pathDEl')">Clear</button>
         </div>
         <textarea id='pathDEl'></textarea>
@@ -171,7 +171,7 @@
         };
 
         // Crop image with value in the preview element
-        document.getElementById('cropBtn').onclick = function(){
+        document.getElementById('polygonCropBtn').onclick = function(){
             var polygonList = eval(previewEl.value);
             var tiledImage = viewer.world.getItemAt(0);
             tiledImage.setCroppingPolygons(polygonList);
@@ -191,7 +191,7 @@
 
         document.getElementById('exampleBtn').onclick = loadExample;
 
-        document.getElementById('pathBtn').onclick = function() {
+        document.getElementById('pathCropBtn').onclick = function() {
             var pathList = eval(pathDEl.value);
             var paths = pathList.map(function(path) {
                 var svg = document.createElementNS("http://www.w3.org/2000/svg", "path");

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -89,15 +89,15 @@
 
         var examples =  [
             [{x: 480, y: 300},{x: 300, y: 420},{x: 600, y: 420}],                   // Triangle
-            [{x: 300, y: 550},{x: 300, y: 750},{x: 600, y: 750},{x: 600, y: 550}]   // Rectangle
+            [{x: 500, y: 500},{x: 700, y: 500},{x: 700, y: 700},{x: 500, y: 700}]   // Rectangle
         ];
         var pathWithExclusion = [
-            'M 300,300',  // Move to x: 500, y: 500
+            'M 500,500',  // Move to x: 500, y: 500
             'h 200',      // Draw a box of size 100
             'v 200',
             'h -200',
             'z',          // Close path
-            'M 350,350',  // Move to x: 600, y:600
+            'M 600,600',  // Move to x: 600, y:600
             'h 30',       // Draw a polygon as exclusion (evenodd rule)
             'l 30,40',
             'h -30',

--- a/test/demo/cropping-polygons.html
+++ b/test/demo/cropping-polygons.html
@@ -112,6 +112,7 @@
         // Load default examples
         function loadExample(){
             previewEl.value = JSON.stringify(examples);
+            pathDEl.value = JSON.stringify([pathWithExclusion, heartShapePath], null, 2);
         }
         loadExample();
 
@@ -184,6 +185,7 @@
             emptyElement('pathDEl');
             var tiledImage = viewer.world.getItemAt(0);
             tiledImage.resetCroppingPolygons();
+            tiledImage.resetCroppingPaths();
             viewer.forceRedraw();
         };
 
@@ -197,6 +199,9 @@
                 return svg;
             });
             var tiledImage = viewer.world.getItemAt(0);
+            tiledImage.setCroppingPaths(paths);
+            viewer.forceRedraw();
+            emptyElement('pathDEl');
         }
 
     </script>


### PR DESCRIPTION
Issue: #1778
Implemented a cropping logic for path using canvas transformation.

Above Here is the original polygon cropping feature.
![209](https://user-images.githubusercontent.com/10471270/90304636-b143c980-de6e-11ea-9f5e-bdaf0af3873f.gif)


This is the new path cropping feature
![211](https://user-images.githubusercontent.com/10471270/90304640-bdc82200-de6e-11ea-9a6d-05250f61b472.gif)

The example rectangular shape in polygon and path has the same dimension,
showing that the new path cropping crops correct location.
![213](https://user-images.githubusercontent.com/10471270/90304653-d20c1f00-de6e-11ea-9e62-ea169e7d6f68.gif)
