### PR TITLE
Fix #2065 and add setMaxLevel for #2059

### DIFF
--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -306,8 +306,8 @@ $.TileSource.prototype = {
         // a memoized re-implementation
         var levelScaleCache = {},
             i;
-        for( i = 0; i <= this.maxlevel; i++ ){
-            levelScaleCache[ i ] = 1 / Math.pow(2, this.maxlevel - i);
+        for( i = 0; i <= this.maxLevel; i++ ){
+            levelScaleCache[ i ] = 1 / Math.pow(2, this.maxLevel - i);
         }
         this.getLevelScale = function( _level ){
             return levelScaleCache[ _level ];

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -219,13 +219,14 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
 
         this.tileOverlap = options.tileOverlap ? options.tileOverlap : 0;
         this.minLevel    = options.minLevel ? options.minLevel : 0;
-        this.maxLevel    = ( undefined !== options.maxLevel && null !== options.maxLevel ) ?
+        this.setMaxLevel( ( undefined !== options.maxLevel && null !== options.maxLevel ) ?
             options.maxLevel : (
                 ( options.width && options.height ) ? Math.ceil(
                     Math.log( Math.max( options.width, options.height ) ) /
                     Math.log( 2 )
                 ) : 0
-            );
+            )
+        );
         if( this.success && $.isFunction( this.success ) ){
             this.success( this );
         }
@@ -278,21 +279,36 @@ $.TileSource.prototype = {
     /**
      * @function
      * @param {Number} level
+     * @return {OpenSeadragon.TileSource} Chainable.
+     */
+    setMaxLevel: function( level ) {
+        this.maxLevel = level;
+        this._memoizeLevelScale( level );
+        return this;
+    },
+
+    /**
+     * @function
+     * @param {Number} level
      */
     getLevelScale: function( level ) {
+        this._memoizeLevelScale( this.maxLevel );
+        return this.getLevelScale( level );
+    },
 
+    // private
+    _memoizeLevelScale: function( level ) {
         // see https://github.com/openseadragon/openseadragon/issues/22
         // we use the tilesources implementation of getLevelScale to generate
         // a memoized re-implementation
         var levelScaleCache = {},
             i;
-        for( i = 0; i <= this.maxLevel; i++ ){
-            levelScaleCache[ i ] = 1 / Math.pow(2, this.maxLevel - i);
+        for( i = 0; i <= level; i++ ){
+            levelScaleCache[ i ] = 1 / Math.pow(2, level - i);
         }
         this.getLevelScale = function( _level ){
             return levelScaleCache[ _level ];
         };
-        return this.getLevelScale( level );
     },
 
     /**

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -276,6 +276,10 @@ $.TileSource.prototype = {
     },
 
     /**
+     * Set the maxLevel to the given level, and perform the memoization of
+     * getLevelScale with the new maxLevel. This function can be useful if the
+     * memoization is required before the first call of getLevelScale, or both
+     * memoized getLevelScale and maxLevel should be changed accordingly.
      * @function
      * @param {Number} level
      */

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -284,14 +284,10 @@ $.TileSource.prototype = {
         // see https://github.com/openseadragon/openseadragon/issues/22
         // we use the tilesources implementation of getLevelScale to generate
         // a memoized re-implementation
-        var maxLevel = Math.ceil(
-                Math.log( Math.max( this.dimensions.x, this.dimensions.y ) ) /
-                Math.log( 2 )
-            ),
-            levelScaleCache = {},
+        var levelScaleCache = {},
             i;
-        for( i = 0; i <= maxLevel; i++ ){
-            levelScaleCache[ i ] = 1 / Math.pow(2, maxLevel - i);
+        for( i = 0; i <= this.maxLevel; i++ ){
+            levelScaleCache[ i ] = 1 / Math.pow(2, this.maxLevel - i);
         }
         this.getLevelScale = function( _level ){
             return levelScaleCache[ _level ];

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -219,14 +219,13 @@ $.TileSource = function( width, height, tileSize, tileOverlap, minLevel, maxLeve
 
         this.tileOverlap = options.tileOverlap ? options.tileOverlap : 0;
         this.minLevel    = options.minLevel ? options.minLevel : 0;
-        this.setMaxLevel( ( undefined !== options.maxLevel && null !== options.maxLevel ) ?
+        this.maxLevel    = ( undefined !== options.maxLevel && null !== options.maxLevel ) ?
             options.maxLevel : (
                 ( options.width && options.height ) ? Math.ceil(
                     Math.log( Math.max( options.width, options.height ) ) /
                     Math.log( 2 )
                 ) : 0
-            )
-        );
+            );
         if( this.success && $.isFunction( this.success ) ){
             this.success( this );
         }
@@ -279,12 +278,10 @@ $.TileSource.prototype = {
     /**
      * @function
      * @param {Number} level
-     * @return {OpenSeadragon.TileSource} Chainable.
      */
     setMaxLevel: function( level ) {
         this.maxLevel = level;
-        this._memoizeLevelScale( level );
-        return this;
+        this._memoizeLevelScale();
     },
 
     /**
@@ -292,19 +289,21 @@ $.TileSource.prototype = {
      * @param {Number} level
      */
     getLevelScale: function( level ) {
-        this._memoizeLevelScale( this.maxLevel );
+        // if getLevelScale is not memoized, we generate the memoized version
+        // at the first call and return the result
+        this._memoizeLevelScale();
         return this.getLevelScale( level );
     },
 
     // private
-    _memoizeLevelScale: function( level ) {
+    _memoizeLevelScale: function() {
         // see https://github.com/openseadragon/openseadragon/issues/22
         // we use the tilesources implementation of getLevelScale to generate
         // a memoized re-implementation
         var levelScaleCache = {},
             i;
-        for( i = 0; i <= level; i++ ){
-            levelScaleCache[ i ] = 1 / Math.pow(2, level - i);
+        for( i = 0; i <= this.maxlevel; i++ ){
+            levelScaleCache[ i ] = 1 / Math.pow(2, this.maxlevel - i);
         }
         this.getLevelScale = function( _level ){
             return levelScaleCache[ _level ];

--- a/test/modules/tilesource.js
+++ b/test/modules/tilesource.js
@@ -128,8 +128,6 @@
 
         assert.equal(tileSource.maxLevel, 12, 'The initial max level should be 12.');
 
-        tileSource.maxLevel = 9;
-
         function assertLevelScale(level, expected) {
             var actual = tileSource.getLevelScale(level);
             assert.ok(Math.abs(actual - expected) < Number.EPSILON, "The scale at level " + level +
@@ -141,6 +139,13 @@
         assertLevelScale(10, 1 / 4);
         assertLevelScale(8, 1 / 16);
         assertLevelScale(6, 1 / 64);
+
+        tileSource.setMaxLevel(9);
+
+        assertLevelScale(9, 1);
+        assertLevelScale(7, 1 / 4);
+        assertLevelScale(5, 1 / 16);
+        assertLevelScale(3, 1 / 64);
     });
 
 }());


### PR DESCRIPTION
This fixes #2065.

Based on #2065, I added a function named `setMaxLevel` for `getLevelScale` memoization, and used the function inside `TileSource` constructor. I think this resolves #2059 without using image dimensions.