### PR TITLE
Fixed preventDefaultAction Functionality in Viewer Events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,7 +36,7 @@ OPENSEADRAGON CHANGELOG
 * Added additional documentation for the zoomPerSecond viewer option (#1872 @msalsbery)
 * MouseTracker: Per #1863, dropped support for Internet Explorer < 11 (#1872 @msalsbery) (#1950 @rmontroy)
 * Fixed simulated drag events in navigator tests (#1949 @msalsbery)
-* Fixed preventDefaultAction functionality in viewer events (# @msalsbery)
+* Fixed preventDefaultAction functionality in viewer events (#1953 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ OPENSEADRAGON CHANGELOG
 * Added additional documentation for the zoomPerSecond viewer option (#1872 @msalsbery)
 * MouseTracker: Per #1863, dropped support for Internet Explorer < 11 (#1872 @msalsbery) (#1950 @rmontroy)
 * Fixed simulated drag events in navigator tests (#1949 @msalsbery)
+* Fixed preventDefaultAction functionality in viewer events (# @msalsbery)
 
 2.4.2:
 

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -494,8 +494,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -527,8 +525,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -560,8 +556,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -585,8 +579,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -613,8 +605,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -643,8 +633,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -671,8 +659,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -696,8 +682,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -722,8 +706,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead. Touch devices no longer generate scroll event.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -748,8 +730,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -772,8 +752,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -805,8 +783,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -833,8 +809,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -863,8 +837,6 @@
          *      True if the shift key was pressed during this event.
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -888,8 +860,6 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -914,8 +884,6 @@
          *      True if the meta key was pressed during this event.
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -940,8 +908,6 @@
          *      True if the meta key was pressed during this event.
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -966,8 +932,6 @@
          *      True if the meta key was pressed during this event.
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -982,8 +946,6 @@
          *      A reference to the tracker instance.
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -998,8 +960,6 @@
          *      A reference to the tracker instance.
          * @param {Object} event.originalEvent
          *      The original event object.
-         * @param {Boolean} event.preventDefaultAction
-         *      Set to true to prevent the tracker subscriber from performing its default action (subscriber implementation dependent). Default: false.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */
@@ -1822,7 +1782,6 @@
                     alt:                  event.altKey,
                     meta:                 event.metaKey,
                     originalEvent:        event,
-                    preventDefaultAction: false,
                     userData:             tracker.userData
                 }
             );
@@ -1850,7 +1809,6 @@
                     alt:                  event.altKey,
                     meta:                 event.metaKey,
                     originalEvent:        event,
-                    preventDefaultAction: false,
                     userData:             tracker.userData
                 }
             );
@@ -1878,7 +1836,6 @@
                     alt:                  event.altKey,
                     meta:                 event.metaKey,
                     originalEvent:        event,
-                    preventDefaultAction: false,
                     userData:             tracker.userData
                 }
             );
@@ -1901,7 +1858,6 @@
                 {
                     eventSource:          tracker,
                     originalEvent:        event,
-                    preventDefaultAction: false,
                     userData:             tracker.userData
                 }
             );
@@ -1924,7 +1880,6 @@
                 {
                     eventSource:          tracker,
                     originalEvent:        event,
-                    preventDefaultAction: false,
                     userData:             tracker.userData
                 }
             );
@@ -2052,7 +2007,6 @@
                     shift:                event.shiftKey,
                     isTouchEvent:         false,
                     originalEvent:        originalEvent,
-                    preventDefaultAction: false,
                     userData:             tracker.userData
                 }
             );
@@ -3098,7 +3052,6 @@
                     buttonDownAny:        pointsList.buttons !== 0,
                     isTouchEvent:         gPoint.type === 'touch',
                     originalEvent:        eventInfo.originalEvent,
-                    preventDefaultAction: false,
                     userData:             tracker.userData
                 }
             );
@@ -3144,7 +3097,6 @@
                 buttonDownAny:        pointsList.buttons !== 0,
                 isTouchEvent:         gPoint.type === 'touch',
                 originalEvent:        eventInfo.originalEvent,
-                preventDefaultAction: false,
                 userData:             tracker.userData
             } );
         }
@@ -3215,7 +3167,6 @@
                         buttons:              pointsList.buttons,
                         isTouchEvent:         gPoint.type === 'touch',
                         originalEvent:        eventInfo.originalEvent,
-                        preventDefaultAction: false,
                         userData:             tracker.userData
                     }
                 );
@@ -3270,7 +3221,6 @@
                             buttons:              pointsList.buttons,
                             isTouchEvent:         gPoint.type === 'touch',
                             originalEvent:        eventInfo.originalEvent,
-                            preventDefaultAction: false,
                             userData:             tracker.userData
                         }
                     );
@@ -3359,7 +3309,6 @@
                         buttons:               pointsList.buttons,
                         isTouchEvent:          gPoint.type === 'touch',
                         originalEvent:         eventInfo.originalEvent,
-                        preventDefaultAction:  false,
                         userData:              tracker.userData
                     }
                 );
@@ -3425,7 +3374,6 @@
                                 insideElementReleased: updateGPoint.insideElement,
                                 isTouchEvent:          updateGPoint.type === 'touch',
                                 originalEvent:         eventInfo.originalEvent,
-                                preventDefaultAction:  false,
                                 userData:              tracker.userData
                             }
                         );
@@ -3443,7 +3391,6 @@
                                 shift:                eventInfo.originalEvent.shiftKey,
                                 isTouchEvent:         updateGPoint.type === 'touch',
                                 originalEvent:        eventInfo.originalEvent,
-                                preventDefaultAction: false,
                                 userData:             tracker.userData
                             }
                         );
@@ -3465,7 +3412,6 @@
                                     shift:                eventInfo.originalEvent.shiftKey,
                                     isTouchEvent:         updateGPoint.type === 'touch',
                                     originalEvent:        eventInfo.originalEvent,
-                                    preventDefaultAction: false,
                                     userData:             tracker.userData
                                 }
                             );
@@ -3493,7 +3439,6 @@
                                             shift:                eventInfo.originalEvent.shiftKey,
                                             isTouchEvent:         updateGPoint.type === 'touch',
                                             originalEvent:        eventInfo.originalEvent,
-                                            preventDefaultAction: false,
                                             userData:             tracker.userData
                                         }
                                     );
@@ -3527,7 +3472,6 @@
                             insideElementReleased: updateGPoint.insideElement,
                             isTouchEvent:          updateGPoint.type === 'touch',
                             originalEvent:         eventInfo.originalEvent,
-                            preventDefaultAction:  false,
                             userData:              tracker.userData
                         }
                     );
@@ -3600,7 +3544,6 @@
                         buttons:              pointsList.buttons,
                         isTouchEvent:         gPoint.type === 'touch',
                         originalEvent:        eventInfo.originalEvent,
-                        preventDefaultAction: false,
                         userData:             tracker.userData
                     }
                 );
@@ -3617,7 +3560,6 @@
                         buttons:              pointsList.buttons,
                         isTouchEvent:         updateGPoint.type === 'touch',
                         originalEvent:        eventInfo.originalEvent,
-                        preventDefaultAction: false,
                         userData:             tracker.userData
                     }
                 );
@@ -3639,7 +3581,6 @@
                         shift:                eventInfo.originalEvent.shiftKey,
                         isTouchEvent:         updateGPoint.type === 'touch',
                         originalEvent:        eventInfo.originalEvent,
-                        preventDefaultAction: false,
                         userData:             tracker.userData
                     }
                 );
@@ -3657,7 +3598,6 @@
                         buttons:              pointsList.buttons,
                         isTouchEvent:         gPointArray[ 0 ].type === 'touch',
                         originalEvent:        eventInfo.originalEvent,
-                        preventDefaultAction: false,
                         userData:             tracker.userData
                     }
                 );
@@ -3683,7 +3623,6 @@
                             distance:             delegate.currentPinchDist,
                             shift:                eventInfo.originalEvent.shiftKey,
                             originalEvent:        eventInfo.originalEvent,
-                            preventDefaultAction: false,
                             userData:             tracker.userData
                         }
                     );
@@ -3730,7 +3669,6 @@
                 buttons:              tracker.getActivePointersListByType( pointerType ).buttons,
                 isTouchEvent:         pointerType === 'touch',
                 originalEvent:        originalMoveEvent,
