### PR TITLE
Add method for getting the relative size of an image

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -420,10 +420,12 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     },
 
     /**
-     * @returns {OpenSeadragon.Point} The dimensions of the image as it would be currently rendered in the viewport
+     * @returns {OpenSeadragon.Point} The TiledImage's content size, in window coordinates.
      */
-     getRelativeSize: function() {
-        return this.getContentSize().times(this.viewport.getZoom());
+     getSizeInWindowCoordinates: function() {
+        var topLeft = this.viewport.imageToWindowCoordinates(new $.Point(0, 0));
+        var bottomRight = this.viewport.imageToWindowCoordinates(this.getContentSize());
+        return new $.Point(bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
     },
 
     // private

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -423,8 +423,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * @returns {OpenSeadragon.Point} The TiledImage's content size, in window coordinates.
      */
      getSizeInWindowCoordinates: function() {
-        var topLeft = this.viewport.imageToWindowCoordinates(new $.Point(0, 0));
-        var bottomRight = this.viewport.imageToWindowCoordinates(this.getContentSize());
+        var topLeft = this.imageToWindowCoordinates(new $.Point(0, 0));
+        var bottomRight = this.imageToWindowCoordinates(this.getContentSize());
         return new $.Point(bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
     },
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -419,6 +419,13 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         return new $.Point(this.source.dimensions.x, this.source.dimensions.y);
     },
 
+    /**
+     * @returns {OpenSeadragon.Point} The dimensions of the image as it would be currently rendered in the viewport
+     */
+     getRelativeSize: function() {
+        return this.getContentSize().times(this.viewport.getZoom());
+    },
+
     // private
     _viewportToImageDelta: function( viewerX, viewerY, current ) {
         var scale = (current ? this._scaleSpring.current.value : this._scaleSpring.target.value);

--- a/test/modules/tiledimage.js
+++ b/test/modules/tiledimage.js
@@ -41,8 +41,11 @@
         viewer.addHandler('open', function(event) {
             var image = viewer.world.getItemAt(0);
             var contentSize = image.getContentSize();
+            var relativeSize = image.getRelativeSize();
             assert.equal(contentSize.x, 500, 'contentSize.x');
             assert.equal(contentSize.y, 2000, 'contentSize.y');
+            assert.equal(relativeSize.x, 12.5, 'relativeSize.x');
+            assert.equal(relativeSize.y, 50, 'relativeSize.y');
 
             checkBounds(assert, image, new OpenSeadragon.Rect(5, 6, 10, 40), 'initial bounds');
 
@@ -74,7 +77,18 @@
             image.setHeight(4);
             checkBounds(assert, image, new OpenSeadragon.Rect(7, 8, 1, 4), 'bounds after width');
 
-            assert.equal(handlerCount, 1, 'correct number of handlers called');
+            viewer.addHandler('zoom', function zoomHandler(event) {
+                var relativeSize = image.getRelativeSize();
+                viewer.removeHandler('zoom', zoomHandler);
+                handlerCount++;
+                assert.equal(relativeSize.x, 4000, 'relativeSize.x after zoom');
+                assert.equal(relativeSize.y, 16000, 'relativeSize.y after zoom');
+            });
+
+            viewer.viewport.zoomTo(8);
+
+            assert.equal(handlerCount, 2, 'correct number of handlers called');
+
             done();
         });
 

--- a/test/modules/tiledimage.js
+++ b/test/modules/tiledimage.js
@@ -41,11 +41,11 @@
         viewer.addHandler('open', function(event) {
             var image = viewer.world.getItemAt(0);
             var contentSize = image.getContentSize();
-            var relativeSize = image.getRelativeSize();
+            var sizeInWindowCoords = image.getSizeInWindowCoordinates();
             assert.equal(contentSize.x, 500, 'contentSize.x');
             assert.equal(contentSize.y, 2000, 'contentSize.y');
-            assert.equal(relativeSize.x, 12.5, 'relativeSize.x');
-            assert.equal(relativeSize.y, 50, 'relativeSize.y');
+            assert.equal(sizeInWindowCoords.x, 125, 'sizeInWindowCoords.x');
+            assert.equal(sizeInWindowCoords.y, 500, 'sizeInWindowCoords.y');
 
             checkBounds(assert, image, new OpenSeadragon.Rect(5, 6, 10, 40), 'initial bounds');
 
@@ -78,14 +78,14 @@
             checkBounds(assert, image, new OpenSeadragon.Rect(7, 8, 1, 4), 'bounds after width');
 
             viewer.addHandler('zoom', function zoomHandler(event) {
-                var relativeSize = image.getRelativeSize();
+                var sizeInWindowCoords = image.getSizeInWindowCoordinates();
                 viewer.removeHandler('zoom', zoomHandler);
                 handlerCount++;
-                assert.equal(relativeSize.x, 4000, 'relativeSize.x after zoom');
-                assert.equal(relativeSize.y, 16000, 'relativeSize.y after zoom');
+                assert.equal(sizeInWindowCoords.x, 4000, 'sizeInWindowCoords.x after zoom');
+                assert.equal(sizeInWindowCoords.y, 16000, 'sizeInWindowCoords.y after zoom');
             });
 
-            viewer.viewport.zoomTo(8);
+            viewer.viewport.zoomTo(8, null, true);
 
             assert.equal(handlerCount, 2, 'correct number of handlers called');
 


### PR DESCRIPTION
I had a specific use-case that needed the rendered (or I suppose, "theoretical" as it may be far larger than the viewport), size of an image from the canvas/world (I can elaborate more if that's interesting).

I had a poke around and couldn't find a native method that would return this value. This value seemed interesting, so I went about implementing a utility for it. Initially my method was something like this:

```
const topLeft = this.viewport.imageToWindowCoordinates(new $.Point(0, 0));
const bottomRight = this.viewport.imageToWindowCoordinates(new $.Point(sourceDimensions.x, sourceDimensions.y));
return new $.Point(bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
```

Only when I was implementing the tests did I realise what I was reaching for was simply the contentSize multiplied by the zoom level. I still think having this as a method might be helpful to a casual user though.