### PR TITLE
Force the display of body to be block when fullscreen

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1000,6 +1000,9 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             bodyStyle.height = "100%";
             docStyle.height = "100%";
 
+            this.bodyDisplay = bodyStyle.display;
+            bodyStyle.display = "block";
+
             //when entering full screen on the ipad it wasn't sufficient to leave
             //the body intact as only only the top half of the screen would
             //respond to touch events on the canvas, while the bottom half treated
@@ -1063,6 +1066,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
             bodyStyle.height = this.bodyHeight;
             docStyle.height = this.docHeight;
+
+            bodyStyle.display = this.bodyDisplay;
 
             body.removeChild( this.element );
             nodes = this.previousBody.length;


### PR DESCRIPTION
If I have something like `display: grid` set on the `body` of my page, going into OSD fullscreen sees it stuck inside the first column:

![image](https://user-images.githubusercontent.com/1784740/122584504-552f7000-d052-11eb-86bc-ae546e03e5a7.png)

This should force the `<body>` to always be `display: block` when fullscreen.

Couldn't see any tests related to fullscreen display, but have tried it locally.