### PR TITLE
fileFormat is no longer hard coded in Zoomify Tile Source

### DIFF
--- a/src/zoomifytilesource.js
+++ b/src/zoomifytilesource.js
@@ -48,6 +48,11 @@
             options.tileSize = 256;
         }
 
+        if(typeof options.fileFormat === 'undefined'){
+            options.fileFormat = 'jpg';
+            this.fileFormat = options.fileFormat;
+        }
+
         var currentImageSize = {
             x: options.width,
             y: options.height
@@ -135,7 +140,7 @@
             var result = 0;
             var num = this._calculateAbsoluteTileNumber(level, x, y);
             result = Math.floor(num / 256);
-            return this.tilesUrl + 'TileGroup' + result + '/' + level + '-' + x + '-' + y + '.jpg';
+            return this.tilesUrl + 'TileGroup' + result + '/' + level + '-' + x + '-' + y + '.' + this.fileFormat;
 
         }
     });


### PR DESCRIPTION
Like DZI, Zoomify supports JPG and PNG tiles.  However, when using Zoomify Tile Source in OSD, only JPG is supported due to hard coding.

This pull request addresses the above issue by providing `fileFormat` option in `tilesource` object. `fileFormat` is optional, and is set as JPG if no value is provided.