### PR TITLE
ReferenceStrip: Fixed destroy() exception and made element focusable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,8 @@ OPENSEADRAGON CHANGELOG
 * Added setImageFormatsSupported function (#1954 @pandaxtc)
 * Added dragToPan to the GestureSettings class, implemented in Viewer (#1956 @msalsbery)
 * Added preventDefault option to MouseTracker handlers: scrollHandler, keyDownHandler, keyUpHandler, keyHandler (#1957 @msalsbery)
+* ReferenceStrip: Fixed issue where its element was being removed from its parent element twice on destroy, causing an exception (#1957 @msalsbery)
+* ReferenceStrip: Made its element focusable for keyboard navigation (#1957 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -41,8 +41,8 @@ OPENSEADRAGON CHANGELOG
 * Added setImageFormatsSupported function (#1954 @pandaxtc)
 * Added dragToPan to the GestureSettings class, implemented in Viewer (#1956 @msalsbery)
 * Added preventDefault option to MouseTracker handlers: scrollHandler, keyDownHandler, keyUpHandler, keyHandler (#1957 @msalsbery)
-* ReferenceStrip: Fixed issue where its element was being removed from its parent element twice on destroy, causing an exception (#1957 @msalsbery)
-* ReferenceStrip: Made its element focusable for keyboard navigation (#1957 @msalsbery)
+* ReferenceStrip: Fixed issue where its element was being removed from its parent element twice on destroy, causing an exception (#1958 @msalsbery)
+* ReferenceStrip: Made its element focusable for keyboard navigation (#1958 @msalsbery)
 
 2.4.2:
 

--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -96,6 +96,8 @@ $.ReferenceStrip = function ( options ) {
 
     this.minPixelRatio = this.viewer.minPixelRatio;
 
+    this.element.tabIndex = 0;
+
     style = this.element.style;
     style.marginTop     = '0px';
     style.marginRight   = '0px';
@@ -281,7 +283,7 @@ $.ReferenceStrip.prototype = {
         this.tracker.destroy();
 
         if (this.element) {
-            this.element.parentNode.removeChild(this.element);
+            this.viewer.removeControl( this.element );
         }
     }
 
@@ -305,6 +307,8 @@ function onStripClick( event ) {
 
         this.viewer.goToPage( page );
     }
+
+    this.element.focus();
 }
 
 


### PR DESCRIPTION
* ReferenceStrip: Fixed issue where its element was being removed from its parent element twice on destroy, causing an exception
* ReferenceStrip: Made its element focusable for keyboard navigation