-                preventDefaultAction: false,
                 userData:             tracker.userData
             } );
         }

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -471,7 +471,7 @@ function onCanvasClick( event ) {
     quick: event.quick,
     shift: event.shift,
     originalEvent: event.originalEvent,
-    preventDefaultAction: event.preventDefaultAction
+    preventDefaultAction: false
   };
   /**
    * Raised when a click event occurs on the {@link OpenSeadragon.Viewer#navigator} element.
@@ -523,7 +523,7 @@ function onCanvasDrag( event ) {
       direction: event.direction,
       shift: event.shift,
       originalEvent: event.originalEvent,
-      preventDefaultAction: event.preventDefaultAction
+      preventDefaultAction: false
     };
     /**
      * Raised when a drag event occurs on the {@link OpenSeadragon.Viewer#navigator} element.

--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -524,7 +524,7 @@ function onStripLeave( event ) {
 function onKeyDown( event ) {
     //console.log( event.keyCode );
 
-    if ( !event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
+    if ( !event.ctrl && !event.alt && !event.meta ) {
         switch ( event.keyCode ) {
             case 38: //up arrow
                 onStripScroll.call( this, { eventSource: this.tracker, position: null, scroll: 1, shift: null } );
@@ -556,7 +556,7 @@ function onKeyDown( event ) {
 function onKeyPress( event ) {
     //console.log( event.keyCode );
 
-    if ( !event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
+    if ( !event.ctrl && !event.alt && !event.meta ) {
         switch ( event.keyCode ) {
             case 61: //=|+
                 onStripScroll.call( this, { eventSource: this.tracker, position: null, scroll: 1, shift: null } );

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2568,7 +2568,7 @@ function onCanvasContextMenu( event ) {
 function onCanvasKeyDown( event ) {
     var canvasKeyDownEventArgs = {
       originalEvent: event.originalEvent,
-      preventDefaultAction: event.preventDefaultAction,
+      preventDefaultAction: false,
       preventVerticalPan: event.preventVerticalPan,
       preventHorizontalPan: event.preventHorizontalPan
     };
@@ -2600,7 +2600,7 @@ function onCanvasKeyDown( event ) {
                   }
                   this.viewport.applyConstraints();
                 }
-                return false;
+                break;
             case 40://down arrow
                 if (!canvasKeyDownEventArgs.preventVerticalPan) {
                   if ( event.shift ) {
@@ -2610,31 +2610,29 @@ function onCanvasKeyDown( event ) {
                   }
                   this.viewport.applyConstraints();
                 }
-                return false;
+                break;
             case 37://left arrow
                 if (!canvasKeyDownEventArgs.preventHorizontalPan) {
                   this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(-this.pixelsPerArrowPress, 0)));
                   this.viewport.applyConstraints();
                 }
-                return false;
+                break;
             case 39://right arrow
                 if (!canvasKeyDownEventArgs.preventHorizontalPan) {
                   this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(this.pixelsPerArrowPress, 0)));
                   this.viewport.applyConstraints();
                 }
-                return false;
+                break;
             default:
                 //console.log( 'navigator keycode %s', event.keyCode );
-                return true;
+                break;
         }
-    } else {
-        return true;
     }
 }
 function onCanvasKeyPress( event ) {
     var canvasKeyPressEventArgs = {
       originalEvent: event.originalEvent,
-      preventDefaultAction: event.preventDefaultAction,
+      preventDefaultAction: false,
       preventVerticalPan: event.preventVerticalPan,
       preventHorizontalPan: event.preventHorizontalPan
     };
@@ -2648,15 +2646,15 @@ function onCanvasKeyPress( event ) {
             case 61://=|+
                 this.viewport.zoomBy(1.1);
                 this.viewport.applyConstraints();
-                return false;
+                break;
             case 45://-|_
                 this.viewport.zoomBy(0.9);
                 this.viewport.applyConstraints();
-                return false;
+                break;
             case 48://0|)
                 this.viewport.goHome();
                 this.viewport.applyConstraints();
-                return false;
+                break;
             case 119://w
             case 87://W
                 if (!canvasKeyPressEventArgs.preventVerticalPan) {
@@ -2667,7 +2665,7 @@ function onCanvasKeyPress( event ) {
                     }
                     this.viewport.applyConstraints();
                   }
-                  return false;
+                  break;
             case 115://s
             case 83://S
                 if (!canvasKeyPressEventArgs.preventVerticalPan) {
@@ -2678,19 +2676,19 @@ function onCanvasKeyPress( event ) {
                   }
                   this.viewport.applyConstraints();
                 }
-                return false;
+                break;
             case 97://a
                 if (!canvasKeyPressEventArgs.preventHorizontalPan) {
                   this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(-40, 0)));
                   this.viewport.applyConstraints();
                 }
-                return false;
+                break;
             case 100://d
                 if (!canvasKeyPressEventArgs.preventHorizontalPan) {
                   this.viewport.panBy(this.viewport.deltaPointsFromPixels(new $.Point(40, 0)));
                   this.viewport.applyConstraints();
                 }
-                return false;
+                break;
             case 114: //r - clockwise rotation
               if(this.viewport.flipped){
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees - this.rotationIncrement, 360));
@@ -2698,7 +2696,7 @@ function onCanvasKeyPress( event ) {
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees + this.rotationIncrement, 360));
               }
               this.viewport.applyConstraints();
-              return false;
+              break;
             case 82: //R - counterclockwise  rotation
               if(this.viewport.flipped){
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees + this.rotationIncrement, 360));
@@ -2706,16 +2704,14 @@ function onCanvasKeyPress( event ) {
                 this.viewport.setRotation($.positiveModulo(this.viewport.degrees - this.rotationIncrement, 360));
               }
               this.viewport.applyConstraints();
-              return false;
+              break;
             case 102: //f
               this.viewport.toggleFlip();
-              return false;
+              break;
             default:
                 // console.log( 'navigator keycode %s', event.keyCode );
-                return true;
+                break;
         }
-    } else {
-        return true;
     }
 }
 
@@ -2738,7 +2734,7 @@ function onCanvasClick( event ) {
         quick: event.quick,
         shift: event.shift,
         originalEvent: event.originalEvent,
-        preventDefaultAction: event.preventDefaultAction
+        preventDefaultAction: false
     };
 
     /**
@@ -2778,7 +2774,7 @@ function onCanvasDblClick( event ) {
         position: event.position,
         shift: event.shift,
         originalEvent: event.originalEvent,
-        preventDefaultAction: event.preventDefaultAction
+        preventDefaultAction: false
     };
 
     /**
@@ -2821,7 +2817,7 @@ function onCanvasDrag( event ) {
         direction: event.direction,
         shift: event.shift,
         originalEvent: event.originalEvent,
-        preventDefaultAction: event.preventDefaultAction
+        preventDefaultAction: false
     };
 
     /**
@@ -2882,7 +2878,37 @@ function onCanvasDrag( event ) {
 }
 
 function onCanvasDragEnd( event ) {
-    if (!event.preventDefaultAction && this.viewport) {
+    var canvasDragEndEventArgs = {
+        tracker: event.eventSource,
+        pointerType: event.pointerType,
+        position: event.position,
+        speed: event.speed,
+        direction: event.direction,
+        shift: event.shift,
+        originalEvent: event.originalEvent,
+        preventDefaultAction: false
+    };
+
+    /**
+     * Raised when a mouse or touch drag operation ends on the {@link OpenSeadragon.Viewer#canvas} element.
+     *
+     * @event canvas-drag-end
+     * @memberof OpenSeadragon.Viewer
+     * @type {object}
+     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
+     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
+     * @property {String} pointerType - "mouse", "touch", "pen", etc.
+     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
+     * @property {Number} speed - Speed at the end of a drag gesture, in pixels per second.
+     * @property {Number} direction - Direction at the end of a drag gesture, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
+     * @property {Boolean} shift - True if the shift key was pressed during this event.
+     * @property {Object} originalEvent - The original DOM event.
+     * @property {Boolean} preventDefaultAction - Set to true to prevent default drag-end flick behaviour. Default: false.
+     * @property {?Object} userData - Arbitrary subscriber-defined object.
+     */
+     this.raiseEvent('canvas-drag-end', canvasDragEndEventArgs);
+
+    if (!canvasDragEndEventArgs.preventDefaultAction && this.viewport) {
         var gestureSettings = this.gestureSettingsByDeviceType(event.pointerType);
         if (gestureSettings.flickEnabled &&
             event.speed >= gestureSettings.flickMinSpeed) {
@@ -2904,31 +2930,6 @@ function onCanvasDragEnd( event ) {
         }
         this.viewport.applyConstraints();
     }
-    /**
-     * Raised when a mouse or touch drag operation ends on the {@link OpenSeadragon.Viewer#canvas} element.
-     *
-     * @event canvas-drag-end
-     * @memberof OpenSeadragon.Viewer
-     * @type {object}
-     * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised this event.
-     * @property {OpenSeadragon.MouseTracker} tracker - A reference to the MouseTracker which originated this event.
-     * @property {String} pointerType - "mouse", "touch", "pen", etc.
-     * @property {OpenSeadragon.Point} position - The position of the event relative to the tracked element.
-     * @property {Number} speed - Speed at the end of a drag gesture, in pixels per second.
-     * @property {Number} direction - Direction at the end of a drag gesture, expressed as an angle counterclockwise relative to the positive X axis (-pi to pi, in radians). Only valid if speed > 0.
-     * @property {Boolean} shift - True if the shift key was pressed during this event.
-     * @property {Object} originalEvent - The original DOM event.
-     * @property {?Object} userData - Arbitrary subscriber-defined object.
-     */
-    this.raiseEvent('canvas-drag-end', {
-        tracker: event.eventSource,
-        pointerType: event.pointerType,
-        position: event.position,
-        speed: event.speed,
-        direction: event.direction,
-        shift: event.shift,
-        originalEvent: event.originalEvent
-    });
 }
 
 function onCanvasEnter( event ) {

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -3,31 +3,33 @@
 (function () {
     var viewer;
 
-    QUnit.module( 'Events', {
+    QUnit.module("Events", {
         beforeEach: function () {
-            $( '<div id="eventsexample"></div>' ).appendTo( "#qunit-fixture" );
+            $('<div id="eventsexample"></div>').appendTo("#qunit-fixture");
 
             testLog.reset();
 
-            viewer = OpenSeadragon( {
-                id: 'eventsexample',
-                prefixUrl: '/build/openseadragon/images/',
-                springStiffness: 100 // Faster animation = faster tests
-            } );
+            viewer = OpenSeadragon({
+                id: "eventsexample",
+                prefixUrl: "/build/openseadragon/images/",
+                springStiffness: 100, // Faster animation = faster tests
+            });
         },
         afterEach: function () {
-            if ( viewer && viewer.close ) {
+            if (viewer && viewer.close) {
                 viewer.close();
             }
 
             viewer = null;
-        }
-    } );
+        },
+    });
 
     // ----------
-    QUnit.test( 'MouseTracker: mouse gestures', function (assert) {
+    QUnit.test("MouseTracker: mouse gestures", function (assert) {
         var done = assert.async();
-        var $canvas = $( viewer.element ).find( '.openseadragon-canvas' ).not( '.navigator .openseadragon-canvas' ),
+        var $canvas = $(viewer.element)
+                .find(".openseadragon-canvas")
+                .not(".navigator .openseadragon-canvas"),
             simEvent = {},
             offset = $canvas.offset(),
             tracker = viewer.innerTracker,
@@ -63,45 +65,45 @@
 
         var hookViewerHandlers = function () {
             origEnterHandler = tracker.enterHandler;
-            tracker.enterHandler = function ( event ) {
+            tracker.enterHandler = function (event) {
                 enterCount++;
                 if (origEnterHandler) {
-                    return origEnterHandler( event );
+                    return origEnterHandler(event);
                 } else {
                     return true;
                 }
             };
             origLeaveHandler = tracker.leaveHandler;
-            tracker.leaveHandler = function ( event ) {
+            tracker.leaveHandler = function (event) {
                 leaveCount++;
                 if (origLeaveHandler) {
-                    return origLeaveHandler( event );
+                    return origLeaveHandler(event);
                 } else {
                     return true;
                 }
             };
             origPressHandler = tracker.pressHandler;
-            tracker.pressHandler = function ( event ) {
+            tracker.pressHandler = function (event) {
                 pressCount++;
                 if (origPressHandler) {
-                    return origPressHandler( event );
+                    return origPressHandler(event);
                 } else {
                     return true;
                 }
             };
             origReleaseHandler = tracker.releaseHandler;
-            tracker.releaseHandler = function ( event ) {
+            tracker.releaseHandler = function (event) {
                 releaseCount++;
                 insideElementPressed = event.insideElementPressed;
                 insideElementReleased = event.insideElementReleased;
                 if (origReleaseHandler) {
-                    return origReleaseHandler( event );
+                    return origReleaseHandler(event);
                 } else {
                     return true;
                 }
             };
             origNonPrimaryPressHandler = tracker.nonPrimaryPressHandler;
-            tracker.nonPrimaryPressHandler = function ( event ) {
+            tracker.nonPrimaryPressHandler = function (event) {
                 if (event.button === 0) {
                     pressCount++;
                 } else if (event.button === 1) {
@@ -110,13 +112,13 @@
                     rightPressCount++;
                 }
                 if (origNonPrimaryPressHandler) {
-                    return origNonPrimaryPressHandler( event );
+                    return origNonPrimaryPressHandler(event);
                 } else {
                     return true;
                 }
             };
             origNonPrimaryReleaseHandler = tracker.nonPrimaryReleaseHandler;
-            tracker.nonPrimaryReleaseHandler = function ( event ) {
+            tracker.nonPrimaryReleaseHandler = function (event) {
                 if (event.button === 0) {
                     releaseCount++;
                 } else if (event.button === 1) {
@@ -125,55 +127,55 @@
                     rightReleaseCount++;
                 }
                 if (origNonPrimaryReleaseHandler) {
-                    return origNonPrimaryReleaseHandler( event );
+                    return origNonPrimaryReleaseHandler(event);
                 } else {
                     return true;
                 }
             };
             origMoveHandler = tracker.moveHandler;
-            tracker.moveHandler = function ( event ) {
+            tracker.moveHandler = function (event) {
                 moveCount++;
                 if (origMoveHandler) {
-                    return origMoveHandler( event );
+                    return origMoveHandler(event);
                 } else {
                     return true;
                 }
             };
             origClickHandler = tracker.clickHandler;
-            tracker.clickHandler = function ( event ) {
+            tracker.clickHandler = function (event) {
                 clickCount++;
                 quickClick = event.quick;
                 if (origClickHandler) {
-                    return origClickHandler( event );
+                    return origClickHandler(event);
                 } else {
                     return true;
                 }
             };
             origDblClickHandler = tracker.dblClickHandler;
-            tracker.dblClickHandler = function ( event ) {
+            tracker.dblClickHandler = function (event) {
                 dblClickCount++;
                 if (origDblClickHandler) {
-                    return origDblClickHandler( event );
+                    return origDblClickHandler(event);
                 } else {
                     return true;
                 }
             };
             origDragHandler = tracker.dragHandler;
-            tracker.dragHandler = function ( event ) {
+            tracker.dragHandler = function (event) {
                 dragCount++;
                 if (origDragHandler) {
-                    return origDragHandler( event );
+                    return origDragHandler(event);
                 } else {
                     return true;
                 }
             };
             origDragEndHandler = tracker.dragEndHandler;
-            tracker.dragEndHandler = function ( event ) {
+            tracker.dragEndHandler = function (event) {
                 dragEndCount++;
                 speed = event.speed;
                 direction = event.direction;
                 if (origDragEndHandler) {
-                    return origDragEndHandler( event );
+                    return origDragEndHandler(event);
                 } else {
                     return true;
                 }
@@ -194,15 +196,15 @@
 
         var simulateEnter = function (x, y) {
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top  + y;
-            $canvas.simulate( 'mouseenter', simEvent );
+            simEvent.clientY = offset.top + y;
+            $canvas.simulate("mouseenter", simEvent);
         };
 
         var simulateLeave = function (x, y) {
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top  + y;
+            simEvent.clientY = offset.top + y;
             simEvent.relatedTarget = document.body;
-            $canvas.simulate( 'mouseleave', simEvent );
+            $canvas.simulate("mouseleave", simEvent);
         };
 
         //var simulateLeaveFrame = function (x, y) {
@@ -215,37 +217,37 @@
         var simulateDown = function (x, y) {
             simEvent.button = 0;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top  + y;
-            $canvas.simulate( 'mousedown', simEvent );
+            simEvent.clientY = offset.top + y;
+            $canvas.simulate("mousedown", simEvent);
         };
 
         var simulateUp = function (x, y) {
             simEvent.button = 0;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top  + y;
-            $canvas.simulate( 'mouseup', simEvent );
+            simEvent.clientY = offset.top + y;
+            $canvas.simulate("mouseup", simEvent);
         };
 
         var simulateNonPrimaryDown = function (x, y, button) {
             simEvent.button = button;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top  + y;
-            $canvas.simulate( 'mousedown', simEvent );
+            simEvent.clientY = offset.top + y;
+            $canvas.simulate("mousedown", simEvent);
         };
 
         var simulateNonPrimaryUp = function (x, y, button) {
             simEvent.button = button;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top  + y;
-            $canvas.simulate( 'mouseup', simEvent );
+            simEvent.clientY = offset.top + y;
+            $canvas.simulate("mouseup", simEvent);
         };
 
         var simulateMove = function (dX, dY, count) {
             var i;
-            for ( i = 0; i < count; i++ ) {
+            for (i = 0; i < count; i++) {
                 simEvent.clientX += dX;
                 simEvent.clientY += dY;
-                $canvas.simulate( 'mousemove', simEvent );
+                $canvas.simulate("mousemove", simEvent);
             }
         };
 
@@ -253,7 +255,7 @@
             simEvent = {
                 button: 0,
                 clientX: offset.left,
-                clientY: offset.top
+                clientY: offset.top,
             };
             enterCount = 0;
             leaveCount = 0;
@@ -276,72 +278,207 @@
         };
 
         var assessGestureExpectations = function (expected) {
-            var pointersList = tracker.getActivePointersListByType('mouse');
-            if ('enterCount' in expected) {
-                assert.equal( enterCount, expected.enterCount, expected.description + 'enterHandler event count matches expected (' + expected.enterCount + ')' );
+            var pointersList = tracker.getActivePointersListByType("mouse");
+            if ("enterCount" in expected) {
+                assert.equal(
+                    enterCount,
+                    expected.enterCount,
+                    expected.description +
+                        "enterHandler event count matches expected (" +
+                        expected.enterCount +
+                        ")"
+                );
             }
-            if ('leaveCount' in expected) {
-                assert.equal( leaveCount, expected.leaveCount, expected.description + 'leaveHandler event count matches expected (' + expected.leaveCount + ')' );
+            if ("leaveCount" in expected) {
+                assert.equal(
+                    leaveCount,
+                    expected.leaveCount,
+                    expected.description +
+                        "leaveHandler event count matches expected (" +
+                        expected.leaveCount +
+                        ")"
+                );
             }
-            if ('pressCount' in expected) {
-                assert.equal( pressCount, expected.pressCount, expected.description + 'pressHandler event count matches expected (' + expected.pressCount + ')' );
+            if ("pressCount" in expected) {
+                assert.equal(
+                    pressCount,
+                    expected.pressCount,
+                    expected.description +
+                        "pressHandler event count matches expected (" +
+                        expected.pressCount +
+                        ")"
+                );
             }
-            if ('releaseCount' in expected) {
-                assert.equal( releaseCount, expected.releaseCount, expected.description + 'releaseHandler event count matches expected (' + expected.releaseCount + ')' );
+            if ("releaseCount" in expected) {
+                assert.equal(
+                    releaseCount,
+                    expected.releaseCount,
+                    expected.description +
+                        "releaseHandler event count matches expected (" +
+                        expected.releaseCount +
+                        ")"
+                );
             }
-            if ('rightPressCount' in expected) {
-                assert.equal( rightPressCount, expected.rightPressCount, expected.description + 'nonPrimaryPressHandler event count (secondary/right button) matches expected (' + expected.rightPressCount + ')' );
+            if ("rightPressCount" in expected) {
+                assert.equal(
+                    rightPressCount,
+                    expected.rightPressCount,
+                    expected.description +
+                        "nonPrimaryPressHandler event count (secondary/right button) matches expected (" +
+                        expected.rightPressCount +
+                        ")"
+                );
             }
-            if ('rightReleaseCount' in expected) {
-                assert.equal( rightReleaseCount, expected.rightReleaseCount, expected.description + 'nonPrimaryReleaseHandler event count (secondary/right button) matches expected (' + expected.rightReleaseCount + ')' );
+            if ("rightReleaseCount" in expected) {
+                assert.equal(
+                    rightReleaseCount,
+                    expected.rightReleaseCount,
+                    expected.description +
+                        "nonPrimaryReleaseHandler event count (secondary/right button) matches expected (" +
+                        expected.rightReleaseCount +
+                        ")"
+                );
             }
-            if ('middlePressCount' in expected) {
-                assert.equal( middlePressCount, expected.middlePressCount, expected.description + 'nonPrimaryPressHandler event count (aux/middle button) matches expected (' + expected.middlePressCount + ')' );
+            if ("middlePressCount" in expected) {
+                assert.equal(
+                    middlePressCount,
+                    expected.middlePressCount,
+                    expected.description +
+                        "nonPrimaryPressHandler event count (aux/middle button) matches expected (" +
+                        expected.middlePressCount +
+                        ")"
+                );
             }
-            if ('middleReleaseCount' in expected) {
-                assert.equal( middleReleaseCount, expected.middleReleaseCount, expected.description + 'nonPrimaryReleaseHandler event count (aux/middle button) matches expected (' + expected.middleReleaseCount + ')' );
+            if ("middleReleaseCount" in expected) {
+                assert.equal(
+                    middleReleaseCount,
+                    expected.middleReleaseCount,
+                    expected.description +
+                        "nonPrimaryReleaseHandler event count (aux/middle button) matches expected (" +
+                        expected.middleReleaseCount +
+                        ")"
+                );
             }
-            if ('moveCount' in expected) {
-                assert.equal( moveCount, expected.moveCount, expected.description + 'moveHandler event count matches expected (' + expected.moveCount + ')' );
+            if ("moveCount" in expected) {
+                assert.equal(
+                    moveCount,
+                    expected.moveCount,
+                    expected.description +
+                        "moveHandler event count matches expected (" +
+                        expected.moveCount +
+                        ")"
+                );
             }
-            if ('clickCount' in expected) {
-                assert.equal( clickCount, expected.clickCount, expected.description + 'clickHandler event count matches expected (' + expected.clickCount + ')' );
+            if ("clickCount" in expected) {
+                assert.equal(
+                    clickCount,
+                    expected.clickCount,
+                    expected.description +
+                        "clickHandler event count matches expected (" +
+                        expected.clickCount +
+                        ")"
+                );
             }
-            if ('dblClickCount' in expected) {
-                assert.equal( dblClickCount, expected.dblClickCount, expected.description + 'dblClickHandler event count matches expected (' + expected.dblClickCount + ')' );
+            if ("dblClickCount" in expected) {
+                assert.equal(
+                    dblClickCount,
+                    expected.dblClickCount,
+                    expected.description +
+                        "dblClickHandler event count matches expected (" +
+                        expected.dblClickCount +
+                        ")"
+                );
             }
-            if ('dragCount' in expected) {
-                assert.equal( dragCount, expected.dragCount, expected.description + 'dragHandler event count matches expected (' + expected.dragCount + ')' );
+            if ("dragCount" in expected) {
+                assert.equal(
+                    dragCount,
+                    expected.dragCount,
+                    expected.description +
+                        "dragHandler event count matches expected (" +
+                        expected.dragCount +
+                        ")"
+                );
             }
-            if ('dragEndCount' in expected) {
-                assert.equal( dragEndCount, expected.dragEndCount, expected.description + 'dragEndHandler event count matches expected (' + expected.dragEndCount + ')' );
+            if ("dragEndCount" in expected) {
+                assert.equal(
+                    dragEndCount,
+                    expected.dragEndCount,
+                    expected.description +
+                        "dragEndHandler event count matches expected (" +
+                        expected.dragEndCount +
+                        ")"
+                );
             }
-            if ('insideElementPressed' in expected) {
-                assert.equal( insideElementPressed, expected.insideElementPressed, expected.description + 'releaseHandler event.insideElementPressed matches expected (' + expected.insideElementPressed + ')' );
+            if ("insideElementPressed" in expected) {
+                assert.equal(
+                    insideElementPressed,
+                    expected.insideElementPressed,
+                    expected.description +
+                        "releaseHandler event.insideElementPressed matches expected (" +
+                        expected.insideElementPressed +
+                        ")"
+                );
             }
-            if ('insideElementReleased' in expected) {
-                assert.equal( insideElementReleased, expected.insideElementReleased, expected.description + 'releaseHandler event.insideElementReleased matches expected (' + expected.insideElementReleased + ')' );
+            if ("insideElementReleased" in expected) {
+                assert.equal(
+                    insideElementReleased,
+                    expected.insideElementReleased,
+                    expected.description +
+                        "releaseHandler event.insideElementReleased matches expected (" +
+                        expected.insideElementReleased +
+                        ")"
+                );
             }
-            if ('contacts' in expected) {
-                assert.equal( pointersList.contacts, expected.contacts, expected.description + 'Remaining pointer contact count matches expected (' + expected.contacts + ')' );
+            if ("contacts" in expected) {
+                assert.equal(
+                    pointersList.contacts,
+                    expected.contacts,
+                    expected.description +
+                        "Remaining pointer contact count matches expected (" +
+                        expected.contacts +
+                        ")"
+                );
             }
-            if ('trackedPointers' in expected) {
-                assert.equal( pointersList.getLength(), expected.trackedPointers, expected.description + 'Remaining tracked pointer count matches expected (' + expected.trackedPointers + ')' );
+            if ("trackedPointers" in expected) {
+                assert.equal(
+                    pointersList.getLength(),
+                    expected.trackedPointers,
+                    expected.description +
+                        "Remaining tracked pointer count matches expected (" +
+                        expected.trackedPointers +
+                        ")"
+                );
             }
-            if ('quickClick' in expected) {
-                assert.equal( quickClick, expected.quickClick, expected.description + 'clickHandler event.quick matches expected (' + expected.quickClick + ')' );
+            if ("quickClick" in expected) {
+                assert.equal(
+                    quickClick,
+                    expected.quickClick,
+                    expected.description +
+                        "clickHandler event.quick matches expected (" +
+                        expected.quickClick +
+                        ")"
+                );
             }
-            if ('speed' in expected) {
-                Util.assessNumericValue(expected.speed, speed, 1.0, expected.description + 'Drag speed ');
+            if ("speed" in expected) {
+                Util.assessNumericValue(
+                    expected.speed,
+                    speed,
+                    1.0,
+                    expected.description + "Drag speed "
+                );
             }
-            if ('direction' in expected) {
-                Util.assessNumericValue(expected.direction, direction, 0.2, expected.description + 'Drag direction ');
+            if ("direction" in expected) {
+                Util.assessNumericValue(
+                    expected.direction,
+                    direction,
+                    0.2,
+                    expected.description + "Drag direction "
+                );
             }
         };
 
-        var onOpen = function ( event ) {
-
-            viewer.removeHandler( 'open', onOpen );
+        var onOpen = function (event) {
+            viewer.removeHandler("open", onOpen);
 
             hookViewerHandlers();
 
@@ -353,24 +490,25 @@
             simulateMove(-1, -1, 10);
             simulateUp(0, 0);
             assessGestureExpectations({
-                description:           'enter-move-release (release in tracked element, press in unknown element):  ',
-                enterCount:            1,
-                leaveCount:            0,
-                pressCount:            0,
-                releaseCount:          1,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             20,
-                clickCount:            0,
-                dblClickCount:         0,
-                dragCount:             0,
-                dragEndCount:          0,
-                insideElementPressed:  false,
+                description:
+                    "enter-move-release (release in tracked element, press in unknown element):  ",
+                enterCount: 1,
+                leaveCount: 0,
+                pressCount: 0,
+                releaseCount: 1,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 20,
+                clickCount: 0,
+                dblClickCount: 0,
+                dragCount: 0,
+                dragEndCount: 0,
+                insideElementPressed: false,
                 insideElementReleased: true,
-                contacts:              0,
-                trackedPointers:       1
+                contacts: 0,
+                trackedPointers: 1,
                 //quickClick:            false
             });
             simulateLeave(-1, -1); // flush tracked pointer
@@ -382,24 +520,24 @@
             simulateMove(-1, -1, 10);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-move-leave (fly-over):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            0,
-                releaseCount:          0,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             20,
-                clickCount:            0,
-                dblClickCount:         0,
-                dragCount:             0,
-                dragEndCount:          0,
+                description: "enter-move-leave (fly-over):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 0,
+                releaseCount: 0,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 20,
+                clickCount: 0,
+                dblClickCount: 0,
+                dragCount: 0,
+                dragEndCount: 0,
                 //insideElementPressed:  false,
                 //insideElementReleased: false,
-                contacts:              0,
-                trackedPointers:       0
+                contacts: 0,
+                trackedPointers: 0,
                 //quickClick:            false
             });
 
@@ -409,24 +547,24 @@
             simulateMove(-1, -1, 10);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'move-leave (fly-over, no enter event):  ',
-                enterCount:            0,
-                leaveCount:            1,
-                pressCount:            0,
-                releaseCount:          0,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             20,
-                clickCount:            0,
-                dblClickCount:         0,
-                dragCount:             0,
-                dragEndCount:          0,
+                description: "move-leave (fly-over, no enter event):  ",
+                enterCount: 0,
+                leaveCount: 1,
+                pressCount: 0,
+                releaseCount: 0,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 20,
+                clickCount: 0,
+                dblClickCount: 0,
+                dragCount: 0,
+                dragEndCount: 0,
                 //insideElementPressed:  false,
                 //insideElementReleased: false,
-                contacts:              0,
-                trackedPointers:       0
+                contacts: 0,
+                trackedPointers: 0,
                 //quickClick:            false
             });
 
@@ -439,24 +577,25 @@
             simulateUp(0, 0);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-press-release-press-release-leave (primary/left double click):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            2,
-                releaseCount:          2,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             0,
-                clickCount:            2,
-                dblClickCount:         1,
-                dragCount:             0,
-                dragEndCount:          2, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
-                insideElementPressed:  true,
+                description:
+                    "enter-press-release-press-release-leave (primary/left double click):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 2,
+                releaseCount: 2,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 0,
+                clickCount: 2,
+                dblClickCount: 1,
+                dragCount: 0,
+                dragEndCount: 2, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
+                insideElementPressed: true,
                 insideElementReleased: true,
-                contacts:              0,
-                trackedPointers:       0
+                contacts: 0,
+                trackedPointers: 0,
                 //quickClick:            true
             });
 
@@ -467,25 +606,26 @@
             simulateUp(0, 0);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-press-release-leave (primary/left click):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            1,
-                releaseCount:          1,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             0,
-                clickCount:            1,
-                dblClickCount:         0,
-                dragCount:             0,
-                dragEndCount:          1, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
-                insideElementPressed:  true,
+                description:
+                    "enter-press-release-leave (primary/left click):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 1,
+                releaseCount: 1,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 0,
+                clickCount: 1,
+                dblClickCount: 0,
+                dragCount: 0,
+                dragEndCount: 1, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
+                insideElementPressed: true,
                 insideElementReleased: true,
-                contacts:              0,
-                trackedPointers:       0,
-                quickClick:            true
+                contacts: 0,
+                trackedPointers: 0,
+                quickClick: true,
             });
 
             // enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click)
@@ -495,24 +635,25 @@
             simulateNonPrimaryUp(0, 0, 2);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            0,
-                releaseCount:          0,
-                rightPressCount:       1,
-                rightReleaseCount:     1,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             0,
-                clickCount:            0,
-                dblClickCount:         0,
-                dragCount:             0,
-                dragEndCount:          0,
+                description:
+                    "enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 0,
+                releaseCount: 0,
+                rightPressCount: 1,
+                rightReleaseCount: 1,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 0,
+                clickCount: 0,
+                dblClickCount: 0,
+                dragCount: 0,
+                dragEndCount: 0,
                 //insideElementPressed:  true,
                 //insideElementReleased: true,
-                contacts:              0,
-                trackedPointers:       0,
+                contacts: 0,
+                trackedPointers: 0,
                 //quickClick:            true
             });
 
@@ -523,24 +664,25 @@
             simulateNonPrimaryUp(0, 0, 1);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-nonprimarypress-nonprimaryrelease-leave (aux/middle click):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            0,
-                releaseCount:          0,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      1,
-                middleReleaseCount:    1,
-                moveCount:             0,
-                clickCount:            0,
-                dblClickCount:         0,
-                dragCount:             0,
-                dragEndCount:          0,
+                description:
+                    "enter-nonprimarypress-nonprimaryrelease-leave (aux/middle click):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 0,
+                releaseCount: 0,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 1,
+                middleReleaseCount: 1,
+                moveCount: 0,
+                clickCount: 0,
+                dblClickCount: 0,
+                dragCount: 0,
+                dragEndCount: 0,
                 //insideElementPressed:  true,
                 //insideElementReleased: true,
-                contacts:              0,
-                trackedPointers:       0,
+                contacts: 0,
+                trackedPointers: 0,
                 //quickClick:            true
             });
 
@@ -553,24 +695,25 @@
             simulateMove(-1, -1, 100);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-nonprimarypress-move-nonprimaryrelease-move-leave (secondary/right button drag, release in tracked element):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            0,
-                releaseCount:          0,
-                rightPressCount:       1,
-                rightReleaseCount:     1,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             200,
-                clickCount:            0,
-                dblClickCount:         0,
-                dragCount:             0,
-                dragEndCount:          0,
+                description:
+                    "enter-nonprimarypress-move-nonprimaryrelease-move-leave (secondary/right button drag, release in tracked element):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 0,
+                releaseCount: 0,
+                rightPressCount: 1,
+                rightReleaseCount: 1,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 200,
+                clickCount: 0,
+                dblClickCount: 0,
+                dragCount: 0,
+                dragEndCount: 0,
                 //insideElementPressed:  true,
                 //insideElementReleased: true,
-                contacts:              0,
-                trackedPointers:       0,
+                contacts: 0,
+                trackedPointers: 0,
                 //quickClick:            false
             });
 
@@ -583,25 +726,26 @@
             simulateMove(-1, -1, 100);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:           'enter-press-move-release-move-leave (drag, release in tracked element):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            1,
-                releaseCount:          1,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             200,
-                clickCount:            1,
-                dblClickCount:         0,
-                dragCount:             100,
-                dragEndCount:          1,
-                insideElementPressed:  true,
+                description:
+                    "enter-press-move-release-move-leave (drag, release in tracked element):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 1,
+                releaseCount: 1,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 200,
+                clickCount: 1,
+                dblClickCount: 0,
+                dragCount: 100,
+                dragEndCount: 1,
+                insideElementPressed: true,
                 insideElementReleased: true,
-                contacts:              0,
-                trackedPointers:       0,
-                quickClick:            false
+                contacts: 0,
+                trackedPointers: 0,
+                quickClick: false,
             });
 
             // enter-press-move-leave-move-release (drag, release outside tracked element)
@@ -614,25 +758,26 @@
             simulateMove(-1, -1, 5);
             simulateUp(-5, -5);
             assessGestureExpectations({
-                description:           'enter-press-move-leave-move-release (drag, release outside tracked element):  ',
-                enterCount:            1,
-                leaveCount:            1,
-                pressCount:            1,
-                releaseCount:          1,
-                rightPressCount:       0,
-                rightReleaseCount:     0,
-                middlePressCount:      0,
-                middleReleaseCount:    0,
-                moveCount:             15,
-                clickCount:            0,
-                dblClickCount:         0,
-                dragCount:             15,
-                dragEndCount:          1,
-                insideElementPressed:  true,
+                description:
+                    "enter-press-move-leave-move-release (drag, release outside tracked element):  ",
+                enterCount: 1,
+                leaveCount: 1,
+                pressCount: 1,
+                releaseCount: 1,
+                rightPressCount: 0,
+                rightReleaseCount: 0,
+                middlePressCount: 0,
+                middleReleaseCount: 0,
+                moveCount: 15,
+                clickCount: 0,
+                dblClickCount: 0,
+                dragCount: 15,
+                dragEndCount: 1,
+                insideElementPressed: true,
                 insideElementReleased: false,
-                contacts:              0,
-                trackedPointers:       0,
-                quickClick:            false
+                contacts: 0,
+                trackedPointers: 0,
+                quickClick: false,
             });
 
             //// enter-press-move-leave-move-release-outside (drag, release outside iframe)
@@ -671,16 +816,15 @@
             done();
         };
 
-        viewer.addHandler( 'open', onOpen );
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
+        viewer.addHandler("open", onOpen);
+        viewer.open("/test/data/testpattern.dzi");
+    });
 
     // ----------
-    if ('TouchEvent' in window) {
-        QUnit.test( 'MouseTracker: touch events', function (assert) {
+    if ("TouchEvent" in window) {
+        QUnit.test("MouseTracker: touch events", function (assert) {
             var done = assert.async();
-            var $canvas = $( viewer.element ).find( '.openseadragon-canvas' ).not( '.navigator .openseadragon-canvas' ),
-                tracker = viewer.innerTracker,
+            var tracker = viewer.innerTracker,
                 touches;
 
             var reset = function () {
@@ -688,115 +832,140 @@
                 TouchUtil.reset();
             };
 
-            var assessTouchExpectations = function ( expected ) {
-                var pointersList = tracker.getActivePointersListByType( 'touch' );
-                if ('captureCount' in expected) {
-                    assert.equal( pointersList.captureCount, expected.captureCount, expected.description + 'Pointer capture count matches expected (' + expected.captureCount + ')' );
+            var assessTouchExpectations = function (expected) {
+                var pointersList = tracker.getActivePointersListByType("touch");
+                if ("captureCount" in expected) {
+                    assert.equal(
+                        pointersList.captureCount,
+                        expected.captureCount,
+                        expected.description +
+                            "Pointer capture count matches expected (" +
+                            expected.captureCount +
+                            ")"
+                    );
                 }
-                if ('contacts' in expected) {
-                    assert.equal( pointersList.contacts, expected.contacts, expected.description + 'Pointer contact count matches expected (' + expected.contacts + ')' );
+                if ("contacts" in expected) {
+                    assert.equal(
+                        pointersList.contacts,
+                        expected.contacts,
+                        expected.description +
+                            "Pointer contact count matches expected (" +
+                            expected.contacts +
+                            ")"
+                    );
                 }
-                if ('trackedPointers' in expected) {
-                    assert.equal( pointersList.getLength(), expected.trackedPointers, expected.description + 'Tracked pointer count matches expected (' + expected.trackedPointers + ')' );
+                if ("trackedPointers" in expected) {
+                    assert.equal(
+                        pointersList.getLength(),
+                        expected.trackedPointers,
+                        expected.description +
+                            "Tracked pointer count matches expected (" +
+                            expected.trackedPointers +
+                            ")"
+                    );
                 }
             };
 
-            var onOpen = function ( event ) {
-                viewer.removeHandler( 'open', onOpen );
+            var onOpen = function (event) {
+                viewer.removeHandler("open", onOpen);
 
-                TouchUtil.initTracker( tracker );
+                TouchUtil.initTracker(tracker);
 
                 // start-end-end (multi-touch start event)
                 reset();
-                touches = TouchUtil.start( [0,0], [20,20] );
+                touches = TouchUtil.start([0, 0], [20, 20]);
                 assessTouchExpectations({
-                    description:        'start-end-end (multi-touch start event) [capture]:  ',
-                    captureCount:       2,
-                    contacts:           2,
-                    trackedPointers:    2
+                    description:
+                        "start-end-end (multi-touch start event) [capture]:  ",
+                    captureCount: 2,
+                    contacts: 2,
+                    trackedPointers: 2,
                 });
-                TouchUtil.end( touches[1] );
-                TouchUtil.end( touches[0] );
+                TouchUtil.end(touches[1]);
+                TouchUtil.end(touches[0]);
                 assessTouchExpectations({
-                    description:        'start-end-end (multi-touch start event) [release]:  ',
-                    captureCount:       0,
-                    contacts:           0,
-                    trackedPointers:    0
+                    description:
+                        "start-end-end (multi-touch start event) [release]:  ",
+                    captureCount: 0,
+                    contacts: 0,
+                    trackedPointers: 0,
                 });
 
                 // start-start-end (multi-touch end event)
                 reset();
-                touches.push( TouchUtil.start([0, 0]) );
-                touches.push( TouchUtil.start([20, 20]) );
+                touches.push(TouchUtil.start([0, 0]));
+                touches.push(TouchUtil.start([20, 20]));
                 assessTouchExpectations({
-                    description:        'start-start-end (multi-touch end event) [capture]:  ',
-                    captureCount:       2,
-                    contacts:           2,
-                    trackedPointers:    2
+                    description:
+                        "start-start-end (multi-touch end event) [capture]:  ",
+                    captureCount: 2,
+                    contacts: 2,
+                    trackedPointers: 2,
                 });
-                TouchUtil.end( touches );
+                TouchUtil.end(touches);
                 assessTouchExpectations({
-                    description:        'start-start-end (multi-touch end event) [release]:  ',
-                    captureCount:       0,
-                    contacts:           0,
-                    trackedPointers:    0
+                    description:
+                        "start-start-end (multi-touch end event) [release]:  ",
+                    captureCount: 0,
+                    contacts: 0,
+                    trackedPointers: 0,
                 });
 
-                TouchUtil.resetTracker( tracker );
+                TouchUtil.resetTracker(tracker);
                 viewer.close();
                 done();
             };
 
-            viewer.addHandler( 'open', onOpen );
-            viewer.open( '/test/data/testpattern.dzi' );
-        } );
+            viewer.addHandler("open", onOpen);
+            viewer.open("/test/data/testpattern.dzi");
+        });
     }
 
     // ----------
-    QUnit.test('Viewer: preventDefaultAction', function(assert) {
+    QUnit.test("Viewer: preventDefaultAction", function (assert) {
         var done = assert.async();
-        var $canvas = $(viewer.element).find('.openseadragon-canvas')
-            .not('.navigator .openseadragon-canvas');
-        var tracker = viewer.innerTracker;
+        var $canvas = $(viewer.element)
+            .find(".openseadragon-canvas")
+            .not(".navigator .openseadragon-canvas");
+        //var tracker = viewer.innerTracker;
         var epsilon = 0.0000001;
 
         function simulateClickAndDrag() {
-            $canvas.simulate('focus');
+            $canvas.simulate("focus");
             // Drag to pan
-            Util.simulateViewerClickWithDrag( {
+            Util.simulateViewerClickWithDrag({
                 viewer: viewer,
                 widthFactor: 0.25,
                 heightFactor: 0.25,
                 dragCount: 10,
                 dragDx: 1,
-                dragDy: 1
-            } );
+                dragDy: 1,
+            });
             // Click to zoom
-            Util.simulateViewerClickWithDrag( {
+            Util.simulateViewerClickWithDrag({
                 viewer: viewer,
                 widthFactor: 0.25,
                 heightFactor: 0.25,
                 dragCount: 0,
                 dragDx: 0,
-                dragDy: 0
-            } );
-            $canvas.simulate('blur');
+                dragDy: 0,
+            });
+            $canvas.simulate("blur");
         }
 
-        var onOpen = function() {
-            viewer.removeHandler('open', onOpen);
+        var onOpen = function () {
+            viewer.removeHandler("open", onOpen);
 
             // Hook viewer events to set preventDefaultAction
-            var origClickHandler = tracker.clickHandler;
-            tracker.clickHandler = function(event) {
+            var onCanvasClick = function (event) {
                 event.preventDefaultAction = true;
-                return origClickHandler(event);
             };
-            var origDragHandler = tracker.dragHandler;
-            tracker.dragHandler = function(event) {
+            var onCanvasDrag = function (event) {
                 event.preventDefaultAction = true;
-                return origDragHandler(event);
             };
+
+            viewer.addHandler("canvas-click", onCanvasClick);
+            viewer.addHandler("canvas-drag", onCanvasDrag);
 
             var originalZoom = viewer.viewport.getZoom();
             var originalBounds = viewer.viewport.getBounds();
@@ -805,376 +974,498 @@
 
             var zoom = viewer.viewport.getZoom();
             var bounds = viewer.viewport.getBounds();
-            Util.assessNumericValue(assert, zoom, originalZoom, epsilon,
-                "Zoom should be prevented");
-            Util.assertRectangleEquals(assert, bounds, originalBounds, epsilon,
-                'Pan should be prevented');
+            Util.assessNumericValue(
+                assert,
+                zoom,
+                originalZoom,
+                epsilon,
+                "Zoom should be prevented"
+            );
+            Util.assertRectangleEquals(
+                assert,
+                bounds,
+                originalBounds,
+                epsilon,
+                "Pan should be prevented"
+            );
 
-            tracker.clickHandler = origClickHandler;
-            tracker.dragHandler = origDragHandler;
+            viewer.removeHandler("canvas-click", onCanvasClick);
+            viewer.removeHandler("canvas-drag", onCanvasDrag);
 
             simulateClickAndDrag();
 
             zoom = viewer.viewport.getZoom();
             bounds = viewer.viewport.getBounds();
-            Util.assessNumericValue(assert, zoom, 0.002, epsilon,
-                "Zoom should not be prevented");
+            Util.assessNumericValue(
+                assert,
+                zoom,
+                0.002,
+                epsilon,
+                "Zoom should not be prevented"
+            );
             Util.assertRectangleEquals(
                 assert,
                 new OpenSeadragon.Rect(-249.5, -0.25, 500, 0.5),
                 bounds,
                 epsilon,
-                'Pan should not be prevented');
+                "Pan should not be prevented"
+            );
 
             viewer.close();
             done();
         };
 
-        viewer.addHandler('open', onOpen);
-        viewer.open('/test/data/testpattern.dzi');
+        viewer.addHandler("open", onOpen);
+        viewer.open("/test/data/testpattern.dzi");
     });
 
     // ----------
-    QUnit.test('Viewer: preventDefaultAction in dblClickHandler', function(assert) {
-        var done = assert.async();
-        var tracker = viewer.innerTracker;
-        var epsilon = 0.0000001;
+    QUnit.test(
+        "Viewer: preventDefaultAction in dblClickHandler",
+        function (assert) {
+            var done = assert.async();
+            var tracker = viewer.innerTracker;
+            var epsilon = 0.0000001;
 
-        function simulateDblTap() {
-            var touches = [];
-            TouchUtil.reset();
+            function simulateDblTap() {
+                var touches = [];
+                TouchUtil.reset();
 
-            touches.push(TouchUtil.start([0,0]));
-            TouchUtil.end( touches[0] );
-            touches.push(TouchUtil.start([0,0]));
-            TouchUtil.end( touches[1] );
+                touches.push(TouchUtil.start([0, 0]));
+                TouchUtil.end(touches[0]);
+                touches.push(TouchUtil.start([0, 0]));
+                TouchUtil.end(touches[1]);
+            }
+
+            var onOpen = function () {
+                viewer.removeHandler("open", onOpen);
+
+                var originalZoom = viewer.viewport.getZoom();
+
+                var onCanvasDblClick = function (event) {
+                    event.preventDefaultAction = true;
+                };
+
+                viewer.addHandler("canvas-double-click", onCanvasDblClick);
+
+                TouchUtil.initTracker(tracker);
+                simulateDblTap();
+
+                var zoom = viewer.viewport.getZoom();
+                Util.assessNumericValue(
+                    assert,
+                    originalZoom,
+                    zoom,
+                    epsilon,
+                    "Zoom on double tap should be prevented"
+                );
+
+                // Reset event handler to original
+                viewer.removeHandler("canvas-double-click", onCanvasDblClick);
+
+                simulateDblTap();
+                originalZoom *= viewer.zoomPerClick;
+
+                zoom = viewer.viewport.getZoom();
+                Util.assessNumericValue(
+                    assert,
+                    originalZoom,
+                    zoom,
+                    epsilon,
+                    "Zoom on double tap should not be prevented"
+                );
+
+                TouchUtil.resetTracker(tracker);
+                viewer.close();
+                done();
+            };
+
+            viewer.addHandler("open", onOpen);
+            viewer.open("/test/data/testpattern.dzi");
         }
+    );
 
-        var onOpen = function() {
-            viewer.removeHandler('open', onOpen);
+    // ----------
+    QUnit.test(
+        "EventSource/MouseTracker/Viewer: event.originalEvent event.userData canvas-drag canvas-drag-end canvas-release canvas-click",
+        function (assert) {
+            var done = assert.async();
+            var $canvas = $(viewer.element)
+                    .find(".openseadragon-canvas")
+                    .not(".navigator .openseadragon-canvas"),
+                mouseTracker = null,
+                userData = { item1: "Test user data", item2: Math.random() },
+                originalUserData = {
+                    item1: userData.item1,
+                    item2: userData.item2,
+                },
+                dragCount = 10,
+                dragsHandledEventSource = 0,
+                dragEndsHandledEventSource = 0,
+                releasesHandledEventSource = 0,
+                clicksHandledEventSource = 0,
+                eventsHandledMouseTracker = 0,
+                eventSourcePassedMouseTracker = 0,
+                originalEventsPassedMouseTracker = 0,
+                eventsHandledViewer = 0,
+                originalEventsPassedViewer = 0,
+                dragEndsExpected = 1,
+                releasesExpected = 1;
 
-            var originalZoom = viewer.viewport.getZoom();
+            var onOpen = function () {
+                viewer.removeHandler("open", onOpen);
 
-            var origDblClickHandler = tracker.dblClickHandler;
-            tracker.dblClickHandler = function(event) {
-                event.preventDefaultAction = true;
-                return origDblClickHandler(event);
+                viewer.addHandler("canvas-drag", onEventSourceDrag);
+                viewer.addHandler("canvas-drag-end", onEventSourceDragEnd);
+                viewer.addHandler("canvas-release", onEventSourceRelease);
+                viewer.addHandler("canvas-click", onEventSourceClick);
+
+                mouseTracker = new OpenSeadragon.MouseTracker({
+                    element: $canvas[0],
+                    userData: userData,
+                    clickTimeThreshold:
+                        OpenSeadragon.DEFAULT_SETTINGS.clickTimeThreshold,
+                    clickDistThreshold:
+                        OpenSeadragon.DEFAULT_SETTINGS.clickDistThreshold,
+                    dblClickTimeThreshold:
+                        OpenSeadragon.DEFAULT_SETTINGS.dblClickTimeThreshold,
+                    dblClickDistThreshold:
+                        OpenSeadragon.DEFAULT_SETTINGS.dblClickDistThreshold,
+                    focusHandler: onMouseTrackerFocus,
+                    blurHandler: onMouseTrackerBlur,
+                    enterHandler: onMouseTrackerEnter,
+                    pressHandler: onMouseTrackerPress,
+                    moveHandler: onMouseTrackerMove,
+                    dragHandler: onMouseTrackerDrag,
+                    dragEndHandler: onMouseTrackerDragEnd,
+                    releaseHandler: onMouseTrackerRelease,
+                    clickHandler: onMouseTrackerClick,
+                    leaveHandler: onMouseTrackerLeave,
+                });
+
+                var event = {
+                    clientX: 1,
+                    clientY: 1,
+                };
+
+                $canvas.simulate("focus", event);
+                Util.simulateViewerClickWithDrag({
+                    viewer: viewer,
+                    widthFactor: 0.25,
+                    heightFactor: 0.25,
+                    dragCount: dragCount,
+                    dragDx: 1,
+                    dragDy: 1,
+                });
+                $canvas.simulate("blur", event);
             };
 
-            TouchUtil.initTracker(tracker);
-            simulateDblTap();
-
-            var zoom = viewer.viewport.getZoom();
-            Util.assessNumericValue(assert, originalZoom, zoom, epsilon,
-                "Zoom on double tap should be prevented");
-
-            // Reset event handler to original
-            tracker.dblClickHandler = origDblClickHandler;
-
-            simulateDblTap();
-            originalZoom = originalZoom * viewer.zoomPerClick;
-
-            zoom = viewer.viewport.getZoom();
-            Util.assessNumericValue(assert, originalZoom, zoom, epsilon,
-                "Zoom on double tap should not be prevented");
-
-
-            var dblClickHandler = function(event) {
-                event.preventDefaultAction = true;
+            var checkOriginalEventReceivedViewer = function (event) {
+                eventsHandledViewer++;
+                //TODO Provide a better check for the original event...simulate doesn't currently extend the object
+                //   with arbitrary user data.
+                if (event && event.originalEvent) {
+                    originalEventsPassedViewer++;
+                }
             };
 
-            viewer.addHandler('canvas-double-click', dblClickHandler);
+            var onEventSourceDrag = function (event) {
+                checkOriginalEventReceivedViewer(event);
+                dragsHandledEventSource++;
+            };
 
-            zoom = viewer.viewport.getZoom();
-            Util.assessNumericValue(assert, originalZoom, zoom, epsilon,
-                "Zoom on double tap should be prevented");
+            var onEventSourceDragEnd = function (event) {
+                checkOriginalEventReceivedViewer(event);
+                dragEndsHandledEventSource++;
+            };
 
-            // Remove custom event handler
-            viewer.removeHandler('canvas-double-click', dblClickHandler);
+            var onEventSourceRelease = function (event) {
+                checkOriginalEventReceivedViewer(event);
+                releasesHandledEventSource++;
+            };
 
-            simulateDblTap();
-            originalZoom = originalZoom * viewer.zoomPerClick;
+            var onEventSourceClick = function (event) {
+                checkOriginalEventReceivedViewer(event);
+                clicksHandledEventSource++;
+            };
 
-            zoom = viewer.viewport.getZoom();
-            Util.assessNumericValue(assert, originalZoom, zoom, epsilon,
-                "Zoom on double tap should not be prevented");
+            var checkOriginalEventReceived = function (event) {
+                eventsHandledMouseTracker++;
+                if (event && event.eventSource === mouseTracker) {
+                    eventSourcePassedMouseTracker++;
+                }
+                //TODO Provide a better check for the original event...simulate doesn't currently extend the object
+                //   with arbitrary user data.
+                if (event && event.originalEvent) {
+                    originalEventsPassedMouseTracker++;
+                }
+            };
 
-            TouchUtil.resetTracker(tracker);
+            var onMouseTrackerFocus = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerBlur = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerEnter = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerPress = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerMove = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerDrag = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerDragEnd = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerRelease = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerClick = function (event) {
+                checkOriginalEventReceived(event);
+            };
+
+            var onMouseTrackerLeave = function (event) {
+                checkOriginalEventReceived(event);
+
+                mouseTracker.destroy();
+                viewer.removeHandler("canvas-drag", onEventSourceDrag);
+                viewer.removeHandler("canvas-release", onEventSourceRelease);
+                viewer.removeHandler("canvas-click", onEventSourceClick);
+
+                assert.equal(
+                    dragsHandledEventSource,
+                    dragCount,
+                    "'canvas-drag' event count matches 'mousemove' event count (" +
+                        dragCount +
+                        ")"
+                );
+                assert.equal(
+                    dragEndsHandledEventSource,
+                    dragEndsExpected,
+                    "'canvas-drag-end' event count matches expected (" +
+                        dragEndsExpected +
+                        ")"
+                );
+                assert.equal(
+                    releasesHandledEventSource,
+                    releasesExpected,
+                    "'canvas-release' event count matches expected (" +
+                        releasesExpected +
+                        ")"
+                );
+                assert.equal(
+                    clicksHandledEventSource,
+                    releasesExpected,
+                    "'canvas-click' event count matches expected (" +
+                        releasesExpected +
+                        ")"
+                );
+                assert.equal(
+                    originalEventsPassedViewer,
+                    eventsHandledViewer,
+                    "Original event received count matches expected (" +
+                        eventsHandledViewer +
+                        ")"
+                );
+
+                assert.equal(
+                    eventSourcePassedMouseTracker,
+                    eventsHandledMouseTracker,
+                    "Event source received count matches expected (" +
+                        eventsHandledMouseTracker +
+                        ")"
+                );
+                assert.equal(
+                    originalEventsPassedMouseTracker,
+                    eventsHandledMouseTracker,
+                    "Original event received count matches expected (" +
+                        eventsHandledMouseTracker +
+                        ")"
+                );
+                assert.deepEqual(
+                    event.userData,
+                    originalUserData,
+                    "MouseTracker userData was untouched"
+                );
+
+                viewer.close();
+                done();
+            };
+
+            viewer.addHandler("open", onOpen);
+            viewer.open("/test/data/testpattern.dzi");
+        }
+    );
+
+    // ----------
+    QUnit.test("EventSource: addHandler without userData", function (assert) {
+        var done = assert.async();
+        var openHandler = function (event) {
+            viewer.removeHandler("open", openHandler);
+            assert.ok(event, "Event handler received event data");
+            if (event) {
+                assert.strictEqual(
+                    event.eventSource,
+                    viewer,
+                    "eventSource sent, eventSource is viewer"
+                );
+                assert.strictEqual(
+                    event.userData,
+                    null,
+                    "User data defaulted to null"
+                );
+            }
             viewer.close();
             done();
         };
 
-        viewer.addHandler('open', onOpen);
-        viewer.open('/test/data/testpattern.dzi');
+        viewer.addHandler("open", openHandler);
+        viewer.open("/test/data/testpattern.dzi");
     });
 
     // ----------
-    QUnit.test( 'EventSource/MouseTracker/Viewer: event.originalEvent event.userData canvas-drag canvas-drag-end canvas-release canvas-click', function (assert) {
+    QUnit.test("EventSource: addHandler with userData", function (assert) {
         var done = assert.async();
-        var $canvas = $( viewer.element ).find( '.openseadragon-canvas' ).not( '.navigator .openseadragon-canvas' ),
-            mouseTracker = null,
-            userData = { item1: 'Test user data', item2: Math.random() },
-            originalUserData = { item1: userData.item1, item2: userData.item2 },
-            dragCount = 10,
-            dragsHandledEventSource = 0,
-            dragEndsHandledEventSource = 0,
-            releasesHandledEventSource = 0,
-            clicksHandledEventSource = 0,
-            eventsHandledMouseTracker = 0,
-            eventSourcePassedMouseTracker = 0,
-            originalEventsPassedMouseTracker = 0,
-            eventsHandledViewer = 0,
-            originalEventsPassedViewer = 0,
-            dragEndsExpected = 1,
-            releasesExpected = 1,
-            clicksExpected = 1;
-
-        var onOpen = function ( event ) {
-            viewer.removeHandler( 'open', onOpen );
-
-            viewer.addHandler( 'canvas-drag', onEventSourceDrag );
-            viewer.addHandler( 'canvas-drag-end', onEventSourceDragEnd );
-            viewer.addHandler( 'canvas-release', onEventSourceRelease );
-            viewer.addHandler( 'canvas-click', onEventSourceClick );
-
-            mouseTracker = new OpenSeadragon.MouseTracker( {
-                element: $canvas[0],
-                userData: userData,
-                clickTimeThreshold: OpenSeadragon.DEFAULT_SETTINGS.clickTimeThreshold,
-                clickDistThreshold: OpenSeadragon.DEFAULT_SETTINGS.clickDistThreshold,
-                dblClickTimeThreshold: OpenSeadragon.DEFAULT_SETTINGS.dblClickTimeThreshold,
-                dblClickDistThreshold: OpenSeadragon.DEFAULT_SETTINGS.dblClickDistThreshold,
-                focusHandler: onMouseTrackerFocus,
-                blurHandler: onMouseTrackerBlur,
-                enterHandler: onMouseTrackerEnter,
-                pressHandler: onMouseTrackerPress,
-                moveHandler: onMouseTrackerMove,
-                dragHandler: onMouseTrackerDrag,
-                dragEndHandler: onMouseTrackerDragEnd,
-                releaseHandler: onMouseTrackerRelease,
-                clickHandler: onMouseTrackerClick,
-                leaveHandler: onMouseTrackerLeave
-            } );
-
-            var event = {
-                clientX:1,
-                clientY:1
-            };
-
-            $canvas.simulate( 'focus', event );
-            Util.simulateViewerClickWithDrag( {
-                viewer: viewer,
-                widthFactor: 0.25,
-                heightFactor: 0.25,
-                dragCount: dragCount,
-                dragDx: 1,
-                dragDy: 1
-            } );
-            $canvas.simulate( 'blur', event );
-        };
-
-        var checkOriginalEventReceivedViewer = function ( event ) {
-            eventsHandledViewer++;
-            //TODO Provide a better check for the original event...simulate doesn't currently extend the object
-            //   with arbitrary user data.
-            if ( event && event.originalEvent ) {
-                originalEventsPassedViewer++;
-            }
-        };
-
-        var onEventSourceDrag = function ( event ) {
-            checkOriginalEventReceivedViewer( event );
-            dragsHandledEventSource++;
-        };
-
-        var onEventSourceDragEnd = function ( event ) {
-            checkOriginalEventReceivedViewer( event );
-            dragEndsHandledEventSource++;
-        };
-
-        var onEventSourceRelease = function ( event ) {
-            checkOriginalEventReceivedViewer( event );
-            releasesHandledEventSource++;
-        };
-
-        var onEventSourceClick = function ( event ) {
-            checkOriginalEventReceivedViewer( event );
-            clicksHandledEventSource++;
-        };
-
-        var checkOriginalEventReceived = function ( event ) {
-            eventsHandledMouseTracker++;
-            if ( event && event.eventSource === mouseTracker ) {
-                eventSourcePassedMouseTracker++;
-            }
-            //TODO Provide a better check for the original event...simulate doesn't currently extend the object
-            //   with arbitrary user data.
-            if ( event && event.originalEvent ) {
-                originalEventsPassedMouseTracker++;
-            }
-        };
-
-        var onMouseTrackerFocus = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerBlur = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerEnter = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerPress = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerMove = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerDrag = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerDragEnd = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerRelease = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerClick = function ( event ) {
-            checkOriginalEventReceived( event );
-        };
-
-        var onMouseTrackerLeave = function ( event ) {
-            checkOriginalEventReceived( event );
-
-            mouseTracker.destroy();
-            viewer.removeHandler( 'canvas-drag', onEventSourceDrag );
-            viewer.removeHandler( 'canvas-release', onEventSourceRelease );
-            viewer.removeHandler( 'canvas-click', onEventSourceClick );
-
-            assert.equal( dragsHandledEventSource, dragCount, "'canvas-drag' event count matches 'mousemove' event count (" + dragCount + ")" );
-            assert.equal( dragEndsHandledEventSource, dragEndsExpected, "'canvas-drag-end' event count matches expected (" + dragEndsExpected + ")" );
-            assert.equal( releasesHandledEventSource, releasesExpected, "'canvas-release' event count matches expected (" + releasesExpected + ")" );
-            assert.equal( clicksHandledEventSource, releasesExpected, "'canvas-click' event count matches expected (" + releasesExpected + ")" );
-            assert.equal( originalEventsPassedViewer, eventsHandledViewer, "Original event received count matches expected (" + eventsHandledViewer + ")" );
-
-            assert.equal( eventSourcePassedMouseTracker, eventsHandledMouseTracker, "Event source received count matches expected (" + eventsHandledMouseTracker + ")" );
-            assert.equal( originalEventsPassedMouseTracker, eventsHandledMouseTracker, "Original event received count matches expected (" + eventsHandledMouseTracker + ")" );
-            assert.deepEqual( event.userData, originalUserData, 'MouseTracker userData was untouched' );
-
-            viewer.close();
-            done();
-        };
-
-        viewer.addHandler( 'open', onOpen );
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
-
-    // ----------
-    QUnit.test( 'EventSource: addHandler without userData', function (assert) {
-        var done = assert.async();
-        var openHandler = function ( event ) {
-            viewer.removeHandler( 'open', openHandler );
-            assert.ok( event, 'Event handler received event data' );
-            if ( event ) {
-                assert.strictEqual( event.eventSource, viewer, 'eventSource sent, eventSource is viewer' );
-                assert.strictEqual( event.userData, null, 'User data defaulted to null' );
-            }
-            viewer.close();
-            done();
-        };
-
-        viewer.addHandler( 'open', openHandler );
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
-
-    // ----------
-    QUnit.test( 'EventSource: addHandler with userData', function (assert) {
-        var done = assert.async();
-        var userData = { item1: 'Test user data', item2: Math.random() },
+        var userData = { item1: "Test user data", item2: Math.random() },
             originalUserData = { item1: userData.item1, item2: userData.item2 };
 
-        var openHandler = function ( event ) {
-            viewer.removeHandler( 'open', openHandler );
-            assert.ok( event, 'Event handler received event data' );
-            assert.ok( event && event.userData, 'Event handler received user data' );
-            if ( event && event.userData ) {
-                assert.deepEqual( event.userData, originalUserData, 'User data was untouched' );
+        var openHandler = function (event) {
+            viewer.removeHandler("open", openHandler);
+            assert.ok(event, "Event handler received event data");
+            assert.ok(
+                event && event.userData,
+                "Event handler received user data"
+            );
+            if (event && event.userData) {
+                assert.deepEqual(
+                    event.userData,
+                    originalUserData,
+                    "User data was untouched"
+                );
             }
             viewer.close();
             done();
         };
 
-        viewer.addHandler( 'open', openHandler, userData );
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
-
-    // ----------
-    QUnit.test('EventSource: addOnceHandler', function(assert) {
-        var eventSource = new OpenSeadragon.EventSource();
-        var userData = 'data';
-        var eventData = {
-            foo: 1
-        };
-        var handlerCalledCount = 0;
-        eventSource.addOnceHandler('test-event', function(event) {
-            handlerCalledCount++;
-            assert.strictEqual(event.foo, eventData.foo,
-                'Event data should be transmitted to the event.');
-            assert.strictEqual(event.userData, userData,
-                'User data should be transmitted to the event.');
-        }, userData);
-        assert.strictEqual(0, handlerCalledCount,
-            'Handler should not have been called yet.');
-        eventSource.raiseEvent('test-event', eventData);
-        assert.strictEqual(1, handlerCalledCount,
-            'Handler should have been called once.');
-        eventSource.raiseEvent('test-event', eventData);
-        assert.strictEqual(1, handlerCalledCount,
-            'Handler should still have been called once.');
+        viewer.addHandler("open", openHandler, userData);
+        viewer.open("/test/data/testpattern.dzi");
     });
 
     // ----------
-    QUnit.test('EventSource: addOnceHandler 2 times', function(assert) {
+    QUnit.test("EventSource: addOnceHandler", function (assert) {
         var eventSource = new OpenSeadragon.EventSource();
-        var userData = 'data';
+        var userData = "data";
         var eventData = {
-            foo: 1
+            foo: 1,
         };
         var handlerCalledCount = 0;
-        eventSource.addOnceHandler('test-event', function(event) {
-            handlerCalledCount++;
-            assert.strictEqual(event.foo, eventData.foo,
-                'Event data should be transmitted to the event.');
-            assert.strictEqual(event.userData, userData,
-                'User data should be transmitted to the event.');
-        }, userData, 2);
-        assert.strictEqual(0, handlerCalledCount,
-            'Handler should not have been called yet.');
-        eventSource.raiseEvent('test-event', eventData);
-        assert.strictEqual(1, handlerCalledCount,
-            'Handler should have been called once.');
-        eventSource.raiseEvent('test-event', eventData);
-        assert.strictEqual(2, handlerCalledCount,
-            'Handler should have been called twice.');
-        eventSource.raiseEvent('test-event', eventData);
-        assert.strictEqual(2, handlerCalledCount,
-            'Handler should still have been called twice.');
+        eventSource.addOnceHandler(
+            "test-event",
+            function (event) {
+                handlerCalledCount++;
+                assert.strictEqual(
+                    event.foo,
+                    eventData.foo,
+                    "Event data should be transmitted to the event."
+                );
+                assert.strictEqual(
+                    event.userData,
+                    userData,
+                    "User data should be transmitted to the event."
+                );
+            },
+            userData
+        );
+        assert.strictEqual(
+            0,
+            handlerCalledCount,
+            "Handler should not have been called yet."
+        );
+        eventSource.raiseEvent("test-event", eventData);
+        assert.strictEqual(
+            1,
+            handlerCalledCount,
+            "Handler should have been called once."
+        );
+        eventSource.raiseEvent("test-event", eventData);
+        assert.strictEqual(
+            1,
+            handlerCalledCount,
+            "Handler should still have been called once."
+        );
     });
 
     // ----------
-    QUnit.test( 'Viewer: tile-drawing event', function (assert) {
+    QUnit.test("EventSource: addOnceHandler 2 times", function (assert) {
+        var eventSource = new OpenSeadragon.EventSource();
+        var userData = "data";
+        var eventData = {
+            foo: 1,
+        };
+        var handlerCalledCount = 0;
+        eventSource.addOnceHandler(
+            "test-event",
+            function (event) {
+                handlerCalledCount++;
+                assert.strictEqual(
+                    event.foo,
+                    eventData.foo,
+                    "Event data should be transmitted to the event."
+                );
+                assert.strictEqual(
+                    event.userData,
+                    userData,
+                    "User data should be transmitted to the event."
+                );
+            },
+            userData,
+            2
+        );
+        assert.strictEqual(
+            0,
+            handlerCalledCount,
+            "Handler should not have been called yet."
+        );
+        eventSource.raiseEvent("test-event", eventData);
+        assert.strictEqual(
+            1,
+            handlerCalledCount,
+            "Handler should have been called once."
+        );
+        eventSource.raiseEvent("test-event", eventData);
+        assert.strictEqual(
+            2,
+            handlerCalledCount,
+            "Handler should have been called twice."
+        );
+        eventSource.raiseEvent("test-event", eventData);
+        assert.strictEqual(
+            2,
+            handlerCalledCount,
+            "Handler should still have been called twice."
+        );
+    });
+
+    // ----------
+    QUnit.test("Viewer: tile-drawing event", function (assert) {
         var done = assert.async();
-        var tileDrawing = function ( event ) {
-            viewer.removeHandler( 'tile-drawing', tileDrawing );
-            assert.ok( event, 'Event handler should be invoked' );
-            if ( event ) {
+        var tileDrawing = function (event) {
+            viewer.removeHandler("tile-drawing", tileDrawing);
+            assert.ok(event, "Event handler should be invoked");
+            if (event) {
                 // Make sure we have the expected elements set
                 assert.ok(event.context, "Context should be set");
                 assert.ok(event.tile, "Tile should be set");
@@ -1184,108 +1475,173 @@
             done();
         };
 
-        viewer.addHandler( 'tile-drawing', tileDrawing );
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
+        viewer.addHandler("tile-drawing", tileDrawing);
+        viewer.open("/test/data/testpattern.dzi");
+    });
 
     // tile-loaded event tests
-    QUnit.test( 'Viewer: tile-loaded event without callback.', function (assert) {
-        var done = assert.async();
-        function tileLoaded ( event ) {
-            viewer.removeHandler( 'tile-loaded', tileLoaded);
-            var tile = event.tile;
-            assert.ok( tile.loading, "The tile should be marked as loading.");
-            assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
-            setTimeout(function() {
-                assert.notOk( tile.loading, "The tile should not be marked as loading.");
-                assert.ok( tile.loaded, "The tile should be marked as loaded.");
-                done();
-            }, 0);
-        }
-
-        viewer.addHandler( 'tile-loaded', tileLoaded);
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
-
-    QUnit.test( 'Viewer: tile-loaded event with 1 callback.', function (assert) {
-        var done = assert.async();
-        function tileLoaded ( event ) {
-            viewer.removeHandler( 'tile-loaded', tileLoaded);
-            var tile = event.tile;
-            var callback = event.getCompletionCallback();
-            assert.ok( tile.loading, "The tile should be marked as loading.");
-            assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
-            assert.ok( callback, "The event should have a callback.");
-            setTimeout(function() {
-                assert.ok( tile.loading, "The tile should be marked as loading.");
-                assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
-                callback();
-                assert.notOk( tile.loading, "The tile should not be marked as loading.");
-                assert.ok( tile.loaded, "The tile should be marked as loaded.");
-                done();
-            }, 0);
-        }
-
-        viewer.addHandler( 'tile-loaded', tileLoaded);
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
-
-    QUnit.test( 'Viewer: tile-loaded event with 2 callbacks.', function (assert) {
-        var done = assert.async();
-        function tileLoaded ( event ) {
-            viewer.removeHandler( 'tile-loaded', tileLoaded);
-            var tile = event.tile;
-            var callback1 = event.getCompletionCallback();
-            var callback2 = event.getCompletionCallback();
-            assert.ok( tile.loading, "The tile should be marked as loading.");
-            assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
-            setTimeout(function() {
-                assert.ok( tile.loading, "The tile should be marked as loading.");
-                assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
-                callback1();
-                assert.ok( tile.loading, "The tile should be marked as loading.");
-                assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
-                setTimeout(function() {
-                    assert.ok( tile.loading, "The tile should be marked as loading.");
-                    assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
-                    callback2();
-                    assert.notOk( tile.loading, "The tile should not be marked as loading.");
-                    assert.ok( tile.loaded, "The tile should be marked as loaded.");
+    QUnit.test(
+        "Viewer: tile-loaded event without callback.",
+        function (assert) {
+            var done = assert.async();
+            function tileLoaded(event) {
+                viewer.removeHandler("tile-loaded", tileLoaded);
+                var tile = event.tile;
+                assert.ok(
+                    tile.loading,
+                    "The tile should be marked as loading."
+                );
+                assert.notOk(
+                    tile.loaded,
+                    "The tile should not be marked as loaded."
+                );
+                setTimeout(function () {
+                    assert.notOk(
+                        tile.loading,
+                        "The tile should not be marked as loading."
+                    );
+                    assert.ok(
+                        tile.loaded,
+                        "The tile should be marked as loaded."
+                    );
                     done();
                 }, 0);
+            }
+
+            viewer.addHandler("tile-loaded", tileLoaded);
+            viewer.open("/test/data/testpattern.dzi");
+        }
+    );
+
+    QUnit.test("Viewer: tile-loaded event with 1 callback.", function (assert) {
+        var done = assert.async();
+        function tileLoaded(event) {
+            viewer.removeHandler("tile-loaded", tileLoaded);
+            var tile = event.tile;
+            var callback = event.getCompletionCallback();
+            assert.ok(tile.loading, "The tile should be marked as loading.");
+            assert.notOk(
+                tile.loaded,
+                "The tile should not be marked as loaded."
+            );
+            assert.ok(callback, "The event should have a callback.");
+            setTimeout(function () {
+                assert.ok(
+                    tile.loading,
+                    "The tile should be marked as loading."
+                );
+                assert.notOk(
+                    tile.loaded,
+                    "The tile should not be marked as loaded."
+                );
+                callback();
+                assert.notOk(
+                    tile.loading,
+                    "The tile should not be marked as loading."
+                );
+                assert.ok(tile.loaded, "The tile should be marked as loaded.");
+                done();
             }, 0);
         }
 
-        viewer.addHandler( 'tile-loaded', tileLoaded);
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
+        viewer.addHandler("tile-loaded", tileLoaded);
+        viewer.open("/test/data/testpattern.dzi");
+    });
 
-    QUnit.test( 'Viewer: tile-unloaded event.', function(assert) {
+    QUnit.test(
+        "Viewer: tile-loaded event with 2 callbacks.",
+        function (assert) {
+            var done = assert.async();
+            function tileLoaded(event) {
+                viewer.removeHandler("tile-loaded", tileLoaded);
+                var tile = event.tile;
+                var callback1 = event.getCompletionCallback();
+                var callback2 = event.getCompletionCallback();
+                assert.ok(
+                    tile.loading,
+                    "The tile should be marked as loading."
+                );
+                assert.notOk(
+                    tile.loaded,
+                    "The tile should not be marked as loaded."
+                );
+                setTimeout(function () {
+                    assert.ok(
+                        tile.loading,
+                        "The tile should be marked as loading."
+                    );
+                    assert.notOk(
+                        tile.loaded,
+                        "The tile should not be marked as loaded."
+                    );
+                    callback1();
+                    assert.ok(
+                        tile.loading,
+                        "The tile should be marked as loading."
+                    );
+                    assert.notOk(
+                        tile.loaded,
+                        "The tile should not be marked as loaded."
+                    );
+                    setTimeout(function () {
+                        assert.ok(
+                            tile.loading,
+                            "The tile should be marked as loading."
+                        );
+                        assert.notOk(
+                            tile.loaded,
+                            "The tile should not be marked as loaded."
+                        );
+                        callback2();
+                        assert.notOk(
+                            tile.loading,
+                            "The tile should not be marked as loading."
+                        );
+                        assert.ok(
+                            tile.loaded,
+                            "The tile should be marked as loaded."
+                        );
+                        done();
+                    }, 0);
+                }, 0);
+            }
+
+            viewer.addHandler("tile-loaded", tileLoaded);
+            viewer.open("/test/data/testpattern.dzi");
+        }
+    );
+
+    QUnit.test("Viewer: tile-unloaded event.", function (assert) {
         var tiledImage;
         var tile;
         var done = assert.async();
 
-        function tileLoaded( event ) {
-            viewer.removeHandler( 'tile-loaded', tileLoaded);
+        function tileLoaded(event) {
+            viewer.removeHandler("tile-loaded", tileLoaded);
             tiledImage = event.tiledImage;
             tile = event.tile;
-            setTimeout(function() {
+            setTimeout(function () {
                 tiledImage.reset();
             }, 0);
         }
 
-        function tileUnloaded( event ) {
-            viewer.removeHandler( 'tile-unloaded', tileUnloaded );
-            assert.equal( tile, event.tile,
-                "The unloaded tile should be the same than the loaded one." );
-            assert.equal( tiledImage, event.tiledImage,
-                "The tiledImage of the unloaded tile should be the same than the one of the loaded one." );
+        function tileUnloaded(event) {
+            viewer.removeHandler("tile-unloaded", tileUnloaded);
+            assert.equal(
+                tile,
+                event.tile,
+                "The unloaded tile should be the same than the loaded one."
+            );
+            assert.equal(
+                tiledImage,
+                event.tiledImage,
+                "The tiledImage of the unloaded tile should be the same than the one of the loaded one."
+            );
             done();
         }
 
-        viewer.addHandler( 'tile-loaded', tileLoaded );
-        viewer.addHandler( 'tile-unloaded', tileUnloaded );
-        viewer.open( '/test/data/testpattern.dzi' );
-    } );
-
-} )();
+        viewer.addHandler("tile-loaded", tileLoaded);
+        viewer.addHandler("tile-unloaded", tileUnloaded);
+        viewer.open("/test/data/testpattern.dzi");
+    });
+})();

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -3,33 +3,31 @@
 (function () {
     var viewer;
 
-    QUnit.module("Events", {
+    QUnit.module( 'Events', {
         beforeEach: function () {
-            $('<div id="eventsexample"></div>').appendTo("#qunit-fixture");
+            $( '<div id="eventsexample"></div>' ).appendTo( "#qunit-fixture" );
 
             testLog.reset();
 
-            viewer = OpenSeadragon({
-                id: "eventsexample",
-                prefixUrl: "/build/openseadragon/images/",
-                springStiffness: 100, // Faster animation = faster tests
-            });
+            viewer = OpenSeadragon( {
+                id: 'eventsexample',
+                prefixUrl: '/build/openseadragon/images/',
+                springStiffness: 100 // Faster animation = faster tests
+            } );
         },
         afterEach: function () {
-            if (viewer && viewer.close) {
+            if ( viewer && viewer.close ) {
                 viewer.close();
             }
 
             viewer = null;
-        },
-    });
+        }
+    } );
 
     // ----------
-    QUnit.test("MouseTracker: mouse gestures", function (assert) {
+    QUnit.test( 'MouseTracker: mouse gestures', function (assert) {
         var done = assert.async();
-        var $canvas = $(viewer.element)
-                .find(".openseadragon-canvas")
-                .not(".navigator .openseadragon-canvas"),
+        var $canvas = $( viewer.element ).find( '.openseadragon-canvas' ).not( '.navigator .openseadragon-canvas' ),
             simEvent = {},
             offset = $canvas.offset(),
             tracker = viewer.innerTracker,
@@ -65,45 +63,45 @@
 
         var hookViewerHandlers = function () {
             origEnterHandler = tracker.enterHandler;
-            tracker.enterHandler = function (event) {
+            tracker.enterHandler = function ( event ) {
                 enterCount++;
                 if (origEnterHandler) {
-                    return origEnterHandler(event);
+                    return origEnterHandler( event );
                 } else {
                     return true;
                 }
             };
             origLeaveHandler = tracker.leaveHandler;
-            tracker.leaveHandler = function (event) {
+            tracker.leaveHandler = function ( event ) {
                 leaveCount++;
                 if (origLeaveHandler) {
-                    return origLeaveHandler(event);
+                    return origLeaveHandler( event );
                 } else {
                     return true;
                 }
             };
             origPressHandler = tracker.pressHandler;
-            tracker.pressHandler = function (event) {
+            tracker.pressHandler = function ( event ) {
                 pressCount++;
                 if (origPressHandler) {
-                    return origPressHandler(event);
+                    return origPressHandler( event );
                 } else {
                     return true;
                 }
             };
             origReleaseHandler = tracker.releaseHandler;
-            tracker.releaseHandler = function (event) {
+            tracker.releaseHandler = function ( event ) {
                 releaseCount++;
                 insideElementPressed = event.insideElementPressed;
                 insideElementReleased = event.insideElementReleased;
                 if (origReleaseHandler) {
-                    return origReleaseHandler(event);
+                    return origReleaseHandler( event );
                 } else {
                     return true;
                 }
             };
             origNonPrimaryPressHandler = tracker.nonPrimaryPressHandler;
-            tracker.nonPrimaryPressHandler = function (event) {
+            tracker.nonPrimaryPressHandler = function ( event ) {
                 if (event.button === 0) {
                     pressCount++;
                 } else if (event.button === 1) {
@@ -112,13 +110,13 @@
                     rightPressCount++;
                 }
                 if (origNonPrimaryPressHandler) {
-                    return origNonPrimaryPressHandler(event);
+                    return origNonPrimaryPressHandler( event );
                 } else {
                     return true;
                 }
             };
             origNonPrimaryReleaseHandler = tracker.nonPrimaryReleaseHandler;
-            tracker.nonPrimaryReleaseHandler = function (event) {
+            tracker.nonPrimaryReleaseHandler = function ( event ) {
                 if (event.button === 0) {
                     releaseCount++;
                 } else if (event.button === 1) {
@@ -127,55 +125,55 @@
                     rightReleaseCount++;
                 }
                 if (origNonPrimaryReleaseHandler) {
-                    return origNonPrimaryReleaseHandler(event);
+                    return origNonPrimaryReleaseHandler( event );
                 } else {
                     return true;
                 }
             };
             origMoveHandler = tracker.moveHandler;
-            tracker.moveHandler = function (event) {
+            tracker.moveHandler = function ( event ) {
                 moveCount++;
                 if (origMoveHandler) {
-                    return origMoveHandler(event);
+                    return origMoveHandler( event );
                 } else {
                     return true;
                 }
             };
             origClickHandler = tracker.clickHandler;
-            tracker.clickHandler = function (event) {
+            tracker.clickHandler = function ( event ) {
                 clickCount++;
                 quickClick = event.quick;
                 if (origClickHandler) {
-                    return origClickHandler(event);
+                    return origClickHandler( event );
                 } else {
                     return true;
                 }
             };
             origDblClickHandler = tracker.dblClickHandler;
-            tracker.dblClickHandler = function (event) {
+            tracker.dblClickHandler = function ( event ) {
                 dblClickCount++;
                 if (origDblClickHandler) {
-                    return origDblClickHandler(event);
+                    return origDblClickHandler( event );
                 } else {
                     return true;
                 }
             };
             origDragHandler = tracker.dragHandler;
-            tracker.dragHandler = function (event) {
+            tracker.dragHandler = function ( event ) {
                 dragCount++;
                 if (origDragHandler) {
-                    return origDragHandler(event);
+                    return origDragHandler( event );
                 } else {
                     return true;
                 }
             };
             origDragEndHandler = tracker.dragEndHandler;
-            tracker.dragEndHandler = function (event) {
+            tracker.dragEndHandler = function ( event ) {
                 dragEndCount++;
                 speed = event.speed;
                 direction = event.direction;
                 if (origDragEndHandler) {
-                    return origDragEndHandler(event);
+                    return origDragEndHandler( event );
                 } else {
                     return true;
                 }
@@ -196,15 +194,15 @@
 
         var simulateEnter = function (x, y) {
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top + y;
-            $canvas.simulate("mouseenter", simEvent);
+            simEvent.clientY = offset.top  + y;
+            $canvas.simulate( 'mouseenter', simEvent );
         };
 
         var simulateLeave = function (x, y) {
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top + y;
+            simEvent.clientY = offset.top  + y;
             simEvent.relatedTarget = document.body;
-            $canvas.simulate("mouseleave", simEvent);
+            $canvas.simulate( 'mouseleave', simEvent );
         };
 
         //var simulateLeaveFrame = function (x, y) {
@@ -217,37 +215,37 @@
         var simulateDown = function (x, y) {
             simEvent.button = 0;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top + y;
-            $canvas.simulate("mousedown", simEvent);
+            simEvent.clientY = offset.top  + y;
+            $canvas.simulate( 'mousedown', simEvent );
         };
 
         var simulateUp = function (x, y) {
             simEvent.button = 0;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top + y;
-            $canvas.simulate("mouseup", simEvent);
+            simEvent.clientY = offset.top  + y;
+            $canvas.simulate( 'mouseup', simEvent );
         };
 
         var simulateNonPrimaryDown = function (x, y, button) {
             simEvent.button = button;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top + y;
-            $canvas.simulate("mousedown", simEvent);
+            simEvent.clientY = offset.top  + y;
+            $canvas.simulate( 'mousedown', simEvent );
         };
 
         var simulateNonPrimaryUp = function (x, y, button) {
             simEvent.button = button;
             simEvent.clientX = offset.left + x;
-            simEvent.clientY = offset.top + y;
-            $canvas.simulate("mouseup", simEvent);
+            simEvent.clientY = offset.top  + y;
+            $canvas.simulate( 'mouseup', simEvent );
         };
 
         var simulateMove = function (dX, dY, count) {
             var i;
-            for (i = 0; i < count; i++) {
+            for ( i = 0; i < count; i++ ) {
                 simEvent.clientX += dX;
                 simEvent.clientY += dY;
-                $canvas.simulate("mousemove", simEvent);
+                $canvas.simulate( 'mousemove', simEvent );
             }
         };
 
@@ -255,7 +253,7 @@
             simEvent = {
                 button: 0,
                 clientX: offset.left,
-                clientY: offset.top,
+                clientY: offset.top
             };
             enterCount = 0;
             leaveCount = 0;
@@ -278,207 +276,72 @@
         };
 
         var assessGestureExpectations = function (expected) {
-            var pointersList = tracker.getActivePointersListByType("mouse");
-            if ("enterCount" in expected) {
-                assert.equal(
-                    enterCount,
-                    expected.enterCount,
-                    expected.description +
-                        "enterHandler event count matches expected (" +
-                        expected.enterCount +
-                        ")"
-                );
+            var pointersList = tracker.getActivePointersListByType('mouse');
+            if ('enterCount' in expected) {
+                assert.equal( enterCount, expected.enterCount, expected.description + 'enterHandler event count matches expected (' + expected.enterCount + ')' );
             }
-            if ("leaveCount" in expected) {
-                assert.equal(
-                    leaveCount,
-                    expected.leaveCount,
-                    expected.description +
-                        "leaveHandler event count matches expected (" +
-                        expected.leaveCount +
-                        ")"
-                );
+            if ('leaveCount' in expected) {
+                assert.equal( leaveCount, expected.leaveCount, expected.description + 'leaveHandler event count matches expected (' + expected.leaveCount + ')' );
             }
-            if ("pressCount" in expected) {
-                assert.equal(
-                    pressCount,
-                    expected.pressCount,
-                    expected.description +
-                        "pressHandler event count matches expected (" +
-                        expected.pressCount +
-                        ")"
-                );
+            if ('pressCount' in expected) {
+                assert.equal( pressCount, expected.pressCount, expected.description + 'pressHandler event count matches expected (' + expected.pressCount + ')' );
             }
-            if ("releaseCount" in expected) {
-                assert.equal(
-                    releaseCount,
-                    expected.releaseCount,
-                    expected.description +
-                        "releaseHandler event count matches expected (" +
-                        expected.releaseCount +
-                        ")"
-                );
+            if ('releaseCount' in expected) {
+                assert.equal( releaseCount, expected.releaseCount, expected.description + 'releaseHandler event count matches expected (' + expected.releaseCount + ')' );
             }
-            if ("rightPressCount" in expected) {
-                assert.equal(
-                    rightPressCount,
-                    expected.rightPressCount,
-                    expected.description +
-                        "nonPrimaryPressHandler event count (secondary/right button) matches expected (" +
-                        expected.rightPressCount +
-                        ")"
-                );
+            if ('rightPressCount' in expected) {
+                assert.equal( rightPressCount, expected.rightPressCount, expected.description + 'nonPrimaryPressHandler event count (secondary/right button) matches expected (' + expected.rightPressCount + ')' );
             }
-            if ("rightReleaseCount" in expected) {
-                assert.equal(
-                    rightReleaseCount,
-                    expected.rightReleaseCount,
-                    expected.description +
-                        "nonPrimaryReleaseHandler event count (secondary/right button) matches expected (" +
-                        expected.rightReleaseCount +
-                        ")"
-                );
+            if ('rightReleaseCount' in expected) {
+                assert.equal( rightReleaseCount, expected.rightReleaseCount, expected.description + 'nonPrimaryReleaseHandler event count (secondary/right button) matches expected (' + expected.rightReleaseCount + ')' );
             }
-            if ("middlePressCount" in expected) {
-                assert.equal(
-                    middlePressCount,
-                    expected.middlePressCount,
-                    expected.description +
-                        "nonPrimaryPressHandler event count (aux/middle button) matches expected (" +
-                        expected.middlePressCount +
-                        ")"
-                );
+            if ('middlePressCount' in expected) {
+                assert.equal( middlePressCount, expected.middlePressCount, expected.description + 'nonPrimaryPressHandler event count (aux/middle button) matches expected (' + expected.middlePressCount + ')' );
             }
-            if ("middleReleaseCount" in expected) {
-                assert.equal(
-                    middleReleaseCount,
-                    expected.middleReleaseCount,
-                    expected.description +
-                        "nonPrimaryReleaseHandler event count (aux/middle button) matches expected (" +
-                        expected.middleReleaseCount +
-                        ")"
-                );
+            if ('middleReleaseCount' in expected) {
+                assert.equal( middleReleaseCount, expected.middleReleaseCount, expected.description + 'nonPrimaryReleaseHandler event count (aux/middle button) matches expected (' + expected.middleReleaseCount + ')' );
             }
-            if ("moveCount" in expected) {
-                assert.equal(
-                    moveCount,
-                    expected.moveCount,
-                    expected.description +
-                        "moveHandler event count matches expected (" +
-                        expected.moveCount +
-                        ")"
-                );
+            if ('moveCount' in expected) {
+                assert.equal( moveCount, expected.moveCount, expected.description + 'moveHandler event count matches expected (' + expected.moveCount + ')' );
             }
-            if ("clickCount" in expected) {
-                assert.equal(
-                    clickCount,
-                    expected.clickCount,
-                    expected.description +
-                        "clickHandler event count matches expected (" +
-                        expected.clickCount +
-                        ")"
-                );
+            if ('clickCount' in expected) {
+                assert.equal( clickCount, expected.clickCount, expected.description + 'clickHandler event count matches expected (' + expected.clickCount + ')' );
             }
-            if ("dblClickCount" in expected) {
-                assert.equal(
-                    dblClickCount,
-                    expected.dblClickCount,
-                    expected.description +
-                        "dblClickHandler event count matches expected (" +
-                        expected.dblClickCount +
-                        ")"
-                );
+            if ('dblClickCount' in expected) {
+                assert.equal( dblClickCount, expected.dblClickCount, expected.description + 'dblClickHandler event count matches expected (' + expected.dblClickCount + ')' );
             }
-            if ("dragCount" in expected) {
-                assert.equal(
-                    dragCount,
-                    expected.dragCount,
-                    expected.description +
-                        "dragHandler event count matches expected (" +
-                        expected.dragCount +
-                        ")"
-                );
+            if ('dragCount' in expected) {
+                assert.equal( dragCount, expected.dragCount, expected.description + 'dragHandler event count matches expected (' + expected.dragCount + ')' );
             }
-            if ("dragEndCount" in expected) {
-                assert.equal(
-                    dragEndCount,
-                    expected.dragEndCount,
-                    expected.description +
-                        "dragEndHandler event count matches expected (" +
-                        expected.dragEndCount +
-                        ")"
-                );
+            if ('dragEndCount' in expected) {
+                assert.equal( dragEndCount, expected.dragEndCount, expected.description + 'dragEndHandler event count matches expected (' + expected.dragEndCount + ')' );
             }
-            if ("insideElementPressed" in expected) {
-                assert.equal(
-                    insideElementPressed,
-                    expected.insideElementPressed,
-                    expected.description +
-                        "releaseHandler event.insideElementPressed matches expected (" +
-                        expected.insideElementPressed +
-                        ")"
-                );
+            if ('insideElementPressed' in expected) {
+                assert.equal( insideElementPressed, expected.insideElementPressed, expected.description + 'releaseHandler event.insideElementPressed matches expected (' + expected.insideElementPressed + ')' );
             }
-            if ("insideElementReleased" in expected) {
-                assert.equal(
-                    insideElementReleased,
-                    expected.insideElementReleased,
-                    expected.description +
-                        "releaseHandler event.insideElementReleased matches expected (" +
-                        expected.insideElementReleased +
-                        ")"
-                );
+            if ('insideElementReleased' in expected) {
+                assert.equal( insideElementReleased, expected.insideElementReleased, expected.description + 'releaseHandler event.insideElementReleased matches expected (' + expected.insideElementReleased + ')' );
             }
-            if ("contacts" in expected) {
-                assert.equal(
-                    pointersList.contacts,
-                    expected.contacts,
-                    expected.description +
-                        "Remaining pointer contact count matches expected (" +
-                        expected.contacts +
-                        ")"
-                );
+            if ('contacts' in expected) {
+                assert.equal( pointersList.contacts, expected.contacts, expected.description + 'Remaining pointer contact count matches expected (' + expected.contacts + ')' );
             }
-            if ("trackedPointers" in expected) {
-                assert.equal(
-                    pointersList.getLength(),
-                    expected.trackedPointers,
-                    expected.description +
-                        "Remaining tracked pointer count matches expected (" +
-                        expected.trackedPointers +
-                        ")"
-                );
+            if ('trackedPointers' in expected) {
+                assert.equal( pointersList.getLength(), expected.trackedPointers, expected.description + 'Remaining tracked pointer count matches expected (' + expected.trackedPointers + ')' );
             }
-            if ("quickClick" in expected) {
-                assert.equal(
-                    quickClick,
-                    expected.quickClick,
-                    expected.description +
-                        "clickHandler event.quick matches expected (" +
-                        expected.quickClick +
-                        ")"
-                );
+            if ('quickClick' in expected) {
+                assert.equal( quickClick, expected.quickClick, expected.description + 'clickHandler event.quick matches expected (' + expected.quickClick + ')' );
             }
-            if ("speed" in expected) {
-                Util.assessNumericValue(
-                    expected.speed,
-                    speed,
-                    1.0,
-                    expected.description + "Drag speed "
-                );
+            if ('speed' in expected) {
+                Util.assessNumericValue(expected.speed, speed, 1.0, expected.description + 'Drag speed ');
             }
-            if ("direction" in expected) {
-                Util.assessNumericValue(
-                    expected.direction,
-                    direction,
-                    0.2,
-                    expected.description + "Drag direction "
-                );
+            if ('direction' in expected) {
+                Util.assessNumericValue(expected.direction, direction, 0.2, expected.description + 'Drag direction ');
             }
         };
 
-        var onOpen = function (event) {
-            viewer.removeHandler("open", onOpen);
+        var onOpen = function ( event ) {
+
+            viewer.removeHandler( 'open', onOpen );
 
             hookViewerHandlers();
 
@@ -490,25 +353,24 @@
             simulateMove(-1, -1, 10);
             simulateUp(0, 0);
             assessGestureExpectations({
-                description:
-                    "enter-move-release (release in tracked element, press in unknown element):  ",
-                enterCount: 1,
-                leaveCount: 0,
-                pressCount: 0,
-                releaseCount: 1,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 20,
-                clickCount: 0,
-                dblClickCount: 0,
-                dragCount: 0,
-                dragEndCount: 0,
-                insideElementPressed: false,
+                description:           'enter-move-release (release in tracked element, press in unknown element):  ',
+                enterCount:            1,
+                leaveCount:            0,
+                pressCount:            0,
+                releaseCount:          1,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             20,
+                clickCount:            0,
+                dblClickCount:         0,
+                dragCount:             0,
+                dragEndCount:          0,
+                insideElementPressed:  false,
                 insideElementReleased: true,
-                contacts: 0,
-                trackedPointers: 1,
+                contacts:              0,
+                trackedPointers:       1
                 //quickClick:            false
             });
             simulateLeave(-1, -1); // flush tracked pointer
@@ -520,24 +382,24 @@
             simulateMove(-1, -1, 10);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description: "enter-move-leave (fly-over):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 0,
-                releaseCount: 0,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 20,
-                clickCount: 0,
-                dblClickCount: 0,
-                dragCount: 0,
-                dragEndCount: 0,
+                description:           'enter-move-leave (fly-over):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            0,
+                releaseCount:          0,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             20,
+                clickCount:            0,
+                dblClickCount:         0,
+                dragCount:             0,
+                dragEndCount:          0,
                 //insideElementPressed:  false,
                 //insideElementReleased: false,
-                contacts: 0,
-                trackedPointers: 0,
+                contacts:              0,
+                trackedPointers:       0
                 //quickClick:            false
             });
 
@@ -547,24 +409,24 @@
             simulateMove(-1, -1, 10);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description: "move-leave (fly-over, no enter event):  ",
-                enterCount: 0,
-                leaveCount: 1,
-                pressCount: 0,
-                releaseCount: 0,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 20,
-                clickCount: 0,
-                dblClickCount: 0,
-                dragCount: 0,
-                dragEndCount: 0,
+                description:           'move-leave (fly-over, no enter event):  ',
+                enterCount:            0,
+                leaveCount:            1,
+                pressCount:            0,
+                releaseCount:          0,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             20,
+                clickCount:            0,
+                dblClickCount:         0,
+                dragCount:             0,
+                dragEndCount:          0,
                 //insideElementPressed:  false,
                 //insideElementReleased: false,
-                contacts: 0,
-                trackedPointers: 0,
+                contacts:              0,
+                trackedPointers:       0
                 //quickClick:            false
             });
 
@@ -577,25 +439,24 @@
             simulateUp(0, 0);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:
-                    "enter-press-release-press-release-leave (primary/left double click):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 2,
-                releaseCount: 2,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 0,
-                clickCount: 2,
-                dblClickCount: 1,
-                dragCount: 0,
-                dragEndCount: 2, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
-                insideElementPressed: true,
+                description:           'enter-press-release-press-release-leave (primary/left double click):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            2,
+                releaseCount:          2,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             0,
+                clickCount:            2,
+                dblClickCount:         1,
+                dragCount:             0,
+                dragEndCount:          2, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
+                insideElementPressed:  true,
                 insideElementReleased: true,
-                contacts: 0,
-                trackedPointers: 0,
+                contacts:              0,
+                trackedPointers:       0
                 //quickClick:            true
             });
 
@@ -606,26 +467,25 @@
             simulateUp(0, 0);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:
-                    "enter-press-release-leave (primary/left click):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 1,
-                releaseCount: 1,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 0,
-                clickCount: 1,
-                dblClickCount: 0,
-                dragCount: 0,
-                dragEndCount: 1, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
-                insideElementPressed: true,
+                description:           'enter-press-release-leave (primary/left click):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            1,
+                releaseCount:          1,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             0,
+                clickCount:            1,
+                dblClickCount:         0,
+                dragCount:             0,
+                dragEndCount:          1, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
+                insideElementPressed:  true,
                 insideElementReleased: true,
-                contacts: 0,
-                trackedPointers: 0,
-                quickClick: true,
+                contacts:              0,
+                trackedPointers:       0,
+                quickClick:            true
             });
 
             // enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click)
@@ -635,25 +495,24 @@
             simulateNonPrimaryUp(0, 0, 2);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:
-                    "enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 0,
-                releaseCount: 0,
-                rightPressCount: 1,
-                rightReleaseCount: 1,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 0,
-                clickCount: 0,
-                dblClickCount: 0,
-                dragCount: 0,
-                dragEndCount: 0,
+                description:           'enter-nonprimarypress-nonprimaryrelease-leave (secondary/right click):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            0,
+                releaseCount:          0,
+                rightPressCount:       1,
+                rightReleaseCount:     1,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             0,
+                clickCount:            0,
+                dblClickCount:         0,
+                dragCount:             0,
+                dragEndCount:          0,
                 //insideElementPressed:  true,
                 //insideElementReleased: true,
-                contacts: 0,
-                trackedPointers: 0,
+                contacts:              0,
+                trackedPointers:       0,
                 //quickClick:            true
             });
 
@@ -664,25 +523,24 @@
             simulateNonPrimaryUp(0, 0, 1);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:
-                    "enter-nonprimarypress-nonprimaryrelease-leave (aux/middle click):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 0,
-                releaseCount: 0,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 1,
-                middleReleaseCount: 1,
-                moveCount: 0,
-                clickCount: 0,
-                dblClickCount: 0,
-                dragCount: 0,
-                dragEndCount: 0,
+                description:           'enter-nonprimarypress-nonprimaryrelease-leave (aux/middle click):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            0,
+                releaseCount:          0,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      1,
+                middleReleaseCount:    1,
+                moveCount:             0,
+                clickCount:            0,
+                dblClickCount:         0,
+                dragCount:             0,
+                dragEndCount:          0,
                 //insideElementPressed:  true,
                 //insideElementReleased: true,
-                contacts: 0,
-                trackedPointers: 0,
+                contacts:              0,
+                trackedPointers:       0,
                 //quickClick:            true
             });
 
@@ -695,25 +553,24 @@
             simulateMove(-1, -1, 100);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:
-                    "enter-nonprimarypress-move-nonprimaryrelease-move-leave (secondary/right button drag, release in tracked element):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 0,
-                releaseCount: 0,
-                rightPressCount: 1,
-                rightReleaseCount: 1,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 200,
-                clickCount: 0,
-                dblClickCount: 0,
-                dragCount: 0,
-                dragEndCount: 0,
+                description:           'enter-nonprimarypress-move-nonprimaryrelease-move-leave (secondary/right button drag, release in tracked element):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            0,
+                releaseCount:          0,
+                rightPressCount:       1,
+                rightReleaseCount:     1,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             200,
+                clickCount:            0,
+                dblClickCount:         0,
+                dragCount:             0,
+                dragEndCount:          0,
                 //insideElementPressed:  true,
                 //insideElementReleased: true,
-                contacts: 0,
-                trackedPointers: 0,
+                contacts:              0,
+                trackedPointers:       0,
                 //quickClick:            false
             });
 
@@ -726,26 +583,25 @@
             simulateMove(-1, -1, 100);
             simulateLeave(-1, -1);
             assessGestureExpectations({
-                description:
-                    "enter-press-move-release-move-leave (drag, release in tracked element):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 1,
-                releaseCount: 1,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 200,
-                clickCount: 1,
-                dblClickCount: 0,
-                dragCount: 100,
-                dragEndCount: 1,
-                insideElementPressed: true,
+                description:           'enter-press-move-release-move-leave (drag, release in tracked element):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            1,
+                releaseCount:          1,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             200,
+                clickCount:            1,
+                dblClickCount:         0,
+                dragCount:             100,
+                dragEndCount:          1,
+                insideElementPressed:  true,
                 insideElementReleased: true,
-                contacts: 0,
-                trackedPointers: 0,
-                quickClick: false,
+                contacts:              0,
+                trackedPointers:       0,
+                quickClick:            false
             });
 
             // enter-press-move-leave-move-release (drag, release outside tracked element)
@@ -758,26 +614,25 @@
             simulateMove(-1, -1, 5);
             simulateUp(-5, -5);
             assessGestureExpectations({
-                description:
-                    "enter-press-move-leave-move-release (drag, release outside tracked element):  ",
-                enterCount: 1,
-                leaveCount: 1,
-                pressCount: 1,
-                releaseCount: 1,
-                rightPressCount: 0,
-                rightReleaseCount: 0,
-                middlePressCount: 0,
-                middleReleaseCount: 0,
-                moveCount: 15,
-                clickCount: 0,
-                dblClickCount: 0,
-                dragCount: 15,
-                dragEndCount: 1,
-                insideElementPressed: true,
+                description:           'enter-press-move-leave-move-release (drag, release outside tracked element):  ',
+                enterCount:            1,
+                leaveCount:            1,
+                pressCount:            1,
+                releaseCount:          1,
+                rightPressCount:       0,
+                rightReleaseCount:     0,
+                middlePressCount:      0,
+                middleReleaseCount:    0,
+                moveCount:             15,
+                clickCount:            0,
+                dblClickCount:         0,
+                dragCount:             15,
+                dragEndCount:          1,
+                insideElementPressed:  true,
                 insideElementReleased: false,
-                contacts: 0,
-                trackedPointers: 0,
-                quickClick: false,
+                contacts:              0,
+                trackedPointers:       0,
+                quickClick:            false
             });
 
             //// enter-press-move-leave-move-release-outside (drag, release outside iframe)
@@ -816,13 +671,13 @@
             done();
         };
 
-        viewer.addHandler("open", onOpen);
-        viewer.open("/test/data/testpattern.dzi");
-    });
+        viewer.addHandler( 'open', onOpen );
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
 
     // ----------
-    if ("TouchEvent" in window) {
-        QUnit.test("MouseTracker: touch events", function (assert) {
+    if ('TouchEvent' in window) {
+        QUnit.test( 'MouseTracker: touch events', function (assert) {
             var done = assert.async();
             var tracker = viewer.innerTracker,
                 touches;
@@ -832,129 +687,102 @@
                 TouchUtil.reset();
             };
 
-            var assessTouchExpectations = function (expected) {
-                var pointersList = tracker.getActivePointersListByType("touch");
-                if ("captureCount" in expected) {
-                    assert.equal(
-                        pointersList.captureCount,
-                        expected.captureCount,
-                        expected.description +
-                            "Pointer capture count matches expected (" +
-                            expected.captureCount +
-                            ")"
-                    );
+            var assessTouchExpectations = function ( expected ) {
+                var pointersList = tracker.getActivePointersListByType( 'touch' );
+                if ('captureCount' in expected) {
+                    assert.equal( pointersList.captureCount, expected.captureCount, expected.description + 'Pointer capture count matches expected (' + expected.captureCount + ')' );
                 }
-                if ("contacts" in expected) {
-                    assert.equal(
-                        pointersList.contacts,
-                        expected.contacts,
-                        expected.description +
-                            "Pointer contact count matches expected (" +
-                            expected.contacts +
-                            ")"
-                    );
+                if ('contacts' in expected) {
+                    assert.equal( pointersList.contacts, expected.contacts, expected.description + 'Pointer contact count matches expected (' + expected.contacts + ')' );
                 }
-                if ("trackedPointers" in expected) {
-                    assert.equal(
-                        pointersList.getLength(),
-                        expected.trackedPointers,
-                        expected.description +
-                            "Tracked pointer count matches expected (" +
-                            expected.trackedPointers +
-                            ")"
-                    );
+                if ('trackedPointers' in expected) {
+                    assert.equal( pointersList.getLength(), expected.trackedPointers, expected.description + 'Tracked pointer count matches expected (' + expected.trackedPointers + ')' );
                 }
             };
 
-            var onOpen = function (event) {
-                viewer.removeHandler("open", onOpen);
+            var onOpen = function ( event ) {
+                viewer.removeHandler( 'open', onOpen );
 
-                TouchUtil.initTracker(tracker);
+                TouchUtil.initTracker( tracker );
 
                 // start-end-end (multi-touch start event)
                 reset();
-                touches = TouchUtil.start([0, 0], [20, 20]);
+                touches = TouchUtil.start( [0,0], [20,20] );
                 assessTouchExpectations({
-                    description:
-                        "start-end-end (multi-touch start event) [capture]:  ",
-                    captureCount: 2,
-                    contacts: 2,
-                    trackedPointers: 2,
+                    description:        'start-end-end (multi-touch start event) [capture]:  ',
+                    captureCount:       2,
+                    contacts:           2,
+                    trackedPointers:    2
                 });
-                TouchUtil.end(touches[1]);
-                TouchUtil.end(touches[0]);
+                TouchUtil.end( touches[1] );
+                TouchUtil.end( touches[0] );
                 assessTouchExpectations({
-                    description:
-                        "start-end-end (multi-touch start event) [release]:  ",
-                    captureCount: 0,
-                    contacts: 0,
-                    trackedPointers: 0,
+                    description:        'start-end-end (multi-touch start event) [release]:  ',
+                    captureCount:       0,
+                    contacts:           0,
+                    trackedPointers:    0
                 });
 
                 // start-start-end (multi-touch end event)
                 reset();
-                touches.push(TouchUtil.start([0, 0]));
-                touches.push(TouchUtil.start([20, 20]));
+                touches.push( TouchUtil.start([0, 0]) );
+                touches.push( TouchUtil.start([20, 20]) );
                 assessTouchExpectations({
-                    description:
-                        "start-start-end (multi-touch end event) [capture]:  ",
-                    captureCount: 2,
-                    contacts: 2,
-                    trackedPointers: 2,
+                    description:        'start-start-end (multi-touch end event) [capture]:  ',
+                    captureCount:       2,
+                    contacts:           2,
+                    trackedPointers:    2
                 });
-                TouchUtil.end(touches);
+                TouchUtil.end( touches );
                 assessTouchExpectations({
-                    description:
-                        "start-start-end (multi-touch end event) [release]:  ",
-                    captureCount: 0,
-                    contacts: 0,
-                    trackedPointers: 0,
+                    description:        'start-start-end (multi-touch end event) [release]:  ',
+                    captureCount:       0,
+                    contacts:           0,
+                    trackedPointers:    0
                 });
 
-                TouchUtil.resetTracker(tracker);
+                TouchUtil.resetTracker( tracker );
                 viewer.close();
                 done();
             };
 
-            viewer.addHandler("open", onOpen);
-            viewer.open("/test/data/testpattern.dzi");
-        });
+            viewer.addHandler( 'open', onOpen );
+            viewer.open( '/test/data/testpattern.dzi' );
+        } );
     }
 
     // ----------
-    QUnit.test("Viewer: preventDefaultAction", function (assert) {
+    QUnit.test('Viewer: preventDefaultAction', function(assert) {
         var done = assert.async();
-        var $canvas = $(viewer.element)
-            .find(".openseadragon-canvas")
-            .not(".navigator .openseadragon-canvas");
-        //var tracker = viewer.innerTracker;
+        var $canvas = $(viewer.element).find('.openseadragon-canvas')
+            .not('.navigator .openseadragon-canvas');
         var epsilon = 0.0000001;
 
         function simulateClickAndDrag() {
-            $canvas.simulate("focus");
+            $canvas.simulate('focus');
             // Drag to pan
-            Util.simulateViewerClickWithDrag({
+            Util.simulateViewerClickWithDrag( {
                 viewer: viewer,
                 widthFactor: 0.25,
                 heightFactor: 0.25,
                 dragCount: 10,
                 dragDx: 1,
-                dragDy: 1,
-            });
+                dragDy: 1
+            } );
             // Click to zoom
-            Util.simulateViewerClickWithDrag({
+            Util.simulateViewerClickWithDrag( {
                 viewer: viewer,
                 widthFactor: 0.25,
                 heightFactor: 0.25,
                 dragCount: 0,
                 dragDx: 0,
-                dragDy: 0,
-            });
-            $canvas.simulate("blur");
+                dragDy: 0
+            } );
+            $canvas.simulate('blur');
         }
 
-        var onOpen = function () {
-            viewer.removeHandler("open", onOpen);
+        var onOpen = function() {
+            viewer.removeHandler('open', onOpen);
 
             // Hook viewer events to set preventDefaultAction
             var onCanvasClick = function (event) {
@@ -963,7 +791,6 @@
             var onCanvasDrag = function (event) {
                 event.preventDefaultAction = true;
             };
-
             viewer.addHandler("canvas-click", onCanvasClick);
             viewer.addHandler("canvas-drag", onCanvasDrag);
 
@@ -974,20 +801,10 @@
 
             var zoom = viewer.viewport.getZoom();
             var bounds = viewer.viewport.getBounds();
-            Util.assessNumericValue(
-                assert,
-                zoom,
-                originalZoom,
-                epsilon,
-                "Zoom should be prevented"
-            );
-            Util.assertRectangleEquals(
-                assert,
-                bounds,
-                originalBounds,
-                epsilon,
-                "Pan should be prevented"
-            );
+            Util.assessNumericValue(assert, zoom, originalZoom, epsilon,
+                "Zoom should be prevented");
+            Util.assertRectangleEquals(assert, bounds, originalBounds, epsilon,
+                'Pan should be prevented');
 
             viewer.removeHandler("canvas-click", onCanvasClick);
             viewer.removeHandler("canvas-drag", onCanvasDrag);
@@ -996,476 +813,343 @@
 
             zoom = viewer.viewport.getZoom();
             bounds = viewer.viewport.getBounds();
-            Util.assessNumericValue(
-                assert,
-                zoom,
-                0.002,
-                epsilon,
-                "Zoom should not be prevented"
-            );
+            Util.assessNumericValue(assert, zoom, 0.002, epsilon,
+                "Zoom should not be prevented");
             Util.assertRectangleEquals(
                 assert,
                 new OpenSeadragon.Rect(-249.5, -0.25, 500, 0.5),
                 bounds,
                 epsilon,
-                "Pan should not be prevented"
-            );
+                'Pan should not be prevented');
 
             viewer.close();
             done();
         };
 
-        viewer.addHandler("open", onOpen);
-        viewer.open("/test/data/testpattern.dzi");
+        viewer.addHandler('open', onOpen);
+        viewer.open('/test/data/testpattern.dzi');
     });
 
     // ----------
-    QUnit.test(
-        "Viewer: preventDefaultAction in dblClickHandler",
-        function (assert) {
-            var done = assert.async();
-            var tracker = viewer.innerTracker;
-            var epsilon = 0.0000001;
-
-            function simulateDblTap() {
-                var touches = [];
-                TouchUtil.reset();
-
-                touches.push(TouchUtil.start([0, 0]));
-                TouchUtil.end(touches[0]);
-                touches.push(TouchUtil.start([0, 0]));
-                TouchUtil.end(touches[1]);
-            }
-
-            var onOpen = function () {
-                viewer.removeHandler("open", onOpen);
-
-                var originalZoom = viewer.viewport.getZoom();
-
-                var onCanvasDblClick = function (event) {
-                    event.preventDefaultAction = true;
-                };
-
-                viewer.addHandler("canvas-double-click", onCanvasDblClick);
-
-                TouchUtil.initTracker(tracker);
-                simulateDblTap();
-
-                var zoom = viewer.viewport.getZoom();
-                Util.assessNumericValue(
-                    assert,
-                    originalZoom,
-                    zoom,
-                    epsilon,
-                    "Zoom on double tap should be prevented"
-                );
-
-                // Reset event handler to original
-                viewer.removeHandler("canvas-double-click", onCanvasDblClick);
-
-                simulateDblTap();
-                originalZoom *= viewer.zoomPerClick;
-
-                zoom = viewer.viewport.getZoom();
-                Util.assessNumericValue(
-                    assert,
-                    originalZoom,
-                    zoom,
-                    epsilon,
-                    "Zoom on double tap should not be prevented"
-                );
-
-                TouchUtil.resetTracker(tracker);
-                viewer.close();
-                done();
-            };
-
-            viewer.addHandler("open", onOpen);
-            viewer.open("/test/data/testpattern.dzi");
-        }
-    );
-
-    // ----------
-    QUnit.test(
-        "EventSource/MouseTracker/Viewer: event.originalEvent event.userData canvas-drag canvas-drag-end canvas-release canvas-click",
-        function (assert) {
-            var done = assert.async();
-            var $canvas = $(viewer.element)
-                    .find(".openseadragon-canvas")
-                    .not(".navigator .openseadragon-canvas"),
-                mouseTracker = null,
-                userData = { item1: "Test user data", item2: Math.random() },
-                originalUserData = {
-                    item1: userData.item1,
-                    item2: userData.item2,
-                },
-                dragCount = 10,
-                dragsHandledEventSource = 0,
-                dragEndsHandledEventSource = 0,
-                releasesHandledEventSource = 0,
-                clicksHandledEventSource = 0,
-                eventsHandledMouseTracker = 0,
-                eventSourcePassedMouseTracker = 0,
-                originalEventsPassedMouseTracker = 0,
-                eventsHandledViewer = 0,
-                originalEventsPassedViewer = 0,
-                dragEndsExpected = 1,
-                releasesExpected = 1;
-
-            var onOpen = function () {
-                viewer.removeHandler("open", onOpen);
-
-                viewer.addHandler("canvas-drag", onEventSourceDrag);
-                viewer.addHandler("canvas-drag-end", onEventSourceDragEnd);
-                viewer.addHandler("canvas-release", onEventSourceRelease);
-                viewer.addHandler("canvas-click", onEventSourceClick);
-
-                mouseTracker = new OpenSeadragon.MouseTracker({
-                    element: $canvas[0],
-                    userData: userData,
-                    clickTimeThreshold:
-                        OpenSeadragon.DEFAULT_SETTINGS.clickTimeThreshold,
-                    clickDistThreshold:
-                        OpenSeadragon.DEFAULT_SETTINGS.clickDistThreshold,
-                    dblClickTimeThreshold:
-                        OpenSeadragon.DEFAULT_SETTINGS.dblClickTimeThreshold,
-                    dblClickDistThreshold:
-                        OpenSeadragon.DEFAULT_SETTINGS.dblClickDistThreshold,
-                    focusHandler: onMouseTrackerFocus,
-                    blurHandler: onMouseTrackerBlur,
-                    enterHandler: onMouseTrackerEnter,
-                    pressHandler: onMouseTrackerPress,
-                    moveHandler: onMouseTrackerMove,
-                    dragHandler: onMouseTrackerDrag,
-                    dragEndHandler: onMouseTrackerDragEnd,
-                    releaseHandler: onMouseTrackerRelease,
-                    clickHandler: onMouseTrackerClick,
-                    leaveHandler: onMouseTrackerLeave,
-                });
-
-                var event = {
-                    clientX: 1,
-                    clientY: 1,
-                };
-
-                $canvas.simulate("focus", event);
-                Util.simulateViewerClickWithDrag({
-                    viewer: viewer,
-                    widthFactor: 0.25,
-                    heightFactor: 0.25,
-                    dragCount: dragCount,
-                    dragDx: 1,
-                    dragDy: 1,
-                });
-                $canvas.simulate("blur", event);
-            };
-
-            var checkOriginalEventReceivedViewer = function (event) {
-                eventsHandledViewer++;
-                //TODO Provide a better check for the original event...simulate doesn't currently extend the object
-                //   with arbitrary user data.
-                if (event && event.originalEvent) {
-                    originalEventsPassedViewer++;
-                }
-            };
-
-            var onEventSourceDrag = function (event) {
-                checkOriginalEventReceivedViewer(event);
-                dragsHandledEventSource++;
-            };
-
-            var onEventSourceDragEnd = function (event) {
-                checkOriginalEventReceivedViewer(event);
-                dragEndsHandledEventSource++;
-            };
-
-            var onEventSourceRelease = function (event) {
-                checkOriginalEventReceivedViewer(event);
-                releasesHandledEventSource++;
-            };
-
-            var onEventSourceClick = function (event) {
-                checkOriginalEventReceivedViewer(event);
-                clicksHandledEventSource++;
-            };
-
-            var checkOriginalEventReceived = function (event) {
-                eventsHandledMouseTracker++;
-                if (event && event.eventSource === mouseTracker) {
-                    eventSourcePassedMouseTracker++;
-                }
-                //TODO Provide a better check for the original event...simulate doesn't currently extend the object
-                //   with arbitrary user data.
-                if (event && event.originalEvent) {
-                    originalEventsPassedMouseTracker++;
-                }
-            };
-
-            var onMouseTrackerFocus = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerBlur = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerEnter = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerPress = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerMove = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerDrag = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerDragEnd = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerRelease = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerClick = function (event) {
-                checkOriginalEventReceived(event);
-            };
-
-            var onMouseTrackerLeave = function (event) {
-                checkOriginalEventReceived(event);
-
-                mouseTracker.destroy();
-                viewer.removeHandler("canvas-drag", onEventSourceDrag);
-                viewer.removeHandler("canvas-release", onEventSourceRelease);
-                viewer.removeHandler("canvas-click", onEventSourceClick);
-
-                assert.equal(
-                    dragsHandledEventSource,
-                    dragCount,
-                    "'canvas-drag' event count matches 'mousemove' event count (" +
-                        dragCount +
-                        ")"
-                );
-                assert.equal(
-                    dragEndsHandledEventSource,
-                    dragEndsExpected,
-                    "'canvas-drag-end' event count matches expected (" +
-                        dragEndsExpected +
-                        ")"
-                );
-                assert.equal(
-                    releasesHandledEventSource,
-                    releasesExpected,
-                    "'canvas-release' event count matches expected (" +
-                        releasesExpected +
-                        ")"
-                );
-                assert.equal(
-                    clicksHandledEventSource,
-                    releasesExpected,
-                    "'canvas-click' event count matches expected (" +
-                        releasesExpected +
-                        ")"
-                );
-                assert.equal(
-                    originalEventsPassedViewer,
-                    eventsHandledViewer,
-                    "Original event received count matches expected (" +
-                        eventsHandledViewer +
-                        ")"
-                );
-
-                assert.equal(
-                    eventSourcePassedMouseTracker,
-                    eventsHandledMouseTracker,
-                    "Event source received count matches expected (" +
-                        eventsHandledMouseTracker +
-                        ")"
-                );
-                assert.equal(
-                    originalEventsPassedMouseTracker,
-                    eventsHandledMouseTracker,
-                    "Original event received count matches expected (" +
-                        eventsHandledMouseTracker +
-                        ")"
-                );
-                assert.deepEqual(
-                    event.userData,
-                    originalUserData,
-                    "MouseTracker userData was untouched"
-                );
-
-                viewer.close();
-                done();
-            };
-
-            viewer.addHandler("open", onOpen);
-            viewer.open("/test/data/testpattern.dzi");
-        }
-    );
-
-    // ----------
-    QUnit.test("EventSource: addHandler without userData", function (assert) {
+    QUnit.test('Viewer: preventDefaultAction in dblClickHandler', function(assert) {
         var done = assert.async();
-        var openHandler = function (event) {
-            viewer.removeHandler("open", openHandler);
-            assert.ok(event, "Event handler received event data");
-            if (event) {
-                assert.strictEqual(
-                    event.eventSource,
-                    viewer,
-                    "eventSource sent, eventSource is viewer"
-                );
-                assert.strictEqual(
-                    event.userData,
-                    null,
-                    "User data defaulted to null"
-                );
+        var tracker = viewer.innerTracker;
+        var epsilon = 0.0000001;
+
+        function simulateDblTap() {
+            var touches = [];
+            TouchUtil.reset();
+
+            touches.push(TouchUtil.start([0,0]));
+            TouchUtil.end( touches[0] );
+            touches.push(TouchUtil.start([0,0]));
+            TouchUtil.end( touches[1] );
+        }
+
+        var onOpen = function() {
+            viewer.removeHandler('open', onOpen);
+
+            var originalZoom = viewer.viewport.getZoom();
+
+            var onCanvasDblClick = function (event) {
+                event.preventDefaultAction = true;
+            };
+
+            viewer.addHandler('canvas-double-click', onCanvasDblClick);
+
+            TouchUtil.initTracker(tracker);
+            simulateDblTap();
+
+            var zoom = viewer.viewport.getZoom();
+            Util.assessNumericValue(assert, originalZoom, zoom, epsilon,
+                "Zoom on double tap should be prevented");
+
+            // Reset event handler to original
+            viewer.removeHandler("canvas-double-click", onCanvasDblClick);
+
+            simulateDblTap();
+            originalZoom *= viewer.zoomPerClick;
+
+            zoom = viewer.viewport.getZoom();
+            Util.assessNumericValue(assert, originalZoom, zoom, epsilon,
+                "Zoom on double tap should not be prevented");
+
+
+            TouchUtil.resetTracker(tracker);
+            viewer.close();
+            done();
+        };
+
+        viewer.addHandler('open', onOpen);
+        viewer.open('/test/data/testpattern.dzi');
+    });
+
+    // ----------
+    QUnit.test( 'EventSource/MouseTracker/Viewer: event.originalEvent event.userData canvas-drag canvas-drag-end canvas-release canvas-click', function (assert) {
+        var done = assert.async();
+        var $canvas = $( viewer.element ).find( '.openseadragon-canvas' ).not( '.navigator .openseadragon-canvas' ),
+            mouseTracker = null,
+            userData = { item1: 'Test user data', item2: Math.random() },
+            originalUserData = { item1: userData.item1, item2: userData.item2 },
+            dragCount = 10,
+            dragsHandledEventSource = 0,
+            dragEndsHandledEventSource = 0,
+            releasesHandledEventSource = 0,
+            clicksHandledEventSource = 0,
+            eventsHandledMouseTracker = 0,
+            eventSourcePassedMouseTracker = 0,
+            originalEventsPassedMouseTracker = 0,
+            eventsHandledViewer = 0,
+            originalEventsPassedViewer = 0,
+            dragEndsExpected = 1,
+            releasesExpected = 1;
+
+        var onOpen = function ( ) {
+            viewer.removeHandler( 'open', onOpen );
+
+            viewer.addHandler( 'canvas-drag', onEventSourceDrag );
+            viewer.addHandler( 'canvas-drag-end', onEventSourceDragEnd );
+            viewer.addHandler( 'canvas-release', onEventSourceRelease );
+            viewer.addHandler( 'canvas-click', onEventSourceClick );
+
+            mouseTracker = new OpenSeadragon.MouseTracker( {
+                element: $canvas[0],
+                userData: userData,
+                clickTimeThreshold: OpenSeadragon.DEFAULT_SETTINGS.clickTimeThreshold,
+                clickDistThreshold: OpenSeadragon.DEFAULT_SETTINGS.clickDistThreshold,
+                dblClickTimeThreshold: OpenSeadragon.DEFAULT_SETTINGS.dblClickTimeThreshold,
+                dblClickDistThreshold: OpenSeadragon.DEFAULT_SETTINGS.dblClickDistThreshold,
+                focusHandler: onMouseTrackerFocus,
+                blurHandler: onMouseTrackerBlur,
+                enterHandler: onMouseTrackerEnter,
+                pressHandler: onMouseTrackerPress,
+                moveHandler: onMouseTrackerMove,
+                dragHandler: onMouseTrackerDrag,
+                dragEndHandler: onMouseTrackerDragEnd,
+                releaseHandler: onMouseTrackerRelease,
+                clickHandler: onMouseTrackerClick,
+                leaveHandler: onMouseTrackerLeave
+            } );
+
+            var event = {
+                clientX:1,
+                clientY:1
+            };
+
+            $canvas.simulate( 'focus', event );
+            Util.simulateViewerClickWithDrag( {
+                viewer: viewer,
+                widthFactor: 0.25,
+                heightFactor: 0.25,
+                dragCount: dragCount,
+                dragDx: 1,
+                dragDy: 1
+            } );
+            $canvas.simulate( 'blur', event );
+        };
+
+        var checkOriginalEventReceivedViewer = function ( event ) {
+            eventsHandledViewer++;
+            //TODO Provide a better check for the original event...simulate doesn't currently extend the object
+            //   with arbitrary user data.
+            if ( event && event.originalEvent ) {
+                originalEventsPassedViewer++;
+            }
+        };
+
+        var onEventSourceDrag = function ( event ) {
+            checkOriginalEventReceivedViewer( event );
+            dragsHandledEventSource++;
+        };
+
+        var onEventSourceDragEnd = function ( event ) {
+            checkOriginalEventReceivedViewer( event );
+            dragEndsHandledEventSource++;
+        };
+
+        var onEventSourceRelease = function ( event ) {
+            checkOriginalEventReceivedViewer( event );
+            releasesHandledEventSource++;
+        };
+
+        var onEventSourceClick = function ( event ) {
+            checkOriginalEventReceivedViewer( event );
+            clicksHandledEventSource++;
+        };
+
+        var checkOriginalEventReceived = function ( event ) {
+            eventsHandledMouseTracker++;
+            if ( event && event.eventSource === mouseTracker ) {
+                eventSourcePassedMouseTracker++;
+            }
+            //TODO Provide a better check for the original event...simulate doesn't currently extend the object
+            //   with arbitrary user data.
+            if ( event && event.originalEvent ) {
+                originalEventsPassedMouseTracker++;
+            }
+        };
+
+        var onMouseTrackerFocus = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerBlur = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerEnter = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerPress = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerMove = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerDrag = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerDragEnd = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerRelease = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerClick = function ( event ) {
+            checkOriginalEventReceived( event );
+        };
+
+        var onMouseTrackerLeave = function ( event ) {
+            checkOriginalEventReceived( event );
+
+            mouseTracker.destroy();
+            viewer.removeHandler( 'canvas-drag', onEventSourceDrag );
+            viewer.removeHandler( 'canvas-release', onEventSourceRelease );
+            viewer.removeHandler( 'canvas-click', onEventSourceClick );
+
+            assert.equal( dragsHandledEventSource, dragCount, "'canvas-drag' event count matches 'mousemove' event count (" + dragCount + ")" );
+            assert.equal( dragEndsHandledEventSource, dragEndsExpected, "'canvas-drag-end' event count matches expected (" + dragEndsExpected + ")" );
+            assert.equal( releasesHandledEventSource, releasesExpected, "'canvas-release' event count matches expected (" + releasesExpected + ")" );
+            assert.equal( clicksHandledEventSource, releasesExpected, "'canvas-click' event count matches expected (" + releasesExpected + ")" );
+            assert.equal( originalEventsPassedViewer, eventsHandledViewer, "Original event received count matches expected (" + eventsHandledViewer + ")" );
+
+            assert.equal( eventSourcePassedMouseTracker, eventsHandledMouseTracker, "Event source received count matches expected (" + eventsHandledMouseTracker + ")" );
+            assert.equal( originalEventsPassedMouseTracker, eventsHandledMouseTracker, "Original event received count matches expected (" + eventsHandledMouseTracker + ")" );
+            assert.deepEqual( event.userData, originalUserData, 'MouseTracker userData was untouched' );
+
+            viewer.close();
+            done();
+        };
+
+        viewer.addHandler( 'open', onOpen );
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
+
+    // ----------
+    QUnit.test( 'EventSource: addHandler without userData', function (assert) {
+        var done = assert.async();
+        var openHandler = function ( event ) {
+            viewer.removeHandler( 'open', openHandler );
+            assert.ok( event, 'Event handler received event data' );
+            if ( event ) {
+                assert.strictEqual( event.eventSource, viewer, 'eventSource sent, eventSource is viewer' );
+                assert.strictEqual( event.userData, null, 'User data defaulted to null' );
             }
             viewer.close();
             done();
         };
 
-        viewer.addHandler("open", openHandler);
-        viewer.open("/test/data/testpattern.dzi");
-    });
+        viewer.addHandler( 'open', openHandler );
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
 
     // ----------
-    QUnit.test("EventSource: addHandler with userData", function (assert) {
+    QUnit.test( 'EventSource: addHandler with userData', function (assert) {
         var done = assert.async();
-        var userData = { item1: "Test user data", item2: Math.random() },
+        var userData = { item1: 'Test user data', item2: Math.random() },
             originalUserData = { item1: userData.item1, item2: userData.item2 };
 
-        var openHandler = function (event) {
-            viewer.removeHandler("open", openHandler);
-            assert.ok(event, "Event handler received event data");
-            assert.ok(
-                event && event.userData,
-                "Event handler received user data"
-            );
-            if (event && event.userData) {
-                assert.deepEqual(
-                    event.userData,
-                    originalUserData,
-                    "User data was untouched"
-                );
+        var openHandler = function ( event ) {
+            viewer.removeHandler( 'open', openHandler );
+            assert.ok( event, 'Event handler received event data' );
+            assert.ok( event && event.userData, 'Event handler received user data' );
+            if ( event && event.userData ) {
+                assert.deepEqual( event.userData, originalUserData, 'User data was untouched' );
             }
             viewer.close();
             done();
         };
 
-        viewer.addHandler("open", openHandler, userData);
-        viewer.open("/test/data/testpattern.dzi");
-    });
+        viewer.addHandler( 'open', openHandler, userData );
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
 
     // ----------
-    QUnit.test("EventSource: addOnceHandler", function (assert) {
+    QUnit.test('EventSource: addOnceHandler', function(assert) {
         var eventSource = new OpenSeadragon.EventSource();
-        var userData = "data";
+        var userData = 'data';
         var eventData = {
-            foo: 1,
+            foo: 1
         };
         var handlerCalledCount = 0;
-        eventSource.addOnceHandler(
-            "test-event",
-            function (event) {
-                handlerCalledCount++;
-                assert.strictEqual(
-                    event.foo,
-                    eventData.foo,
-                    "Event data should be transmitted to the event."
-                );
-                assert.strictEqual(
-                    event.userData,
-                    userData,
-                    "User data should be transmitted to the event."
-                );
-            },
-            userData
-        );
-        assert.strictEqual(
-            0,
-            handlerCalledCount,
-            "Handler should not have been called yet."
-        );
-        eventSource.raiseEvent("test-event", eventData);
-        assert.strictEqual(
-            1,
-            handlerCalledCount,
-            "Handler should have been called once."
-        );
-        eventSource.raiseEvent("test-event", eventData);
-        assert.strictEqual(
-            1,
-            handlerCalledCount,
-            "Handler should still have been called once."
-        );
+        eventSource.addOnceHandler('test-event', function(event) {
+            handlerCalledCount++;
+            assert.strictEqual(event.foo, eventData.foo,
+                'Event data should be transmitted to the event.');
+            assert.strictEqual(event.userData, userData,
+                'User data should be transmitted to the event.');
+        }, userData);
+        assert.strictEqual(0, handlerCalledCount,
+            'Handler should not have been called yet.');
+        eventSource.raiseEvent('test-event', eventData);
+        assert.strictEqual(1, handlerCalledCount,
+            'Handler should have been called once.');
+        eventSource.raiseEvent('test-event', eventData);
+        assert.strictEqual(1, handlerCalledCount,
+            'Handler should still have been called once.');
     });
 
     // ----------
-    QUnit.test("EventSource: addOnceHandler 2 times", function (assert) {
+    QUnit.test('EventSource: addOnceHandler 2 times', function(assert) {
         var eventSource = new OpenSeadragon.EventSource();
-        var userData = "data";
+        var userData = 'data';
         var eventData = {
-            foo: 1,
+            foo: 1
         };
         var handlerCalledCount = 0;
-        eventSource.addOnceHandler(
-            "test-event",
-            function (event) {
-                handlerCalledCount++;
-                assert.strictEqual(
-                    event.foo,
-                    eventData.foo,
-                    "Event data should be transmitted to the event."
-                );
-                assert.strictEqual(
-                    event.userData,
-                    userData,
-                    "User data should be transmitted to the event."
-                );
-            },
-            userData,
-            2
-        );
-        assert.strictEqual(
-            0,
-            handlerCalledCount,
-            "Handler should not have been called yet."
-        );
-        eventSource.raiseEvent("test-event", eventData);
-        assert.strictEqual(
-            1,
-            handlerCalledCount,
-            "Handler should have been called once."
-        );
-        eventSource.raiseEvent("test-event", eventData);
-        assert.strictEqual(
-            2,
-            handlerCalledCount,
-            "Handler should have been called twice."
-        );
-        eventSource.raiseEvent("test-event", eventData);
-        assert.strictEqual(
-            2,
-            handlerCalledCount,
-            "Handler should still have been called twice."
-        );
+        eventSource.addOnceHandler('test-event', function(event) {
+            handlerCalledCount++;
+            assert.strictEqual(event.foo, eventData.foo,
+                'Event data should be transmitted to the event.');
+            assert.strictEqual(event.userData, userData,
+                'User data should be transmitted to the event.');
+        }, userData, 2);
+        assert.strictEqual(0, handlerCalledCount,
+            'Handler should not have been called yet.');
+        eventSource.raiseEvent('test-event', eventData);
+        assert.strictEqual(1, handlerCalledCount,
+            'Handler should have been called once.');
+        eventSource.raiseEvent('test-event', eventData);
+        assert.strictEqual(2, handlerCalledCount,
+            'Handler should have been called twice.');
+        eventSource.raiseEvent('test-event', eventData);
+        assert.strictEqual(2, handlerCalledCount,
+            'Handler should still have been called twice.');
     });
 
     // ----------
-    QUnit.test("Viewer: tile-drawing event", function (assert) {
+    QUnit.test( 'Viewer: tile-drawing event', function (assert) {
         var done = assert.async();
-        var tileDrawing = function (event) {
-            viewer.removeHandler("tile-drawing", tileDrawing);
-            assert.ok(event, "Event handler should be invoked");
-            if (event) {
+        var tileDrawing = function ( event ) {
+            viewer.removeHandler( 'tile-drawing', tileDrawing );
+            assert.ok( event, 'Event handler should be invoked' );
+            if ( event ) {
                 // Make sure we have the expected elements set
                 assert.ok(event.context, "Context should be set");
                 assert.ok(event.tile, "Tile should be set");
@@ -1475,173 +1159,108 @@
             done();
         };
 
-        viewer.addHandler("tile-drawing", tileDrawing);
-        viewer.open("/test/data/testpattern.dzi");
-    });
+        viewer.addHandler( 'tile-drawing', tileDrawing );
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
 
     // tile-loaded event tests
-    QUnit.test(
-        "Viewer: tile-loaded event without callback.",
-        function (assert) {
-            var done = assert.async();
-            function tileLoaded(event) {
-                viewer.removeHandler("tile-loaded", tileLoaded);
-                var tile = event.tile;
-                assert.ok(
-                    tile.loading,
-                    "The tile should be marked as loading."
-                );
-                assert.notOk(
-                    tile.loaded,
-                    "The tile should not be marked as loaded."
-                );
-                setTimeout(function () {
-                    assert.notOk(
-                        tile.loading,
-                        "The tile should not be marked as loading."
-                    );
-                    assert.ok(
-                        tile.loaded,
-                        "The tile should be marked as loaded."
-                    );
-                    done();
-                }, 0);
-            }
-
-            viewer.addHandler("tile-loaded", tileLoaded);
-            viewer.open("/test/data/testpattern.dzi");
-        }
-    );
-
-    QUnit.test("Viewer: tile-loaded event with 1 callback.", function (assert) {
+    QUnit.test( 'Viewer: tile-loaded event without callback.', function (assert) {
         var done = assert.async();
-        function tileLoaded(event) {
-            viewer.removeHandler("tile-loaded", tileLoaded);
+        function tileLoaded ( event ) {
+            viewer.removeHandler( 'tile-loaded', tileLoaded);
             var tile = event.tile;
-            var callback = event.getCompletionCallback();
-            assert.ok(tile.loading, "The tile should be marked as loading.");
-            assert.notOk(
-                tile.loaded,
-                "The tile should not be marked as loaded."
-            );
-            assert.ok(callback, "The event should have a callback.");
-            setTimeout(function () {
-                assert.ok(
-                    tile.loading,
-                    "The tile should be marked as loading."
-                );
-                assert.notOk(
-                    tile.loaded,
-                    "The tile should not be marked as loaded."
-                );
-                callback();
-                assert.notOk(
-                    tile.loading,
-                    "The tile should not be marked as loading."
-                );
-                assert.ok(tile.loaded, "The tile should be marked as loaded.");
+            assert.ok( tile.loading, "The tile should be marked as loading.");
+            assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
+            setTimeout(function() {
+                assert.notOk( tile.loading, "The tile should not be marked as loading.");
+                assert.ok( tile.loaded, "The tile should be marked as loaded.");
                 done();
             }, 0);
         }
 
-        viewer.addHandler("tile-loaded", tileLoaded);
-        viewer.open("/test/data/testpattern.dzi");
-    });
+        viewer.addHandler( 'tile-loaded', tileLoaded);
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
 
-    QUnit.test(
-        "Viewer: tile-loaded event with 2 callbacks.",
-        function (assert) {
-            var done = assert.async();
-            function tileLoaded(event) {
-                viewer.removeHandler("tile-loaded", tileLoaded);
-                var tile = event.tile;
-                var callback1 = event.getCompletionCallback();
-                var callback2 = event.getCompletionCallback();
-                assert.ok(
-                    tile.loading,
-                    "The tile should be marked as loading."
-                );
-                assert.notOk(
-                    tile.loaded,
-                    "The tile should not be marked as loaded."
-                );
-                setTimeout(function () {
-                    assert.ok(
-                        tile.loading,
-                        "The tile should be marked as loading."
-                    );
-                    assert.notOk(
-                        tile.loaded,
-                        "The tile should not be marked as loaded."
-                    );
-                    callback1();
-                    assert.ok(
-                        tile.loading,
-                        "The tile should be marked as loading."
-                    );
-                    assert.notOk(
-                        tile.loaded,
-                        "The tile should not be marked as loaded."
-                    );
-                    setTimeout(function () {
-                        assert.ok(
-                            tile.loading,
-                            "The tile should be marked as loading."
-                        );
-                        assert.notOk(
-                            tile.loaded,
-                            "The tile should not be marked as loaded."
-                        );
-                        callback2();
-                        assert.notOk(
-                            tile.loading,
-                            "The tile should not be marked as loading."
-                        );
-                        assert.ok(
-                            tile.loaded,
-                            "The tile should be marked as loaded."
-                        );
-                        done();
-                    }, 0);
-                }, 0);
-            }
-
-            viewer.addHandler("tile-loaded", tileLoaded);
-            viewer.open("/test/data/testpattern.dzi");
+    QUnit.test( 'Viewer: tile-loaded event with 1 callback.', function (assert) {
+        var done = assert.async();
+        function tileLoaded ( event ) {
+            viewer.removeHandler( 'tile-loaded', tileLoaded);
+            var tile = event.tile;
+            var callback = event.getCompletionCallback();
+            assert.ok( tile.loading, "The tile should be marked as loading.");
+            assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
+            assert.ok( callback, "The event should have a callback.");
+            setTimeout(function() {
+                assert.ok( tile.loading, "The tile should be marked as loading.");
+                assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
+                callback();
+                assert.notOk( tile.loading, "The tile should not be marked as loading.");
+                assert.ok( tile.loaded, "The tile should be marked as loaded.");
+                done();
+            }, 0);
         }
-    );
 
-    QUnit.test("Viewer: tile-unloaded event.", function (assert) {
+        viewer.addHandler( 'tile-loaded', tileLoaded);
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
+
+    QUnit.test( 'Viewer: tile-loaded event with 2 callbacks.', function (assert) {
+        var done = assert.async();
+        function tileLoaded ( event ) {
+            viewer.removeHandler( 'tile-loaded', tileLoaded);
+            var tile = event.tile;
+            var callback1 = event.getCompletionCallback();
+            var callback2 = event.getCompletionCallback();
+            assert.ok( tile.loading, "The tile should be marked as loading.");
+            assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
+            setTimeout(function() {
+                assert.ok( tile.loading, "The tile should be marked as loading.");
+                assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
+                callback1();
+                assert.ok( tile.loading, "The tile should be marked as loading.");
+                assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
+                setTimeout(function() {
+                    assert.ok( tile.loading, "The tile should be marked as loading.");
+                    assert.notOk( tile.loaded, "The tile should not be marked as loaded.");
+                    callback2();
+                    assert.notOk( tile.loading, "The tile should not be marked as loading.");
+                    assert.ok( tile.loaded, "The tile should be marked as loaded.");
+                    done();
+                }, 0);
+            }, 0);
+        }
+
+        viewer.addHandler( 'tile-loaded', tileLoaded);
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
+
+    QUnit.test( 'Viewer: tile-unloaded event.', function(assert) {
         var tiledImage;
         var tile;
         var done = assert.async();
 
-        function tileLoaded(event) {
-            viewer.removeHandler("tile-loaded", tileLoaded);
+        function tileLoaded( event ) {
+            viewer.removeHandler( 'tile-loaded', tileLoaded);
             tiledImage = event.tiledImage;
             tile = event.tile;
-            setTimeout(function () {
+            setTimeout(function() {
                 tiledImage.reset();
             }, 0);
         }
 
-        function tileUnloaded(event) {
-            viewer.removeHandler("tile-unloaded", tileUnloaded);
-            assert.equal(
-                tile,
-                event.tile,
-                "The unloaded tile should be the same than the loaded one."
-            );
-            assert.equal(
-                tiledImage,
-                event.tiledImage,
-                "The tiledImage of the unloaded tile should be the same than the one of the loaded one."
-            );
+        function tileUnloaded( event ) {
+            viewer.removeHandler( 'tile-unloaded', tileUnloaded );
+            assert.equal( tile, event.tile,
+                "The unloaded tile should be the same than the loaded one." );
+            assert.equal( tiledImage, event.tiledImage,
+                "The tiledImage of the unloaded tile should be the same than the one of the loaded one." );
             done();
         }
 
-        viewer.addHandler("tile-loaded", tileLoaded);
-        viewer.addHandler("tile-unloaded", tileUnloaded);
-        viewer.open("/test/data/testpattern.dzi");
-    });
-})();
+        viewer.addHandler( 'tile-loaded', tileLoaded );
+        viewer.addHandler( 'tile-unloaded', tileUnloaded );
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
+
+} )();


### PR DESCRIPTION
preventDefaultAction functionality on viewer events was broken and/or used incorrectly in several places. This patch fixes those issues

Additionally, preventDefaultAction was unused in MouseTracker - removed it