### PR TITLE
Attempting to get the original target for click events

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -1193,7 +1193,7 @@
      *      the emulated event, a synthetic event object created with values from the actual DOM event,
      *      or null if no DOM event applies. Emulated events can occur on eventType "wheel" on legacy mouse-scroll
      *      event emitting user agents.
-     * @property {Boolean} isStopable
+     * @property {Boolean} isStoppable
      *      True if propagation of the event (e.g. bubbling) can be stopped with stopPropagation/stopImmediatePropagation.
      * @property {Boolean} isCancelable
      *      True if the event's default handling by the browser can be prevented with preventDefault.
@@ -2840,7 +2840,7 @@
     function getEventProcessDefaults( tracker, eventInfo ) {
         switch ( eventInfo.eventType ) {
             case 'pointermove':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = !tracker.hasGestureHandlers;
@@ -2852,28 +2852,28 @@
             case 'keydown':
             case 'keyup':
             case 'keypress':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false; // onContextMenu(), onKeyDown(), onKeyUp(), onKeyPress() may set true
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
                 break;
             case 'pointerdown':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false; // updatePointerDown() may set true (tracker.hasGestureHandlers)
                 eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
                 break;
             case 'pointerup':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
                 break;
             case 'wheel':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false; // handleWheelEvent() may set true
                 eventInfo.preventGesture = !tracker.hasScrollHandler;
@@ -2882,21 +2882,21 @@
             case 'gotpointercapture':
             case 'lostpointercapture':
             case 'pointercancel':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = false;
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
                 break;
             case 'click':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = !!tracker.clickHandler;
                 eventInfo.preventGesture = false;
                 eventInfo.stopPropagation = false;
                 break;
             case 'dblclick':
-                eventInfo.isStopable = true;
+                eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = !!tracker.dblClickHandler;
                 eventInfo.preventGesture = false;
@@ -2907,7 +2907,7 @@
             case 'pointerenter':
             case 'pointerleave':
             default:
-                eventInfo.isStopable = false;
+                eventInfo.isStoppable = false;
                 eventInfo.isCancelable = false;
                 eventInfo.preventDefault = false;
                 eventInfo.preventGesture = false;

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -737,6 +737,8 @@
          *      True if the original event is a touch event, otherwise false. <span style="color:red;">Deprecated. Use pointerType and/or originalEvent instead.</span>
          * @param {Object} event.originalEvent
          *      The original event object.
+         * @param {Element} event.originalTarget
+         *      The DOM element clicked on.
          * @param {Object} event.userData
          *      Arbitrary user-defined object.
          */

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -3272,6 +3272,7 @@
             //updateGPoint.captured = true; // Handled by updatePointerCaptured()
             updateGPoint.insideElementPressed = true;
             updateGPoint.insideElement = true;
+            updateGPoint.originalTarget = eventInfo.originalEvent.target;
             updateGPoint.contactPos = gPoint.currentPos;
             updateGPoint.contactTime = gPoint.currentTime;
             updateGPoint.lastPos = updateGPoint.currentPos;
@@ -3286,6 +3287,7 @@
             gPoint.captured = false; // Handled by updatePointerCaptured()
             gPoint.insideElementPressed = true;
             gPoint.insideElement = true;
+            gPoint.originalTarget = eventInfo.originalEvent.target;
             startTrackingPointer( pointsList, gPoint );
             return;
         }
@@ -3504,6 +3506,7 @@
                                     shift:                eventInfo.originalEvent.shiftKey,
                                     isTouchEvent:         updateGPoint.type === 'touch',
                                     originalEvent:        eventInfo.originalEvent,
+                                    originalTarget:       updateGPoint.originalTarget,
                                     userData:             tracker.userData
                                 }
                             );

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2850,6 +2850,7 @@ function onCanvasClick( event ) {
         quick: event.quick,
         shift: event.shift,
         originalEvent: event.originalEvent,
+        originalTarget: event.originalTarget,
         preventDefaultAction: false
     };
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2866,6 +2866,7 @@ function onCanvasClick( event ) {
      * @property {Boolean} quick - True only if the clickDistThreshold and clickTimeThreshold are both passed. Useful for differentiating between clicks and drags.
      * @property {Boolean} shift - True if the shift key was pressed during this event.
      * @property {Object} originalEvent - The original DOM event.
+     * @property {Element} originalTarget - The DOM element clicked on.
      * @property {Boolean} preventDefaultAction - Set to true to prevent default click to zoom behaviour. Default: false.
      * @property {?Object} userData - Arbitrary subscriber-defined object.
      */


### PR DESCRIPTION
Fixes #1997

Here's my attempt to fix https://github.com/openseadragon/openseadragon/issues/1997, but it doesn't seem to be working. Here's my test code (for use in test/demo/basic.html): 

```
var viewer = OpenSeadragon({
    id: "contentDiv",
    prefixUrl: "../../build/openseadragon/images/",
    tileSources: "../data/testpattern.dzi",
});

viewer.addHandler("open", function(event) {
    var elt = elt = document.createElement("div");
    elt.className = "runtime-overlay";
    elt.style.background = "white";
    elt.style.outline = "3px solid red";
    elt.style.width = "100px";
    elt.textContent = "Open console and click on me";
    viewer.addOverlay({
        element: elt,
        location: new OpenSeadragon.Point(0.6, 0.6),
        height: 0.1,
        placement: OpenSeadragon.Placement.TOP_LEFT,
        rotationMode: OpenSeadragon.OverlayRotationMode.NO_ROTATION
    });

});

viewer.addHandler('canvas-click', function(event) {
    console.log(event);
});
```

When I run it and click on the overlay, the event that's logged has an `originalTarget` but it's `div.openseadragon-canvas` (whereas we want it to be `div.runtime-overlay`). 

I've tried doing `console.log` on the event during `pointerDown` handling, and those events are all in terms of the canvas. I'm not sure where to get the overlay, and why it's not showing up in the event.
 
@msalsbery do you have any insights on this? 