### PR TITLE
MouseTracker preProcessEvent on keydown, keyup, keypress, focus, blur Events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,7 +34,7 @@ OPENSEADRAGON CHANGELOG
 * MouseTracker: added contextMenuHandler option for handling contextmenu events (#1872 @msalsbery)
 * Viewer: added a canvas-contextmenu event (#1872 @msalsbery)
 * Added additional documentation for the zoomPerSecond viewer option (#1872 @msalsbery)
-* MouseTracker: Per #1863, dropped support for Internet Explorer < 11 (#1872 @msalsbery) (#1950 @rmontroy)
+* MouseTracker: Per #1863, dropped support for Internet Explorer < 11 (#1872 @msalsbery) (#1950 @rmontroy) (#1951 @msalsbery)
 * Fixed simulated drag events in navigator tests (#1949 @msalsbery)
 * Added preventDefault option to MouseTracker.contextMenuHandler and Viewer 'canvas-contextmenu' event args (#1951 @msalsbery)
 * MouseTracker: Added preProcessEventHandler for keydown, keyup, keypress, focus, blur Events (#1951 @msalsbery)

--- a/changelog.txt
+++ b/changelog.txt
@@ -36,7 +36,8 @@ OPENSEADRAGON CHANGELOG
 * Added additional documentation for the zoomPerSecond viewer option (#1872 @msalsbery)
 * MouseTracker: Per #1863, dropped support for Internet Explorer < 11 (#1872 @msalsbery)
 * Fixed simulated drag events in navigator tests (#1949 @msalsbery)
-* Added preventDefault option to MouseTracker.contextMenuHandler and Viewer 'canvas-contextmenu' event args (# @msalsbery)
+* Added preventDefault option to MouseTracker.contextMenuHandler and Viewer 'canvas-contextmenu' event args (#1951 @msalsbery)
+* MouseTracker: Added preProcessEventHandler for keydown, keyup, keypress, focus, blur Events (#1951 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ OPENSEADRAGON CHANGELOG
 * Added additional documentation for the zoomPerSecond viewer option (#1872 @msalsbery)
 * MouseTracker: Per #1863, dropped support for Internet Explorer < 11 (#1872 @msalsbery)
 * Fixed simulated drag events in navigator tests (#1949 @msalsbery)
+* Added preventDefault option to MouseTracker.contextMenuHandler and Viewer 'canvas-contextmenu' event args (# @msalsbery)
 
 2.4.2:
 

--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -114,9 +114,8 @@
             }
 
             $.addEvent(image, 'load', function () {
-                /* IE8 fix since it has no naturalWidth and naturalHeight */
-                _this.width = Object.prototype.hasOwnProperty.call(image, 'naturalWidth') ? image.naturalWidth : image.width;
-                _this.height = Object.prototype.hasOwnProperty.call(image, 'naturalHeight') ? image.naturalHeight : image.height;
+                _this.width = image.naturalWidth;
+                _this.height = image.naturalHeight;
                 _this.aspectRatio = _this.width / _this.height;
                 _this.dimensions = new $.Point(_this.width, _this.height);
                 _this._tileWidth = _this.width;
@@ -210,9 +209,8 @@
         _buildLevels: function () {
             var levels = [{
                     url: this._image.src,
-                    /* IE8 fix since it has no naturalWidth and naturalHeight */
-                    width: Object.prototype.hasOwnProperty.call(this._image, 'naturalWidth') ? this._image.naturalWidth : this._image.width,
-                    height:  Object.prototype.hasOwnProperty.call(this._image, 'naturalHeight') ? this._image.naturalHeight : this._image.height
+                    width: this._image.naturalWidth,
+                    height:  this._image.naturalHeight
                 }];
 
             if (!this.buildPyramid || !$.supportsCanvas || !this.useCanvas) {
@@ -221,9 +219,8 @@
                 return levels;
             }
 
-            /* IE8 fix since it has no naturalWidth and naturalHeight */
-            var currentWidth = Object.prototype.hasOwnProperty.call(this._image, 'naturalWidth') ? this._image.naturalWidth : this._image.width;
-            var currentHeight = Object.prototype.hasOwnProperty.call(this._image, 'naturalHeight') ? this._image.naturalHeight : this._image.height;
+            var currentWidth = this._image.naturalWidth;
+            var currentHeight = this._image.naturalHeight;
 
 
             var bigCanvas = document.createElement("canvas");

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2857,8 +2857,6 @@
             case 'pointerover':
             case 'pointerout':
             case 'contextmenu':
-            case 'keydown':
-            case 'keyup':
                 eventInfo.isStopable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
@@ -2906,6 +2904,20 @@
                 eventInfo.isStopable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = !!tracker.dblClickHandler;
+                eventInfo.preventGesture = false;
+                eventInfo.stopPropagation = false;
+                break;
+            case 'keydown':
+                eventInfo.isStopable = true;
+                eventInfo.isCancelable = true;
+                eventInfo.preventDefault = !!tracker.keyDownHandler;
+                eventInfo.preventGesture = false;
+                eventInfo.stopPropagation = false;
+                break;
+            case 'keyup':
+                eventInfo.isStopable = true;
+                eventInfo.isCancelable = true;
+                eventInfo.preventDefault = !!tracker.keyUpHandler;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
                 break;

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2856,6 +2856,9 @@
                 break;
             case 'pointerover':
             case 'pointerout':
+            case 'contextmenu':
+            case 'keydown':
+            case 'keyup':
                 eventInfo.isStopable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
@@ -2903,21 +2906,6 @@
                 eventInfo.isStopable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = !!tracker.dblClickHandler;
-                eventInfo.preventGesture = false;
-                eventInfo.stopPropagation = false;
-                break;
-            case 'contextmenu':
-                eventInfo.isStopable = true;
-                eventInfo.isCancelable = true;
-                eventInfo.preventDefault = false;
-                eventInfo.preventGesture = false;
-                eventInfo.stopPropagation = false;
-                break;
-            case 'keydown':
-            case 'keyup':
-                eventInfo.isStopable = true;
-                eventInfo.isCancelable = true;
-                eventInfo.preventDefault = false;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
                 break;

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -2914,16 +2914,10 @@
                 eventInfo.stopPropagation = false;
                 break;
             case 'keydown':
-                eventInfo.isStopable = true;
-                eventInfo.isCancelable = true;
-                eventInfo.preventDefault = !!tracker.keyDownHandler;
-                eventInfo.preventGesture = false;
-                eventInfo.stopPropagation = false;
-                break;
             case 'keyup':
                 eventInfo.isStopable = true;
                 eventInfo.isCancelable = true;
-                eventInfo.preventDefault = !!tracker.keyUpHandler;
+                eventInfo.preventDefault = false;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
                 break;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2546,6 +2546,13 @@ function onBlur(){
 }
 
 function onCanvasContextMenu( event ) {
+    var eventArgs = {
+        tracker: event.eventSource,
+        position: event.position,
+        originalEvent: event.originalEvent,
+        preventDefault: event.preventDefault
+    };
+
     /**
      * Raised when a contextmenu event occurs in the {@link OpenSeadragon.Viewer#canvas} element.
      *
@@ -2556,13 +2563,12 @@ function onCanvasContextMenu( event ) {
      * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
      * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
      * @property {Object} originalEvent - The original DOM event.
+     * @property {Boolean} preventDefault - Set to true to prevent the default user-agent's handling of the contextmenu event.
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */
-    this.raiseEvent( 'canvas-contextmenu', {
-        tracker: event.eventSource,
-        position: event.position,
-        originalEvent: event.originalEvent
-    });
+    this.raiseEvent( 'canvas-contextmenu', eventArgs );
+
+    event.preventDefault = eventArgs.preventDefault;
 }
 
 function onCanvasKeyDown( event ) {


### PR DESCRIPTION
Also:

Added preventDefault option to MouseTracker.contextMenuHandler and Viewer 'canvas-contextmenu' event objects for easy disabling of context menu on viewers

Removed a bit more IE<11 code
