### PR TITLE
Provide a static method in OpenSeadragon to get an existing viewer

### DIFF
--- a/.eslintrc.hound.json
+++ b/.eslintrc.hound.json
@@ -278,8 +278,9 @@
         ]
     },
     "globals": {
-        "OpenSeadragon": true,
-        "define": false,
-        "module": false
+        "OpenSeadragon": "writable",
+        "define": "readonly",
+        "module": "readonly",
+        "Map": "readonly"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,9 +17,10 @@
         }
     },
     "globals": {
-        "OpenSeadragon": true,
-        "define": false,
-        "module": false
+        "OpenSeadragon": "writable",
+        "define": "readonly",
+        "module": "readonly",
+        "Map": "readonly"
     },
     "rules": {
         "no-unused-vars": [

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -749,9 +749,7 @@
 
 /* eslint-disable no-redeclare */
 function OpenSeadragon( options ){
-    var viewer = new OpenSeadragon.Viewer( options );
-    OpenSeadragon._viewers.set(viewer.element, viewer);
-    return viewer;
+    return new OpenSeadragon.Viewer( options );
 }
 
 (function( $ ){
@@ -1409,10 +1407,10 @@ function OpenSeadragon( options ){
          * Keep track of which {@link Viewer}s have been created.
          * - Key: {@link Element} to which a Viewer is attached.
          * - Value: {@link Viewer} of the element defined by the key.
+         * @private
          * @static
          * @type {Object}
          */
-        // eslint-disable-next-line no-undef
         _viewers: new Map(),
 
        /**

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -749,7 +749,9 @@
 
 /* eslint-disable no-redeclare */
 function OpenSeadragon( options ){
-    return new OpenSeadragon.Viewer( options );
+    var viewer = new OpenSeadragon.Viewer( options );
+    OpenSeadragon._viewers.set(viewer.element, viewer);
+    return viewer;
 }
 
 (function( $ ){
@@ -1403,6 +1405,26 @@ function OpenSeadragon( options ){
             CHROMEEDGE: 7
         },
 
+        /**
+         * Keep track of which {@link Viewer}s have been created.
+         * - Key: {@link Element} to which a Viewer is attached.
+         * - Value: {@link Viewer} of the element defined by the key.
+         * @static
+         * @type {Object}
+         */
+        // eslint-disable-next-line no-undef
+        _viewers: new Map(),
+
+       /**
+         * Returns the {@link Viewer} attached to a given DOM element. If there is
+         * no viewer attached to the provided element, undefined is returned.
+         * @function
+         * @param {String|Element} element Accepts an id or element.
+         * @returns {Viewer} The viewer attached to the given element, or undefined.
+         */
+        getViewer: function(element) {
+            return $._viewers.get(this.getElement(element));
+        },
 
         /**
          * Returns a DOM Element for the given id or element.

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -481,6 +481,8 @@ $.Viewer = function( options ) {
         this.drawer.setImageSmoothingEnabled(this.imageSmoothingEnabled);
     }
 
+    // Register the viewer
+    $._viewers.set(this.element, this);
 };
 
 $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, /** @lends OpenSeadragon.Viewer.prototype */{
@@ -823,6 +825,9 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         // clear all our references to dom objects
         this.canvas = null;
         this.container = null;
+
+        // Unregister the viewer
+        $._viewers.delete(this.element);
 
         // clear our reference to the main element - they will need to pass it in again, creating a new viewer
         this.element = null;

--- a/test/modules/viewerretrieval.js
+++ b/test/modules/viewerretrieval.js
@@ -1,0 +1,93 @@
+/* global QUnit, $, testLog */
+
+(function() {
+    var viewer1;
+    var viewer2;
+
+    QUnit.module('ViewerRetrieval', {
+        beforeEach: function () {
+            $('<div id="example1"></div><div id="example2"></div>')
+                .appendTo("#qunit-fixture");
+
+            testLog.reset();
+
+            viewer1 = OpenSeadragon({
+                id: 'example1',
+                prefixUrl: 'build/openseadragon/images/',
+                springStiffness: 100 // Faster animation = faster tests
+            });
+
+            viewer2 = OpenSeadragon({
+                id: 'example2',
+                prefixUrl: 'build/openseadragon/images/',
+                springStiffness: 100
+            });
+        },
+
+        afterEach: function () {
+            if (viewer1 && viewer1.destroy) {
+                viewer1.destroy();
+            }
+            if (viewer2 && viewer2.destroy) {
+                viewer2.destroy();
+            }
+            viewer1 = viewer2 = null;
+        }
+    });
+
+    QUnit.test('Get Viewers by Id', function(assert) {
+        var retrievedViewer1 = OpenSeadragon.getViewer('example1');
+        assert.ok(retrievedViewer1, 'Attached viewer retrieved');
+        assert.equal(retrievedViewer1, viewer1, 'Viewers are same instance');
+
+        var retrievedViewer2 = OpenSeadragon.getViewer('example2');
+        assert.ok(retrievedViewer2, 'Attached viewer retrieved');
+        assert.equal(retrievedViewer2, viewer2, 'Viewers are same instance');
+
+        // Internal state
+        assert.equal(OpenSeadragon._viewers.size, 2, 'Correct amount of viewers');
+    });
+
+    QUnit.test('Get Viewers by Element', function(assert) {
+        var retrievedViewer1 = OpenSeadragon.getViewer(
+            document.getElementById('example1'));
+        assert.ok(retrievedViewer1, 'Attached viewer retrieved');
+        assert.equal(retrievedViewer1, viewer1, 'Viewers are same instance');
+
+        var retrievedViewer2 = OpenSeadragon.getViewer(
+            document.getElementById('example2'));
+        assert.ok(retrievedViewer2, 'Attached viewer retrieved');
+        assert.equal(retrievedViewer2, viewer2, 'Viewers are same instance');
+
+        // Internal state
+        assert.equal(OpenSeadragon._viewers.size, 2, 'Correct amount of viewers');
+    });
+
+    QUnit.test('Undefined on Get Non-Existent Viewer by Id', function(assert) {
+        var notFoundViewer = OpenSeadragon.getViewer('no-viewer');
+        assert.equal(notFoundViewer, undefined, "Not found viewer is undefined");
+    });
+
+    QUnit.test('Undefined on Get Non-Existent Viewer by Element', function(assert) {
+        var element = document.createElement('div');
+        element.id = 'no-viewer';
+        document.body.appendChild(element);
+
+        var notFoundViewer = OpenSeadragon.getViewer(element);
+        assert.equal(notFoundViewer, undefined, "Not found viewer is undefined");
+    });
+
+    QUnit.test('Cleanup Viewers Registration', function(assert) {
+        viewer1.destroy();
+        viewer2.destroy();
+        viewer1 = viewer2 = null;
+
+        var retrievedViewer1 = OpenSeadragon.getViewer('example1');
+        var retrievedViewer2 = OpenSeadragon.getViewer('example2');
+        assert.equal(retrievedViewer1, undefined, 'Viewer was destroyed');
+        assert.equal(retrievedViewer2, undefined, 'Viewer was destroyed');
+
+        // Internal state
+        assert.equal(OpenSeadragon._viewers.size, 0, 'No viewers are registered');
+    });
+})();

--- a/test/test.html
+++ b/test/test.html
@@ -22,6 +22,7 @@
     <!-- Polyfill must be inserted first because it is testing functions
          reassignments which could be done by other test. -->
     <script src="/test/modules/polyfills.js"></script>
+    <script src="/test/modules/viewerretrieval.js"></script>
     <script src="/test/modules/basic.js"></script>
     <script src="/test/modules/strings.js"></script>
     <script src="/test/modules/formats.js"></script>


### PR DESCRIPTION
Solves #1983 

Add a static method to `OpenSeadragon` to allow retrieval of a viewer which has been attached to an element. From my limited testing, this retrieval also works when the viewer is created in a different file, which is the use case described in the issue.

Proposed API in `OpenSeadragon`, according to @iangilman's [suggestion](https://github.com/openseadragon/openseadragon/issues/1983#issuecomment-852355495):

```js
/**
 * Returns the {@link Viewer} attached to a given DOM element. If there is
 * no viewer attached to the provided element, undefined is returned.
 * @function
 * @param {String|Element} element Accepts an id or element.
 * @returns {Viewer} The viewer attached to the given element, or undefined.
 */
getViewer: function(element) {
    return $._viewers.get(this.getElement(element));
},
```

The viewers are stored in a `Map` in the property `_viewers`, using the underscore prefix to indicate that it is a private property. I used this convention according to @iangilman's [code style suggestion](https://github.com/openseadragon/openseadragon/issues/456#issue-40077339).

### Work that I think still needs to be done

- [x] Remove viewer from `_viewers` on [`viewer.destroy()`](https://github.com/openseadragon/openseadragon/blob/fd85d5e22f8a8cf9f0b534c2428f4c7f645268bf/src/viewer.js#L748)
- [x] Implement tests for `OpenSeadragon.getViewer(element)`
