### PR TITLE
Implement per-image flipping

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -452,6 +452,7 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
         myItem.setWidth(bounds.width, immediately);
         myItem.setRotation(theirItem.getRotation(), immediately);
         myItem.setClip(theirItem.getClip());
+        myItem.setFlip(theirItem.getFlip());
     },
 
     // private

--- a/src/tile.js
+++ b/src/tile.js
@@ -177,6 +177,12 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, aja
      */
     this.size       = null;
     /**
+     * Whether to flip the tile when rendering.
+     * @member {Boolean} flipped
+     * @memberof OpenSeadragon.Tile#
+     */
+    this.flipped    = false;
+    /**
      * The start time of this tile's blending.
      * @member {Number} blendStart
      * @memberof OpenSeadragon.Tile#
@@ -296,6 +302,10 @@ $.Tile.prototype = {
         this.style.height  = this.size.y + "px";
         this.style.width   = this.size.x + "px";
 
+        if (this.flipped) {
+            this.style.transform = "scaleX(-1)";
+        }
+
         $.setElementOpacity( this.element, this.opacity );
     },
 
@@ -376,13 +386,17 @@ $.Tile.prototype = {
             sourceHeight = rendered.canvas.height;
         }
 
+        context.translate(position.x + size.x / 2, 0);
+        if (this.flipped) {
+            context.scale(-1, 1);
+        }
         context.drawImage(
             rendered.canvas,
             0,
             0,
             sourceWidth,
             sourceHeight,
-            position.x,
+            -size.x / 2,
             position.y,
             size.x,
             size.y

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -866,7 +866,6 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     setFlip: function(flip) {
         this.flipped = !!flip;
         this._needsDraw = true;
-        this._raiseBoundsChange();
     },
 
     /**
@@ -1501,7 +1500,7 @@ function getTile(
         tilesMatrix[ level ][ x ] = {};
     }
 
-    if ( !tilesMatrix[ level ][ x ][ y ] ) {
+    if ( !tilesMatrix[ level ][ x ][ y ] || ((!!tilesMatrix[ level ][ x ][ y ].flipped) !== (!!tiledImage.flipped)) ) {
         xMod    = ( numTiles.x + ( x % numTiles.x ) ) % numTiles.x;
         yMod    = ( numTiles.y + ( y % numTiles.y ) ) % numTiles.y;
         bounds  = tiledImage.getTileBounds( level, x, y );
@@ -1549,6 +1548,8 @@ function getTile(
         if (yMod === numTiles.y - 1) {
             tile.isBottomMost = true;
         }
+
+        tile.flipped = tiledImage.flipped;
 
         tilesMatrix[ level ][ x ][ y ] = tile;
     }
@@ -1749,7 +1750,6 @@ function positionTile( tile, overlap, viewport, viewportCenter, levelVisibility,
     tile.size       = sizeC;
     tile.squaredDistance   = tileSquaredDistance;
     tile.visibility = levelVisibility;
-    tile.flipped = tiledImage.getFlip();
 }
 
 /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1500,7 +1500,7 @@ function getTile(
         tilesMatrix[ level ][ x ] = {};
     }
 
-    if ( !tilesMatrix[ level ][ x ][ y ] || ((!!tilesMatrix[ level ][ x ][ y ].flipped) !== (!!tiledImage.flipped)) ) {
+    if ( !tilesMatrix[ level ][ x ][ y ] || !tilesMatrix[ level ][ x ][ y ].flipped !== !tiledImage.flipped ) {
         xMod    = ( numTiles.x + ( x % numTiles.x ) ) % numTiles.x;
         yMod    = ( numTiles.y + ( y % numTiles.y ) ) % numTiles.y;
         bounds  = tiledImage.getTileBounds( level, x, y );

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1526,8 +1526,14 @@ function getTile(
             sourceBounds
         );
 
-        if (xMod === numTiles.x - 1) {
-            tile.isRightMost = true;
+        if (tiledImage.getFlip()) {
+            if (xMod === 0) {
+                tile.isRightMost = true;
+            }
+        } else {
+            if (xMod === numTiles.x - 1) {
+                tile.isRightMost = true;
+            }
         }
 
         if (yMod === numTiles.y - 1) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -866,6 +866,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     setFlip: function(flip) {
         this.flipped = !!flip;
         this._needsDraw = true;
+        this._raiseBoundsChange();
     },
 
     /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -850,6 +850,13 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     },
 
     /**
+     * @returns {Boolean} Whether the TiledImage should be flipped before rendering.
+     */
+    getFlip: function() {
+        return !!this.flipped;
+    },
+
+    /**
      * @returns {Number} The TiledImage's current opacity.
      */
     getOpacity: function() {
@@ -1701,6 +1708,7 @@ function positionTile( tile, overlap, viewport, viewportCenter, levelVisibility,
     tile.size       = sizeC;
     tile.squaredDistance   = tileSquaredDistance;
     tile.visibility = levelVisibility;
+    tile.flipped = tiledImage.getFlip();
 }
 
 /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -860,6 +860,16 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     },
 
     /**
+     * @param {Boolean} flip Whether the TiledImage should be flipped before rendering.
+     * @fires OpenSeadragon.TiledImage.event:bounds-change
+     */
+    setFlip: function(flip) {
+        this.flipped = !!flip;
+        this._needsDraw = true;
+        this._raiseBoundsChange();
+    },
+
+    /**
      * @returns {Number} The TiledImage's current opacity.
      */
     getOpacity: function() {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1301,6 +1301,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * @param {Boolean} [options.preload=false]  Default switch for loading hidden images (true loads, false blocks)
      * @param {Number} [options.degrees=0] Initial rotation of the tiled image around
      * its top left corner in degrees.
+     * @param {Boolean} [options.flipped=false] Whether to horizontally flip the image.
      * @param {String} [options.compositeOperation] How the image is composited onto other images.
      * @param {String} [options.crossOriginPolicy] The crossOriginPolicy for this specific image,
      * overriding viewer.crossOriginPolicy.
@@ -1463,6 +1464,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     opacity: queueItem.options.opacity,
                     preload: queueItem.options.preload,
                     degrees: queueItem.options.degrees,
+                    flipped: queueItem.options.flipped,
                     compositeOperation: queueItem.options.compositeOperation,
                     springStiffness: _this.springStiffness,
                     animationTime: _this.animationTime,

--- a/test/demo/flipping.html
+++ b/test/demo/flipping.html
@@ -20,8 +20,6 @@
                 margin: 0.3em;
             }
 
