### PR TITLE
Change Tile.cacheKey strategy

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -132,7 +132,13 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, aja
      * @member {String} cacheKey
      * @memberof OpenSeadragon.Tile#
      */
+    if (cacheKey === undefined) {
+        $.console.error("Tile constructor needs 'cacheKey' variable: creation tile cache" +
+            " in Tile class is deprecated. TileSource.prototype.getTileHashKey will be used.");
+        cacheKey = $.TileSource.prototype.getTileHashKey(level, x, y, url, ajaxHeaders, postData);
+    }
     this.cacheKey = cacheKey;
+
     /**
      * Is this tile loaded?
      * @member {Boolean} loaded

--- a/src/tile.js
+++ b/src/tile.js
@@ -54,8 +54,9 @@
  *      with HTML the entire tile is always used.
  * @param {String} postData HTTP POST data  (usually but not necessarily in k=v&k2=v2... form,
  *      see TileSrouce::getPostData) or null
+ * @param {String} cacheKey key to act as a tile cache, must be unique for tiles with unique image data
  */
-$.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, ajaxHeaders, sourceBounds, postData) {
+$.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, ajaxHeaders, sourceBounds, postData, cacheKey) {
     /**
      * The zoom level this tile belongs to.
      * @member {Number} level
@@ -131,11 +132,7 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, aja
      * @member {String} cacheKey
      * @memberof OpenSeadragon.Tile#
      */
-    if (this.ajaxHeaders) {
-        this.cacheKey = this.url + "+" + JSON.stringify(this.ajaxHeaders);
-    } else {
-        this.cacheKey = this.url;
-    }
+    this.cacheKey = cacheKey;
     /**
      * Is this tile loaded?
      * @member {Boolean} loaded

--- a/src/tile.js
+++ b/src/tile.js
@@ -52,7 +52,7 @@
  * @param {OpenSeadragon.Rect} sourceBounds The portion of the tile to use as the source of the
  *      drawing operation, in pixels. Note that this only works when drawing with canvas; when drawing
  *      with HTML the entire tile is always used.
- * @param {String} postData HTTP POST data  (usually but not necessarily in k=v&k2=v2... form,
+ * @param {String} postData HTTP POST data (usually but not necessarily in k=v&k2=v2... form,
  *      see TileSrouce::getPostData) or null
  * @param {String} cacheKey key to act as a tile cache, must be unique for tiles with unique image data
  */
@@ -101,8 +101,8 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, aja
      */
     this.url     = url;
     /**
-     * Post parameters for this tile. Either it is an URL-encoded string
-     * in k1=v1&k2=v2... format or null
+     * Post parameters for this tile. For example, it can be an URL-encoded string
+     * in k1=v1&k2=v2... format, or a JSON, or a FormData instance... or null if no POST request used
      * @member {String} postData HTTP POST data (usually but not necessarily in k=v&k2=v2... form,
      *      see TileSrouce::getPostData) or null
      * @memberof OpenSeadragon.Tile#

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1,36 +1,36 @@
 /*
-* OpenSeadragon - TiledImage
-*
-* Copyright (C) 2009 CodePlex Foundation
-* Copyright (C) 2010-2013 OpenSeadragon contributors
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are
-* met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-*   this list of conditions and the following disclaimer.
-*
-* - Redistributions in binary form must reproduce the above copyright
-*   notice, this list of conditions and the following disclaimer in the
-*   documentation and/or other materials provided with the distribution.
-*
-* - Neither the name of CodePlex Foundation nor the names of its
-*   contributors may be used to endorse or promote products derived from
-*   this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-* A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
-* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-* TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * OpenSeadragon - TiledImage
+ *
+ * Copyright (C) 2009 CodePlex Foundation
+ * Copyright (C) 2010-2013 OpenSeadragon contributors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * - Neither the name of CodePlex Foundation nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 (function( $ ){
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1530,7 +1530,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                 this.loadTilesWithAjax,
                 ajaxHeaders,
                 sourceBounds,
-                post
+                post,
+                tileSource.getTileHashKey(level, xMod, yMod, url, ajaxHeaders, post)
             );
 
             if (this.getFlip()) {

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -639,7 +639,11 @@ $.TileSource.prototype = {
      *   let result = new FormData();
      *   result.append("data", myData);
      *   return result;
-
+     *
+     * IMPORTANT: in case you move all the logic on image fetching
+     * to post data, you must re-define 'getTileHashKey(...)' to
+     * stay unique for different tile images.
+     *
      * @param level
      * @param x
      * @param y
@@ -664,6 +668,29 @@ $.TileSource.prototype = {
      */
     getTileAjaxHeaders: function( level, x, y ) {
         return {};
+    },
+
+    /**
+     * Most tiles are cached because their 'context2D' property is null (otherwise no caching occurs).
+     * Then, their cache is uniquely determined by this key: this key should be different if images
+     * are different! Note: default behaviour does not take into account post data.
+     *
+     * A tile can have either context2D defined (TileSource.prototype.getContext2D)
+     * or it's context2D is set manually. In those cases cache is not used and this function
+     * is irrelevant.
+     * @param level tile level it was fetched with
+     * @param x x-coordinate in the pyramid level
+     * @param y y-coordinate in the pyramid level
+     * @param url the tile was fetched with
+     * @param ajaxHeaders the tile was fetched with
+     * @param post data the tile was fetched with
+     */
+    getTileHashKey: function(level, x, y, url, ajaxHeaders, post) {
+        if (ajaxHeaders) {
+            return url + "+" + JSON.stringify(ajaxHeaders);
+        } else {
+            return url;
+        }
     },
 
     /**

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -671,21 +671,19 @@ $.TileSource.prototype = {
     },
 
     /**
-     * Most tiles are cached because their 'context2D' property is null (otherwise no caching occurs).
-     * Then, their cache is uniquely determined by this key: this key should be different if images
-     * are different! Note: default behaviour does not take into account post data.
-     *
      * A tile can have either context2D defined (TileSource.prototype.getContext2D)
-     * or it's context2D is set manually. In those cases cache is not used and this function
-     * is irrelevant.
+     * or its context2D is set manually. In those cases cache is not used and this function
+     * is irrelevant. Otherwise, the tile cache object is uniquely determined by this key:
+     * keys should be different if images are different!
+     * Note: default behaviour does not take into account post data.
      * @param level tile level it was fetched with
      * @param x x-coordinate in the pyramid level
      * @param y y-coordinate in the pyramid level
      * @param url the tile was fetched with
      * @param ajaxHeaders the tile was fetched with
-     * @param post data the tile was fetched with
+     * @param postData data the tile was fetched with
      */
-    getTileHashKey: function(level, x, y, url, ajaxHeaders, post) {
+    getTileHashKey: function(level, x, y, url, ajaxHeaders, postData) {
         if (ajaxHeaders) {
             return url + "+" + JSON.stringify(ajaxHeaders);
         } else {

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -644,9 +644,9 @@ $.TileSource.prototype = {
      * to post data, you must re-define 'getTileHashKey(...)' to
      * stay unique for different tile images.
      *
-     * @param level
-     * @param x
-     * @param y
+     * @param {Number} level
+     * @param {Number} x
+     * @param {Number} y
      * @return {* || null} post data to send with tile configuration request
      */
     getTilePostData: function( level, x, y ) {
@@ -671,17 +671,19 @@ $.TileSource.prototype = {
     },
 
     /**
-     * A tile can have either context2D defined (TileSource.prototype.getContext2D)
-     * or its context2D is set manually. In those cases cache is not used and this function
-     * is irrelevant. Otherwise, the tile cache object is uniquely determined by this key:
-     * keys should be different if images are different!
+     * The tile cache object is uniquely determined by this key and used to lookup
+     * the image data in cache: keys should be different if images are different.
+     *
+     * In case a tile has context2D property defined (TileSource.prototype.getContext2D)
+     * or its context2D is set manually; the cache is not used and this function
+     * is irrelevant.
      * Note: default behaviour does not take into account post data.
-     * @param level tile level it was fetched with
-     * @param x x-coordinate in the pyramid level
-     * @param y y-coordinate in the pyramid level
-     * @param url the tile was fetched with
-     * @param ajaxHeaders the tile was fetched with
-     * @param postData data the tile was fetched with
+     * @param {Number} level tile level it was fetched with
+     * @param {Number} x x-coordinate in the pyramid level
+     * @param {Number} y y-coordinate in the pyramid level
+     * @param {String} url the tile was fetched with
+     * @param {Object} ajaxHeaders the tile was fetched with
+     * @param {*} postData data the tile was fetched with (type depends on getTilePostData(..) return type)
      */
     getTileHashKey: function(level, x, y, url, ajaxHeaders, postData) {
         if (ajaxHeaders) {

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -425,7 +425,7 @@
                 clickCount:            2,
                 dblClickCount:         1,
                 dragCount:             0,
-                dragEndCount:          2, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
+                dragEndCount:          0, // drag-end event no longer fired if pointer didn't move (#2064)
                 insideElementPressed:  true,
                 insideElementReleased: true,
                 contacts:              0,
@@ -453,7 +453,7 @@
                 clickCount:            1,
                 dblClickCount:         0,
                 dragCount:             0,
-                dragEndCount:          1, // v2.5.0+ drag-end event now fired even if pointer didn't move (#1459)
+                dragEndCount:          0, // drag-end event no longer fired if pointer didn't move (#2064)
                 insideElementPressed:  true,
                 insideElementReleased: true,
                 contacts:              0,


### PR DESCRIPTION
Cache key generation is not always easily derive-able, move the key factory function to the `TileSource`.