### PR TITLE
Fix rotation constraints bug

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -575,7 +575,7 @@ $.Viewport.prototype = {
             this.zoomTo(constrainedZoom, this.zoomPoint, immediately);
         }
 
-        var bounds = this.getBoundsNoRotate();
+        var bounds = this.getBounds();
         var constrainedBounds = this._applyBoundaryConstraints(bounds);
         this._raiseConstraintsEvent(immediately);
 
@@ -583,7 +583,7 @@ $.Viewport.prototype = {
             bounds.y !== constrainedBounds.y ||
             immediately) {
             this.fitBounds(
-                constrainedBounds.rotate(-this.getRotation()),
+                constrainedBounds,
                 immediately);
         }
         return this;


### PR DESCRIPTION
Addresses a bug where bounds do not correctly take rotation into consideration. The proposed fix includes rotation when getting bounds inside of the `applyConstraints` function instead of applying the current rotation to the final bounds. Feedback is needed to ensure this doesn't have unintended side effects elsewhere but so far this has resolved the issue for me.
Closes #2040 