### PR TITLE
Fixing issue where the `ajaxHeaders` are not being set for image requests

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2373,7 +2373,8 @@ function getTileSourceImplementation( viewer, tileSource, imgOptions, successCal
                 crossOriginPolicy: imgOptions.crossOriginPolicy !== undefined ?
                     imgOptions.crossOriginPolicy : viewer.crossOriginPolicy,
                 ajaxWithCredentials: viewer.ajaxWithCredentials,
-                ajaxHeaders: viewer.ajaxHeaders,
+                ajaxHeaders: imgOptions.ajaxHeaders ?
+                    imgOptions.ajaxHeaders : viewer.ajaxHeaders,
                 useCanvas: viewer.useCanvas,
                 success: function( event ) {
                     successCallback( event.tileSource );


### PR DESCRIPTION
This PR fixes an issue where image requests with custom `ajaxHeaders` set do not actually use those `ajaxHeaders`. For example if I have this code below where I am dynamically adding images and each image has it's own `ajaxHeaders` set:
```
    urls.forEach((url, index) => {
        viewer.addTiledImage({
            tileSource: url,
            loadTilesWithAjax: true,
            width: 10,
            ajaxHeaders: {
                Authorization: tokens[index],
            },
        });
    });
```

The requests to not actually use the `ajaxHeaders` for these images until actual tile requests are made.

This PR fixes this issue. 

cc: @iangilman as we chatted on Gitter about this.