### PR TITLE
Remove foced tile overlap for tilesources with tileoverlap=0

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1735,10 +1735,6 @@ function positionTile( tile, overlap, viewport, viewportCenter, levelVisibility,
         tileCenter = positionT.plus( sizeT.divide( 2 ) ),
         tileSquaredDistance = viewportCenter.squaredDistanceTo( tileCenter );
 
-    if ( !overlap ) {
-        sizeC = sizeC.plus( new $.Point( 1, 1 ) );
-    }
-
     if (tile.isRightMost && tiledImage.wrapHorizontal) {
         sizeC.x += 0.75; // Otherwise Firefox and Safari show seams
     }


### PR DESCRIPTION
This should resolve openseadragon#1722. This same change was proposed in PR #1731

This is a fix for tiny visible stitching errors for tilesources with overlap=0, due to the forced overlap. The forced overlap appeared to be put in place for a time when the non-canvas renderer was more widely used due to browser support. With the non-canvas renderer, the forced overlap may have prevented visible seams between tiles. However, now that canvas is  almost [universally supported](https://caniuse.com/canvas), I'm not sure this workaround is still necessary? 

I stumbled into this issue as a tiny "stitching errors" were surfaced in a commerical project leveraging OSD that I maintain. We were programatically comparing ROIs from our OSD based viewer to those from another viewer (based on openlayers), leveraing the same tilesource backend, which has zero tile overlap.

The comparisons revealed subtle differences at tile boundaries. In a few instances, we noticed tiny visible seams between tiles. We tracked that down to the issue discussed in #1722. Removing this code resolved the issue. 

We'd love to get this change merged upstream. Perhaps we could conditionally disable this code for canvas renderers? Let me know how we can get this PR accepted! Thanks again!