### PR TITLE
fix: avoid crash when setting useCanvas to false

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2055,7 +2055,7 @@ function drawTiles( tiledImage, lastDrawn ) {
         imageZoom > tiledImage.smoothTileEdgesMinZoom &&
         !tiledImage.iOSDevice &&
         tiledImage.getRotation(true) % 360 === 0 && // TODO: support tile edge smoothing with tiled image rotation.
-        $.supportsCanvas) {
+        $.supportsCanvas && tiledImage.viewer.useCanvas) {
         // When zoomed in a lot (>100%) the tile edges are visible.
         // So we have to composite them at ~100% and scale them up together.
         // Note: Disabled on iOS devices per default as it causes a native crash


### PR DESCRIPTION
If OpenSeadragon is configured with useCanvas: false, on platforms that can support canvas, it crashes in TiledImage.draw() as the drawTiles() function assumes a canvas context exists if the device supports canvas and is not IOS. A simple fix is to check if the viewer is configured to useCanvas as well.