-
-
         </style>
     </head>
     <body>
@@ -57,6 +55,7 @@
     </div>
 
     <div class="options">
+        Viewport
         <div class="button">
             <input type="checkbox" id="fview" onchange="flipViewport(this.checked)">
             <label for="fview">Flip Viewport</label>
@@ -73,21 +72,25 @@
             // debugMode: true,
             id: "contentDiv",
             prefixUrl: "../../build/openseadragon/images/",
-            showNavigator:true
+            showNavigator:true,
+            tileSources: [
+                {
+                    tileSource: "../data/testpattern.dzi",
+                    x: 0,
+                    y: 0,
+                    flipped: document.getElementById("ffirst").checked,
+                    degrees: document.getElementById("rfirst").checked * 45,
+                }, {
+                    tileSource: "../data/testpattern.dzi",
+                    x: 1,
+                    y: 0,
+                    flipped: document.getElementById("fsecond").checked,
+                    degrees: document.getElementById("rsecond").checked * 45,
+                }
+            ]
         });
 
-        var first = viewer.addTiledImage({
-            tileSource: "../data/testpattern.dzi",
-            x: 0,
-            y: 0,
-        });
-
-        var second = viewer.addTiledImage({
-            tileSource: "../data/testpattern.dzi",
-            x: 1,
-            y: 0,
-            flipped: true,
-        });
+        viewer.viewport.setFlip(document.getElementById("fview").checked);
 
         function debug(v) {
             viewer.setDebugMode(v);

--- a/test/demo/flipping.html
+++ b/test/demo/flipping.html
@@ -36,7 +36,7 @@
         First
         <div class="button">
             <input type="checkbox" id="ffirst" onchange="flip(0, this.checked)">
-            <label for="ffirst">Flip (Partially Implemented)</label>
+            <label for="ffirst">Flip</label>
         </div>
         <div class="button">
             <input type="checkbox" id="rfirst" onchange="rotate(0, this.checked * 45)">
@@ -48,7 +48,7 @@
         Second
         <div class="button">
             <input type="checkbox" id="fsecond" onchange="flip(1, this.checked)" checked>
-            <label for="fsecond">Flip (Partially Implemented)</label>
+            <label for="fsecond">Flip</label>
         </div>
         <div class="button">
             <input type="checkbox" id="rsecond" onchange="rotate(1, this.checked * 45)">

--- a/test/demo/flipping.html
+++ b/test/demo/flipping.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>OpenSeadragon Flipping Demo</title>
+        <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+        <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+        <style type="text/css">
+
+            .openseadragon1 {
+                width: 800px;
+                height: 600px;
+                float: left;
+            }
+
+            .options {
+                margin: 0.5em;
+            }
+
+            .button {
+                margin: 0.3em;
+            }
+
+
+
+        </style>
+    </head>
+    <body>
+    <div>
+        Simple demo page to show image flipping.
+    </div>
+    <div id="contentDiv" class="openseadragon1">
+
+
+    </div>
+    <div class="options">
+        First
+        <div class="button">
+            <input type="checkbox" id="ffirst" onchange="flip(0, this.checked)">
+            <label for="ffirst">Flip (Not Implemented Yet)</label>
+        </div>
+        <div class="button">
+            <input type="checkbox" id="rfirst" onchange="rotate(0, this.checked * 45)">
+            <label for="rfirst">Rotate</label>
+        </div>
+    </div>
+
+    <div class="options">
+        Second
+        <div class="button">
+            <input type="checkbox" id="fsecond" onchange="flip(1, this.checked)" checked>
+            <label for="fsecond">Flip (Not Implemented Yet)</label>
+        </div>
+        <div class="button">
+            <input type="checkbox" id="rsecond" onchange="rotate(1, this.checked * 45)">
+            <label for="rsecond">Rotate</label>
+        </div>
+    </div>
+
+    <div class="options">
+        <div class="button">
+            <input type="checkbox" id="fview" onchange="flipViewport(this.checked)">
+            <label for="fview">Flip Viewport</label>
+        </div>
+
+        <div class="button">
+            <input type="checkbox" id="debug" onchange="debug(this.checked)">
+            <label for="debug">Debug Mode</label>
+        </div>
+    </div>
+    <script type="text/javascript">
+
+        var viewer = OpenSeadragon({
+            // debugMode: true,
+            id: "contentDiv",
+            prefixUrl: "../../build/openseadragon/images/",
+            showNavigator:true
+        });
+
+        var first = viewer.addTiledImage({
+            tileSource: "../data/testpattern.dzi",
+            x: 0,
+            y: 0,
+        });
+
+        var second = viewer.addTiledImage({
+            tileSource: "../data/testpattern.dzi",
+            x: 1,
+            y: 0,
+            flipped: true,
+        });
+
+        function debug(v) {
+            viewer.setDebugMode(v);
+        }
+
+        function flip(n, v) {
+            viewer.world.getItemAt(n).setFlip(v);
+        }
+
+        function rotate(n, v) {
+            viewer.world.getItemAt(n).setRotation(v);
+        }
+
+        function flipViewport(v) {
+            viewer.viewport.setFlip(v);
+        }
+
+    </script>
+    </body>
+</html>

--- a/test/demo/flipping.html
+++ b/test/demo/flipping.html
@@ -36,7 +36,7 @@
         First
         <div class="button">
             <input type="checkbox" id="ffirst" onchange="flip(0, this.checked)">
-            <label for="ffirst">Flip (Not Implemented Yet)</label>
+            <label for="ffirst">Flip (Partially Implemented)</label>
         </div>
         <div class="button">
             <input type="checkbox" id="rfirst" onchange="rotate(0, this.checked * 45)">
@@ -48,7 +48,7 @@
         Second
         <div class="button">
             <input type="checkbox" id="fsecond" onchange="flip(1, this.checked)" checked>
-            <label for="fsecond">Flip (Not Implemented Yet)</label>
+            <label for="fsecond">Flip (Partially Implemented)</label>
         </div>
         <div class="button">
             <input type="checkbox" id="rsecond" onchange="rotate(1, this.checked * 45)">


### PR DESCRIPTION
This works by re-arranging the tiles within the image, and then rendering each tile flipped horizontally.

To use, set "flipped" on the image instead of the viewer.

Changing the flip state after loading is not yet supported. It will require rebuilding the tile bounds.

Implements #1553  
