### PR TITLE
Navigator is matched to viewer when it succeeds

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -404,6 +404,8 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
                 var myItem = event.item;
                 myItem._originalForNavigator = original;
                 _this._matchBounds(myItem, original, true);
+                _this._matchOpacity(myItem, original);
+                _this._matchCompositeOperation(myItem, original);
 
                 function matchBounds() {
                     _this._matchBounds(myItem, original);


### PR DESCRIPTION
I'm working on an application that opens several tiled images at once and potentially alters the opacities of the images upon the viewer's `open` event. This reveals a bug in the navigator that results from the following course of events:

1. The viewer begins opening a tiled image with its initial opacity
2. Upon completion, the tiled image begins opening a corresponding tiled image in the navigator with the initial opacity
3. After all tiled images in the viewer have been opened, the `open` event is triggered and their opacities are altered
4. The tiled images in the navigator finish opening, call their success callbacks, and add event handlers for reacting to opacity changes

This possible course of events results in the tiled images in the navigator not matching the altered opacities, and instead keeping the initial opacities for some or all of the images until they are altered again, as some of their event handlers are not set up in time. This bug could also affect composite operations.

A simple example that can be used to observe this bug, where the navigator content shows up as invisible even though the image can be seen in the viewer:
```JavaScript
const options = {
    id: "viewport",
    prefixUrl: "js/openseadragon/images/",
    showNavigator: true
};
const sources = [
    {tileSource: /* Image */, opacity: 0}
];
const viewer = OpenSeadragon(options);
viewer.open(sources);
viewer.addHandler("open", () => {
    viewer.world.getItemAt(0).setOpacity(1);
});
```

The solution to this bug included in this pull request is to simply call `_matchOpacity()` and `_matchCompositeOperation()` in the success callback to make sure the navigator has the most up-to-date values before setting up the handlers.