### PR TITLE
Removed unnecessary touch-action:none and pointer-events:none settings on overlay container DIV

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -54,7 +54,8 @@ OPENSEADRAGON CHANGELOG
 * Added a static method in OpenSeadragon to get an existing viewer (#2000 @HerCerM)
 * Now ensuring that the new item is already in the navigator when the "add-item" event fires (#2005 @RammasEchor)
 * Added keys to change image in sequence mode (j: previous, k: next) (#2007 @RammasEchor)
-* Fixed a bug where the navigator wouldn't pick up opacity/composite changes made while it is loading (#2018 @crydell) 
+* Fixed a bug where the navigator wouldn't pick up opacity/composite changes made while it is loading (#2018 @crydell)
+* Removed unnecessary pointer-events:none setting on overlay container DIV element (#2042 @msalsbery)
 
 2.4.2:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -55,7 +55,7 @@ OPENSEADRAGON CHANGELOG
 * Now ensuring that the new item is already in the navigator when the "add-item" event fires (#2005 @RammasEchor)
 * Added keys to change image in sequence mode (j: previous, k: next) (#2007 @RammasEchor)
 * Fixed a bug where the navigator wouldn't pick up opacity/composite changes made while it is loading (#2018 @crydell)
-* Removed unnecessary pointer-events:none setting on overlay container DIV element (#2042 @msalsbery)
+* Removed unnecessary touch-action:none and pointer-events:none settings on overlay container DIV element (#2042 @msalsbery)
 
 2.4.2:
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -408,7 +408,6 @@ $.Viewer = function( options ) {
 
     // Overlay container
     this.overlaysContainer    = $.makeNeutralElement( "div" );
-    $.setElementPointerEventsNone( this.overlaysContainer );
     $.setElementTouchActionNone( this.overlaysContainer );
     this.canvas.appendChild( this.overlaysContainer );
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -408,7 +408,6 @@ $.Viewer = function( options ) {
 
     // Overlay container
     this.overlaysContainer    = $.makeNeutralElement( "div" );
-    $.setElementTouchActionNone( this.overlaysContainer );
     this.canvas.appendChild( this.overlaysContainer );
 
     // Now that we have a drawer, see if it supports rotate. If not we need to remove the rotate buttons


### PR DESCRIPTION
Recent MouseTracker fixes have made this setting unnecessary...removed it.

Also removed the touch-action:none setting, as it shouldn't be needed on the overlay container element