### PR TITLE
Fix getLevelScale to use image dimensions

### DIFF
--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -284,10 +284,14 @@ $.TileSource.prototype = {
         // see https://github.com/openseadragon/openseadragon/issues/22
         // we use the tilesources implementation of getLevelScale to generate
         // a memoized re-implementation
-        var levelScaleCache = {},
+        var maxLevel = Math.ceil(
+                Math.log( Math.max( this.dimensions.x, this.dimensions.y ) ) /
+                Math.log( 2 )
+            ),
+            levelScaleCache = {},
             i;
-        for( i = 0; i <= this.maxLevel; i++ ){
-            levelScaleCache[ i ] = 1 / Math.pow(2, this.maxLevel - i);
+        for( i = 0; i <= maxLevel; i++ ){
+            levelScaleCache[ i ] = 1 / Math.pow(2, maxLevel - i);
         }
         this.getLevelScale = function( _level ){
             return levelScaleCache[ _level ];

--- a/test/modules/tilesource.js
+++ b/test/modules/tilesource.js
@@ -120,4 +120,27 @@
         assertTileAtPoint(0, new OpenSeadragon.Point(1, 3033 / 2000), new OpenSeadragon.Point(0, 0));
     });
 
+    QUnit.test('changing maxLevel', function(assert) {
+        var tileSource = new OpenSeadragon.TileSource({
+            width: 4096,
+            height: 4096,
+        });
+
+        assert.equal(tileSource.maxLevel, 12, 'The initial max level should be 12.');
+
+        tileSource.maxLevel = 9;
+
+        function assertLevelScale(level, expected) {
+            var actual = tileSource.getLevelScale(level);
+            assert.ok(Math.abs(actual - expected) < Number.EPSILON, "The scale at level " + level +
+                " should be " + expected.toString() +
+                " got " + actual.toString());
+        }
+
+        assertLevelScale(12, 1);
+        assertLevelScale(10, 1 / 4);
+        assertLevelScale(8, 1 / 16);
+        assertLevelScale(6, 1 / 64);
+    });
+
 }());


### PR DESCRIPTION
Hello, I would like to request for a review on this PR.

Currently, `TileSource.getLevelScale()` calculates and memoizes the image scale at every levels using `TileSource.maxLevel` at its first invocation. However, the `maxLevel` variable could be changed by a user before `getLevelScale` is invoked. When the function is executed after `maxLevel` is changed, it could cause an issue where tiles are not properly loaded. The following link is a simple reproduction of the issue: https://codesandbox.io/s/osd-change-maxlevel-60ckw

Thank you so much, and I would appreciate your opinions on the PR!