### PR TITLE
fix: change tileSources in demo for iiif

### DIFF
--- a/test/demo/iiif.html
+++ b/test/demo/iiif.html
@@ -25,7 +25,7 @@
         // debugMode: true,
         id: "contentDiv",
         prefixUrl: "../../build/openseadragon/images/",
-        tileSources: "http://wellcomelibrary.org/iiif-img/b11768265-0/a6801943-b8b4-4674-908c-7d5b27e70569/info.json",
+        tileSources: "../data/iiif_2_0_tiled/info.json",
         showNavigator:true
     });
 


### PR DESCRIPTION
Tile source hosted on wellcomelibrary.org is no longer available. Changed it to a local tile source