### PR TITLE
Extends the fix for seams in transparent images to any browsers

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -352,7 +352,7 @@ $.Drawer.prototype = {
         if (this.useCanvas) {
             var context = this._getContext(useSketch);
             scale = scale || 1;
-            tile.drawCanvas(context, drawingHandler, scale, translate);
+            tile.drawCanvas(context, drawingHandler, scale, translate, this._shouldRoundPositionAndSize);
         } else {
             tile.drawHTML( this.canvas );
         }

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -344,15 +344,18 @@ $.Drawer.prototype = {
      * where <code>rendered</code> is the context with the pre-drawn image.
      * @param {Float} [scale=1] - Apply a scale to tile position and size. Defaults to 1.
      * @param {OpenSeadragon.Point} [translate] A translation vector to offset tile position
+     * @param {Boolean} [shouldRoundPositionAndSize] - Tells whether to round
+     * position and size of tiles supporting alpha channel in non-transparency
+     * context.
      */
-    drawTile: function(tile, drawingHandler, useSketch, scale, translate) {
+    drawTile: function(tile, drawingHandler, useSketch, scale, translate, shouldRoundPositionAndSize) {
         $.console.assert(tile, '[Drawer.drawTile] tile is required');
         $.console.assert(drawingHandler, '[Drawer.drawTile] drawingHandler is required');
 
         if (this.useCanvas) {
             var context = this._getContext(useSketch);
             scale = scale || 1;
-            tile.drawCanvas(context, drawingHandler, scale, translate, this._shouldRoundPositionAndSize);
+            tile.drawCanvas(context, drawingHandler, scale, translate, shouldRoundPositionAndSize);
         } else {
             tile.drawHTML( this.canvas );
         }

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1424,9 +1424,25 @@ function OpenSeadragon( options ){
          * @property {Number} ALWAYS Apply subpixel rounding for transparency during animation and when animation is over.
          */
         SUBPIXEL_ROUNDING_OCCURRENCES: {
-            NEVER:          0,
-            ONLY_AT_REST:   1,
-            ALWAYS:         2
+            NEVER:        0,
+            ONLY_AT_REST: 1,
+            ALWAYS:       2
+        },
+
+        /**
+         * An enumeration of animation states.
+         * @static
+         * @type {Object}
+         * @property {Number} AT_REST Indicates there are no more animations running and the image is at rest.
+         * @property {Number} ANIMATION_STARTED Indicates the image is in motion and it just started.
+         * @property {Number} ANIMATING Indicates the image was in motion and is still in motion.
+         * @property {Number} ANIMATION_FINISHED Indicates the image was in motion and is not in motion anymore.
+         */
+         ANIMATION_STATES: {
+            AT_REST:            0,
+            ANIMATION_STARTED:  1,
+            ANIMATING:          2,
+            ANIMATION_FINISHED: 3
         },
 
         /**

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1430,22 +1430,6 @@ function OpenSeadragon( options ){
         },
 
         /**
-         * An enumeration of animation states.
-         * @static
-         * @type {Object}
-         * @property {Number} AT_REST Indicates there are no more animations running and the image is at rest.
-         * @property {Number} ANIMATION_STARTED Indicates the image is in motion and it just started.
-         * @property {Number} ANIMATING Indicates the image was in motion and is still in motion.
-         * @property {Number} ANIMATION_FINISHED Indicates the image was in motion and is not in motion anymore.
-         */
-         ANIMATION_STATES: {
-            AT_REST:            0,
-            ANIMATION_STARTED:  1,
-            ANIMATING:          2,
-            ANIMATION_FINISHED: 3
-        },
-
-        /**
          * Keep track of which {@link Viewer}s have been created.
          * - Key: {@link Element} to which a Viewer is attached.
          * - Value: {@link Viewer} of the element defined by the key.

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -209,12 +209,16 @@
   *     You can pass a CSS color value like "#FF8800".
   *     When passing a function the tiledImage and canvas context are available as argument which is useful when you draw a gradient or pattern.
   *
-  * @property {Object} [subPixelRounding=null]
-  *     Determines when subpixel rounding should be applied for tiles rendering.
-  *     This property is a subpixel rounding enum values dictionary [number] --> string.
-  *     The key is a $.BROWSERS value, and the value is one of 'ALWAYS', 'ONLY_AT_REST' or 'NEVER',
+  * @property {Object} [subPixelRoundingForTransparency=null]
+  *     Determines when subpixel rounding should be applied for tiles when rendering images that support transparency.
+  *     This property is a subpixel rounding enum values dictionary [{@link BROWSERS}] --> {@link SUBPIXEL_ROUNDING_OCCURRENCES}.
+  *     The key is a {@link BROWSERS} value, and the value is one of {@link SUBPIXEL_ROUNDING_OCCURRENCES},
   *     indicating, for a given browser, when to apply subpixel rounding.
-  *     Key '' is the fallback value for any browser not specified in the dictionary.
+  *     Key '*' is the fallback value for any browser not specified in the dictionary.
+  *     This property has a simple mode, and one can set it directly to
+  *     {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER}, {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST} or {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS}
+  *     in order to apply this rule for all browser. The values {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS} would be equivalent to { '*', SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS }.
+  *     The default is {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER} for all browsers, for backward compatibility reason.
   *
   * @property {Number} [degrees=0]
   *     Initial rotation.
@@ -1265,12 +1269,12 @@ function OpenSeadragon( options ){
             flipped:                    false,
 
             // APPEARANCE
-            opacity:                    1,
-            preload:                    false,
-            compositeOperation:         null,
-            imageSmoothingEnabled:      true,
-            placeholderFillStyle:       null,
-            subPixelRounding:           null,
+            opacity:                           1,
+            preload:                           false,
+            compositeOperation:                null,
+            imageSmoothingEnabled:             true,
+            placeholderFillStyle:              null,
+            subPixelRoundingForTransparency:   null,
 
             //REFERENCE STRIP SETTINGS
             showReferenceStrip:          false,
@@ -1409,6 +1413,20 @@ function OpenSeadragon( options ){
             OPERA:      5,
             EDGE:       6,
             CHROMEEDGE: 7
+        },
+
+        /**
+         * An enumeration of Browser vendors.
+         * @static
+         * @type {Object}
+         * @property {Number} NEVER Never apply subpixel rounding for transparency.
+         * @property {Number} ONLY_AT_REST Do not apply subpixel rounding for transparency during animation (panning, zoom, rotation) and apply it once animation is over.
+         * @property {Number} ALWAYS Apply subpixel rounding for transparency during animation and when animation is over.
+         */
+        SUBPIXEL_ROUNDING_OCCURRENCES: {
+            NEVER:          0,
+            ONLY_AT_REST:   1,
+            ALWAYS:         2
         },
 
         /**

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -209,6 +209,13 @@
   *     You can pass a CSS color value like "#FF8800".
   *     When passing a function the tiledImage and canvas context are available as argument which is useful when you draw a gradient or pattern.
   *
+  * @property {Object} [subPixelRounding=null]
+  *     Determines when subpixel rounding should be applied for tiles rendering.
+  *     This property is a subpixel rounding enum values dictionary [number] --> string.
+  *     The key is a $.BROWSERS value, and the value is one of 'ALWAYS', 'ONLY_AT_REST' or 'NEVER',
+  *     indicating, for a given browser, when to apply subpixel rounding.
+  *     Key '' is the fallback value for any browser not specified in the dictionary.
+  *
   * @property {Number} [degrees=0]
   *     Initial rotation.
   *
@@ -1263,6 +1270,7 @@ function OpenSeadragon( options ){
             compositeOperation:         null,
             imageSmoothingEnabled:      true,
             placeholderFillStyle:       null,
+            subPixelRounding:           null,
 
             //REFERENCE STRIP SETTINGS
             showReferenceStrip:          false,

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1416,7 +1416,7 @@ function OpenSeadragon( options ){
         },
 
         /**
-         * An enumeration of Browser vendors.
+         * An enumeration of when subpixel rounding should occur.
          * @static
          * @type {Object}
          * @property {Number} NEVER Never apply subpixel rounding for transparency.

--- a/src/tile.js
+++ b/src/tile.js
@@ -318,8 +318,11 @@ $.Tile.prototype = {
      * where <code>rendered</code> is the context with the pre-drawn image.
      * @param {Number} [scale=1] - Apply a scale to position and size
      * @param {OpenSeadragon.Point} [translate] - A translation vector
+     * @param {Boolean} [shouldRoundPositionAndSize] - Tells whether to round
+     * position and size of tiles supporting alpha channel in non-transparency
+     * context.
      */
-    drawCanvas: function( context, drawingHandler, scale, translate ) {
+    drawCanvas: function( context, drawingHandler, scale, translate, shouldRoundPositionAndSize ) {
 
         var position = this.position.times($.pixelDensityRatio),
             size     = this.size.times($.pixelDensityRatio),
@@ -363,6 +366,14 @@ $.Tile.prototype = {
         //an image with an alpha channel, then the only way
         //to avoid seeing the tile underneath is to clear the rectangle
         if (context.globalAlpha === 1 && this._hasTransparencyChannel()) {
+            if (shouldRoundPositionAndSize) {
+                // Round to the nearest whole pixel so we don't get seams from overlap.
+                position.x = Math.round(position.x);
+                position.y = Math.round(position.y);
+                size.x = Math.round(size.x);
+                size.y = Math.round(size.y);
+            }
+
             //clearing only the inside of the rectangle occupied
             //by the png prevents edge flikering
             context.clearRect(

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2214,11 +2214,9 @@ function drawTiles( tiledImage, lastDrawn ) {
         shouldRoundPositionAndSize = !isAnimating;
     }
 
-    tiledImage._drawer._shouldRoundPositionAndSize = shouldRoundPositionAndSize;
-
     for (var i = lastDrawn.length - 1; i >= 0; i--) {
         tile = lastDrawn[ i ];
-        tiledImage._drawer.drawTile( tile, tiledImage._drawingHandler, useSketch, sketchScale, sketchTranslate );
+        tiledImage._drawer.drawTile( tile, tiledImage._drawingHandler, useSketch, sketchScale, sketchTranslate, shouldRoundPositionAndSize );
         tile.beingDrawn = true;
 
         if( tiledImage.viewer ){

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1963,42 +1963,6 @@ var DEFAULT_SUBPIXEL_ROUNDING_RULE = $.SUBPIXEL_ROUNDING_OCCURRENCES.NEVER;
 /**
  * @private
  * @inner
- * Determines whether the subpixel rounding enum value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS} or not.
- *
- * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
- * @returns {Boolean} True if input value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS}, false otherwise.
- */
-function isSubPixelRoundingRuleAlways(value) {
-    return value === $.SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS;
-}
-
-/**
- * @private
- * @inner
- * Determines whether the subpixel rounding enum value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST} or not.
- *
- * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
- * @returns {Boolean} True if input value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST}, false otherwise.
- */
- function isSubPixelRoundingRuleOnlyAtRest(value) {
-    return value === $.SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST;
-}
-
-/**
- * @private
- * @inner
- * Determines whether the subpixel rounding enum value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER} or not.
- *
- * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
- * @returns {Boolean} True if input value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER}, false otherwise.
- */
- function isSubPixelRoundingRuleNever(value) {
-    return value === DEFAULT_SUBPIXEL_ROUNDING_RULE;
-}
-
-/**
- * @private
- * @inner
  * Checks whether the input value is an invalid subpixel rounding enum value.
  *
  * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
@@ -2006,9 +1970,9 @@ function isSubPixelRoundingRuleAlways(value) {
  * {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS}, {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST} or {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER} value.
  */
  function isSubPixelRoundingRuleUnknown(value) {
-    return !isSubPixelRoundingRuleAlways(value) &&
-        !isSubPixelRoundingRuleOnlyAtRest(value) &&
-        !isSubPixelRoundingRuleNever(value);
+    return value !== $.SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS &&
+        value !== $.SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST &&
+        value !== $.SUBPIXEL_ROUNDING_OCCURRENCES.NEVER;
 }
 
 /**
@@ -2207,13 +2171,11 @@ function drawTiles( tiledImage, lastDrawn ) {
 
     var shouldRoundPositionAndSize = false;
 
-    if (isSubPixelRoundingRuleAlways(subPixelRoundingRule)) {
+    if (subPixelRoundingRule === $.SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS) {
         shouldRoundPositionAndSize = true;
-    } else if (isSubPixelRoundingRuleOnlyAtRest(subPixelRoundingRule)) {
-        shouldRoundPositionAndSize = tiledImage.viewer && (
-            tiledImage.viewer.getAnimationState() === $.ANIMATION_STATES.ANIMATION_FINISHED ||
-            tiledImage.viewer.getAnimationState() === $.ANIMATION_STATES.AT_REST // Testing AT_REST here is for the very first render after loading.
-        );
+    } else if (subPixelRoundingRule === $.SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST) {
+        var isAnimating = tiledImage.viewer && tiledImage.viewer.isAnimating();
+        shouldRoundPositionAndSize = !isAnimating;
     }
 
     for (var i = lastDrawn.length - 1; i >= 0; i--) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2210,8 +2210,10 @@ function drawTiles( tiledImage, lastDrawn ) {
     if (isSubPixelRoundingRuleAlways(subPixelRoundingRule)) {
         shouldRoundPositionAndSize = true;
     } else if (isSubPixelRoundingRuleOnlyAtRest(subPixelRoundingRule)) {
-        var isAnimating = tiledImage.viewer && tiledImage.viewer.isAnimating();
-        shouldRoundPositionAndSize = !isAnimating;
+        shouldRoundPositionAndSize = tiledImage.viewer && (
+            tiledImage.viewer.getAnimationState() === $.ANIMATION_STATES.ANIMATION_FINISHED ||
+            tiledImage.viewer.getAnimationState() === $.ANIMATION_STATES.AT_REST // Testing AT_REST here is for the very first render after loading.
+        );
     }
 
     for (var i = lastDrawn.length - 1; i >= 0; i--) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -160,25 +160,25 @@ $.TiledImage = function( options ) {
         _hasOpaqueTile: false,  // Do we have even one fully opaque tile?
         _tilesLoading:  0,     // The number of pending tile requests.
         //configurable settings
-        springStiffness:        $.DEFAULT_SETTINGS.springStiffness,
-        animationTime:          $.DEFAULT_SETTINGS.animationTime,
-        minZoomImageRatio:      $.DEFAULT_SETTINGS.minZoomImageRatio,
-        wrapHorizontal:         $.DEFAULT_SETTINGS.wrapHorizontal,
-        wrapVertical:           $.DEFAULT_SETTINGS.wrapVertical,
-        immediateRender:        $.DEFAULT_SETTINGS.immediateRender,
-        blendTime:              $.DEFAULT_SETTINGS.blendTime,
-        alwaysBlend:            $.DEFAULT_SETTINGS.alwaysBlend,
-        minPixelRatio:          $.DEFAULT_SETTINGS.minPixelRatio,
-        smoothTileEdgesMinZoom: $.DEFAULT_SETTINGS.smoothTileEdgesMinZoom,
-        iOSDevice:              $.DEFAULT_SETTINGS.iOSDevice,
-        debugMode:              $.DEFAULT_SETTINGS.debugMode,
-        crossOriginPolicy:      $.DEFAULT_SETTINGS.crossOriginPolicy,
-        ajaxWithCredentials:    $.DEFAULT_SETTINGS.ajaxWithCredentials,
-        placeholderFillStyle:   $.DEFAULT_SETTINGS.placeholderFillStyle,
-        opacity:                $.DEFAULT_SETTINGS.opacity,
-        preload:                $.DEFAULT_SETTINGS.preload,
-        compositeOperation:     $.DEFAULT_SETTINGS.compositeOperation,
-        subPixelRounding:       $.DEFAULT_SETTINGS.subPixelRounding
+        springStiffness:                   $.DEFAULT_SETTINGS.springStiffness,
+        animationTime:                     $.DEFAULT_SETTINGS.animationTime,
+        minZoomImageRatio:                 $.DEFAULT_SETTINGS.minZoomImageRatio,
+        wrapHorizontal:                    $.DEFAULT_SETTINGS.wrapHorizontal,
+        wrapVertical:                      $.DEFAULT_SETTINGS.wrapVertical,
+        immediateRender:                   $.DEFAULT_SETTINGS.immediateRender,
+        blendTime:                         $.DEFAULT_SETTINGS.blendTime,
+        alwaysBlend:                       $.DEFAULT_SETTINGS.alwaysBlend,
+        minPixelRatio:                     $.DEFAULT_SETTINGS.minPixelRatio,
+        smoothTileEdgesMinZoom:            $.DEFAULT_SETTINGS.smoothTileEdgesMinZoom,
+        iOSDevice:                         $.DEFAULT_SETTINGS.iOSDevice,
+        debugMode:                         $.DEFAULT_SETTINGS.debugMode,
+        crossOriginPolicy:                 $.DEFAULT_SETTINGS.crossOriginPolicy,
+        ajaxWithCredentials:               $.DEFAULT_SETTINGS.ajaxWithCredentials,
+        placeholderFillStyle:              $.DEFAULT_SETTINGS.placeholderFillStyle,
+        opacity:                           $.DEFAULT_SETTINGS.opacity,
+        preload:                           $.DEFAULT_SETTINGS.preload,
+        compositeOperation:                $.DEFAULT_SETTINGS.compositeOperation,
+        subPixelRoundingForTransparency:   $.DEFAULT_SETTINGS.subPixelRoundingForTransparency
     }, options );
 
     this._preload = this.preload;
@@ -1958,39 +1958,39 @@ function compareTiles( previousBest, tile ) {
  * Defines the value for subpixel rounding to fallback to in case of missing or
  * invalid value.
  */
-var DEFAULT_SUBPIXEL_ROUNDING_RULE = 'NEVER';
+var DEFAULT_SUBPIXEL_ROUNDING_RULE = $.SUBPIXEL_ROUNDING_OCCURRENCES.NEVER;
 
 /**
  * @private
  * @inner
- * Determines whether the subpixel rounding enum value is 'ALWAYS' or not.
+ * Determines whether the subpixel rounding enum value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS} or not.
  *
- * @param {string} value - The subpixel rounding enum value to check, case sensitive.
- * @returns {Boolean} True if input value is 'ALWAYS', false otherwise.
+ * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
+ * @returns {Boolean} True if input value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS}, false otherwise.
  */
 function isSubPixelRoundingRuleAlways(value) {
-    return value === 'ALWAYS';
+    return value === $.SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS;
 }
 
 /**
  * @private
  * @inner
- * Determines whether the subpixel rounding enum value is 'ONLY_AT_REST' or not.
+ * Determines whether the subpixel rounding enum value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST} or not.
  *
- * @param {string} value - The subpixel rounding enum value to check, case sensitive.
- * @returns {Boolean} True if input value is 'ONLY_AT_REST', false otherwise.
+ * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
+ * @returns {Boolean} True if input value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST}, false otherwise.
  */
  function isSubPixelRoundingRuleOnlyAtRest(value) {
-    return value === 'ONLY_AT_REST';
+    return value === $.SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST;
 }
 
 /**
  * @private
  * @inner
- * Determines whether the subpixel rounding enum value is 'NEVER' or not.
+ * Determines whether the subpixel rounding enum value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER} or not.
  *
- * @param {string} value - The subpixel rounding enum value to check, case sensitive.
- * @returns {Boolean} True if input value is 'NEVER', false otherwise.
+ * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
+ * @returns {Boolean} True if input value is {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER}, false otherwise.
  */
  function isSubPixelRoundingRuleNever(value) {
     return value === DEFAULT_SUBPIXEL_ROUNDING_RULE;
@@ -2001,12 +2001,9 @@ function isSubPixelRoundingRuleAlways(value) {
  * @inner
  * Checks whether the input value is an invalid subpixel rounding enum value.
  *
- * @param {string} value - The subpixel rounding enum value to check, case sensitive.
+ * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to check.
  * @returns {Boolean} Returns true if the input value is none of the expected
- * 'ALWAYS', 'ONLY_AT_REST' or 'NEVER' value.
- * Note that if passed a valid value but with the incorrect casing, the return
- * value will be true. If input is 'always', then true is returned, indicating
- * it is an unknown value.
+ * {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS}, {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST} or {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER} value.
  */
  function isSubPixelRoundingRuleUnknown(value) {
     return !isSubPixelRoundingRuleAlways(value) &&
@@ -2018,13 +2015,10 @@ function isSubPixelRoundingRuleAlways(value) {
  * @private
  * @inner
  * Ensures the returned value is always a valid subpixel rounding enum value,
- * defaulting to 'NEVER' if input is missing or invalid.
+ * defaulting to {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER} if input is missing or invalid.
  *
- * @param {string} value - The subpixel rounding enum value to normalize, case sensitive.
- * @returns {string} Returns a valid subpixel rounding enum value.
- * Note that if passed a valid value but with the incorrect casing, the return
- * value will be the default 'NEVER'. If input is 'always', then 'NEVER' is
- * returned.
+ * @param {SUBPIXEL_ROUNDING_OCCURRENCES} value - The subpixel rounding enum value to normalize.
+ * @returns {SUBPIXEL_ROUNDING_OCCURRENCES} Returns a valid subpixel rounding enum value.
  */
  function normalizeSubPixelRoundingRule(value) {
     if (isSubPixelRoundingRuleUnknown(value)) {
@@ -2039,19 +2033,23 @@ function isSubPixelRoundingRuleAlways(value) {
  * Ensures the returned value is always a valid subpixel rounding enum value,
  * defaulting to 'NEVER' if input is missing or invalid.
  *
- * @param {Object} subPixelRoundingRules - A subpixel rounding enum values dictionary [number] --> string.
- * @returns {string} Returns the determined subpixel rounding enum value for the
+ * @param {Object} subPixelRoundingRules - A subpixel rounding enum values dictionary [{@link BROWSERS}] --> {@link SUBPIXEL_ROUNDING_OCCURRENCES}.
+ * @returns {SUBPIXEL_ROUNDING_OCCURRENCES} Returns the determined subpixel rounding enum value for the
  * current browser.
  */
 function determineSubPixelRoundingRule(subPixelRoundingRules) {
+    if (typeof subPixelRoundingRules === 'number') {
+        return normalizeSubPixelRoundingRule(subPixelRoundingRules);
+    }
+
     if (!subPixelRoundingRules || !$.Browser) {
         return DEFAULT_SUBPIXEL_ROUNDING_RULE;
     }
 
     var subPixelRoundingRule = subPixelRoundingRules[$.Browser.vendor];
 
-    if (!subPixelRoundingRule || isSubPixelRoundingRuleUnknown(subPixelRoundingRule)) {
-        subPixelRoundingRule = subPixelRoundingRules[''];
+    if (isSubPixelRoundingRuleUnknown(subPixelRoundingRule)) {
+        subPixelRoundingRule = subPixelRoundingRules['*'];
     }
 
     return normalizeSubPixelRoundingRule(subPixelRoundingRule);
@@ -2205,7 +2203,7 @@ function drawTiles( tiledImage, lastDrawn ) {
         tiledImage._drawer.drawRectangle(placeholderRect, fillStyle, useSketch);
     }
 
-    var subPixelRoundingRule = determineSubPixelRoundingRule(tiledImage.subPixelRounding);
+    var subPixelRoundingRule = determineSubPixelRoundingRule(tiledImage.subPixelRoundingForTransparency);
 
     var shouldRoundPositionAndSize = false;
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -203,6 +203,7 @@ $.Viewer = function( options ) {
         fsBoundsDelta:     new $.Point( 1, 1 ),
         prevContainerSize: null,
         animating:         false,
+        animationState:    $.ANIMATION_STATES.AT_REST,
         forceRedraw:       false,
         mouseInside:       false,
         group:             null,
@@ -713,6 +714,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         }
 
         THIS[ this.hash ].animating = false;
+        THIS[ this.hash ].animationState = $.ANIMATION_STATES.AT_REST;
+
         this.world.removeAll();
         this.imageLoader.clear();
 
@@ -2353,6 +2356,10 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     isAnimating: function () {
         return THIS[ this.hash ].animating;
     },
+
+    getAnimationState: function () {
+        return THIS[ this.hash ].animationState;
+    },
 });
 
 
@@ -3502,6 +3509,8 @@ function updateOnce( viewer ) {
     var currentAnimating = THIS[ viewer.hash ].animating;
 
     if ( !currentAnimating && animated ) {
+        THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.ANIMATION_STARTED;
+
         /**
          * Raised when any spring animation starts (zoom, pan, etc.).
          *
@@ -3515,7 +3524,18 @@ function updateOnce( viewer ) {
         abortControlsAutoHide( viewer );
     }
 
-    if ( animated || THIS[ viewer.hash ].forceRedraw || viewer.world.needsDraw() ) {
+    var lastAnimation = false;
+
+    if (currentAnimating) {
+        if (animated) {
+            THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.ANIMATING;
+        } else {
+            THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.ANIMATION_FINISHED;
+            lastAnimation = true;
+        }
+    }
+
+    if ( animated || lastAnimation || THIS[ viewer.hash ].forceRedraw || viewer.world.needsDraw() ) {
         drawWorld( viewer );
         viewer._drawOverlays();
         if( viewer.navigator ){
@@ -3540,6 +3560,8 @@ function updateOnce( viewer ) {
     }
 
     if ( currentAnimating && !animated ) {
+        THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.AT_REST;
+
         /**
          * Raised when any spring animation ends (zoom, pan, etc.).
          *
@@ -3557,13 +3579,6 @@ function updateOnce( viewer ) {
     }
 
     THIS[ viewer.hash ].animating = animated;
-
-    // Intentionally use currentAnimating as the value at the current frame,
-    // regardless of THIS[ viewer.hash ].animating being updated.
-    if (currentAnimating && !animated) {
-        // Ensure a draw occurs once animation is over.
-        drawWorld( viewer );
-    }
 
     //viewer.profiler.endUpdate();
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1495,7 +1495,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     loadTilesWithAjax: queueItem.options.loadTilesWithAjax,
                     ajaxHeaders: queueItem.options.ajaxHeaders,
                     debugMode: _this.debugMode,
-                    subPixelRounding: _this.subPixelRounding
+                    subPixelRoundingForTransparency: _this.subPixelRoundingForTransparency
                 });
 
                 if (_this.collectionMode) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1494,7 +1494,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     ajaxWithCredentials: queueItem.options.ajaxWithCredentials,
                     loadTilesWithAjax: queueItem.options.loadTilesWithAjax,
                     ajaxHeaders: queueItem.options.ajaxHeaders,
-                    debugMode: _this.debugMode
+                    debugMode: _this.debugMode,
+                    subPixelRounding: _this.subPixelRounding
                 });
 
                 if (_this.collectionMode) {
@@ -2347,6 +2348,10 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             next = 0;
         }
         this.goToPage( next );
+    },
+
+    isAnimating: function () {
+        return THIS[ this.hash ].animating;
     },
 });
 
@@ -3494,7 +3499,9 @@ function updateOnce( viewer ) {
         animated = viewer.referenceStrip.update( viewer.viewport ) || animated;
     }
 
-    if ( !THIS[ viewer.hash ].animating && animated ) {
+    var currentAnimating = THIS[ viewer.hash ].animating;
+
+    if ( !currentAnimating && animated ) {
         /**
          * Raised when any spring animation starts (zoom, pan, etc.).
          *
@@ -3532,7 +3539,7 @@ function updateOnce( viewer ) {
         }
     }
 
-    if ( THIS[ viewer.hash ].animating && !animated ) {
+    if ( currentAnimating && !animated ) {
         /**
          * Raised when any spring animation ends (zoom, pan, etc.).
          *
@@ -3550,6 +3557,13 @@ function updateOnce( viewer ) {
     }
 
     THIS[ viewer.hash ].animating = animated;
+
+    // Intentionally use currentAnimating as the value at the current frame,
+    // regardless of THIS[ viewer.hash ].animating being updated.
+    if (currentAnimating && !animated) {
+        // Ensure a draw occurs once animation is over.
+        drawWorld( viewer );
+    }
 
     //viewer.profiler.endUpdate();
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -203,7 +203,6 @@ $.Viewer = function( options ) {
         fsBoundsDelta:     new $.Point( 1, 1 ),
         prevContainerSize: null,
         animating:         false,
-        animationState:    $.ANIMATION_STATES.AT_REST,
         forceRedraw:       false,
         mouseInside:       false,
         group:             null,
@@ -714,7 +713,6 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         }
 
         THIS[ this.hash ].animating = false;
-        THIS[ this.hash ].animationState = $.ANIMATION_STATES.AT_REST;
 
         this.world.removeAll();
         this.imageLoader.clear();
@@ -2356,10 +2354,6 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     isAnimating: function () {
         return THIS[ this.hash ].animating;
     },
-
-    getAnimationState: function () {
-        return THIS[ this.hash ].animationState;
-    },
 });
 
 
@@ -3509,8 +3503,6 @@ function updateOnce( viewer ) {
     var currentAnimating = THIS[ viewer.hash ].animating;
 
     if ( !currentAnimating && animated ) {
-        THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.ANIMATION_STARTED;
-
         /**
          * Raised when any spring animation starts (zoom, pan, etc.).
          *
@@ -3524,18 +3516,13 @@ function updateOnce( viewer ) {
         abortControlsAutoHide( viewer );
     }
 
-    var lastAnimation = false;
+    var isAnimationFinished = currentAnimating && !animated;
 
-    if (currentAnimating) {
-        if (animated) {
-            THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.ANIMATING;
-        } else {
-            THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.ANIMATION_FINISHED;
-            lastAnimation = true;
-        }
+    if ( isAnimationFinished ) {
+        THIS[ viewer.hash ].animating = false;
     }
 
-    if ( animated || lastAnimation || THIS[ viewer.hash ].forceRedraw || viewer.world.needsDraw() ) {
+    if ( animated || isAnimationFinished || THIS[ viewer.hash ].forceRedraw || viewer.world.needsDraw() ) {
         drawWorld( viewer );
         viewer._drawOverlays();
         if( viewer.navigator ){
@@ -3559,9 +3546,7 @@ function updateOnce( viewer ) {
         }
     }
 
-    if ( currentAnimating && !animated ) {
-        THIS[ viewer.hash ].animationState = $.ANIMATION_STATES.AT_REST;
-
+    if ( isAnimationFinished ) {
         /**
          * Raised when any spring animation ends (zoom, pan, etc.).
          *


### PR DESCRIPTION
This PR is supposed to supersede #1713

Multiple things to discuss about:

1. I use the term `subPixelRounding` in the settings, whereas this is only specific to image capable of transparency, in the context of non-transparency. Whereas this would make a way too long setting property, the name I currently use is technically incorrect.
2. I added an argument to the `[Tile].drawCanvas()` function to pass whether rounding should be applied or not. Not sure if there is a better / more conventional way to do it.
3. I decided to have the default settings to be `null` instead of `{ '': 'NEVER' }` because both can be made equivalent at runtime, and it simplifies Doxygen and `DEFAULT_SETTINGS` property.
4. I put the `subPixelRounding` in the `APPEARANCE` section of the settings, let me know if you think of a better place.
5. Instead of "tracking" the animation state, I opted for exposing it, and then check it when needed.
6. I decided to set a private variable `_shouldRoundPositionAndSize ` in the `Drawer` instead of passing it to `[Drawer].drawTile()` function. This is dissymmetric with the way value is passed to `[Tile].drawCanvas()`, but it seemed to make more sense in this case as `[Drawer].drawTile()` already has a lot of arguments, and the same state is reused for multiple tiles rendered. Personally I'm not super fan of the approach I chose, so if you have a suggestion, I'm all ears. Also, maybe `tiledImage._drawer._shouldRoundPositionAndSize` should be set back to `false` at the end of the loop.
