### PR TITLE
Doc: small documentation fix

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -166,7 +166,7 @@
         /**
          * The maximum distance allowed between two pointer click events
          * to be treated as a click gesture.
-         * @member {Number} clickDistThreshold
+         * @member {Number} dblClickDistThreshold
          * @memberof OpenSeadragon.MouseTracker#
          */
         this.dblClickDistThreshold = options.dblClickDistThreshold || $.DEFAULT_SETTINGS.dblClickDistThreshold;

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -165,7 +165,7 @@
         this.dblClickTimeThreshold = options.dblClickTimeThreshold || $.DEFAULT_SETTINGS.dblClickTimeThreshold;
         /**
          * The maximum distance allowed between two pointer click events
-         * to be treated as a click gesture.
+         * to be treated as a double-click gesture.
          * @member {Number} dblClickDistThreshold
          * @memberof OpenSeadragon.MouseTracker#
          */


### PR DESCRIPTION
Fixes https://github.com/openseadragon/openseadragon/issues/2111

> This line should say `dblClickDistThreshold` - not `clickDistThreshold`:
> 
> https://github.com/openseadragon/openseadragon/blob/51e3ea7fa08f10765be25f4c1f9ba7764ee6e79b/src/mousetracker.js#L169

