### PR TITLE
Delegate error printing to the ajax caller.

### DIFF
--- a/src/eventsource.js
+++ b/src/eventsource.js
@@ -122,6 +122,18 @@ $.EventSource.prototype = {
         }
     },
 
+    /**
+     * Get the amount of handlers registered for a given event.
+     * @param {String} eventName - Name of event to inspect.
+     * @return {number} amount of events
+     */
+    numberOfHandlers: function (eventName) {
+        var events = this.events[ eventName ];
+        if ( !events ) {
+            return 0;
+        }
+        return events.length;
+    },
 
     /**
      * Remove all event handlers for a given event type. If no type is given all

--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -130,7 +130,7 @@ ImageJob.prototype = {
                     self.image.src = url;
                 },
                 error: function(request) {
-                    self.errorMsg = "Image load aborted - XHR error";
+                    self.errorMsg = "Image load aborted - XHR error: Ajax returned " + request.status;
                     self.finish(false);
                 }
             });

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2364,10 +2364,10 @@ function OpenSeadragon( options ){
                           protocol !== "https:" )) {
                         onSuccess( request );
                     } else {
-                        $.console.error( "AJAX request returned %d: %s", request.status, url );
-
                         if ( $.isFunction( onError ) ) {
                             onError( request );
+                        } else {
+                            $.console.error( "AJAX request returned %d: %s", request.status, url );
                         }
                     }
                 }

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -529,7 +529,7 @@ $.TileSource.prototype = {
                         exception rather than the second one raised when we try to access xhr.status
                      */
                     try {
-                        msg = "HTTP " + xhr.status + " attempting to load TileSource";
+                        msg = "HTTP " + xhr.status + " attempting to load TileSource: " + url;
                     } catch ( e ) {
                         var formattedExc;
                         if ( typeof ( exc ) === "undefined" || !exc.toString ) {
@@ -538,8 +538,10 @@ $.TileSource.prototype = {
                             formattedExc = exc.toString();
                         }
 
-                        msg = formattedExc + " attempting to load TileSource";
+                        msg = formattedExc + " attempting to load TileSource: " + url;
                     }
+
+                    $.console.error(msg);
 
                     /***
                      * Raised when an error occurs loading a TileSource.

--- a/test/modules/basic.js
+++ b/test/modules/basic.js
@@ -58,8 +58,8 @@
 
             assert.equal($(".openseadragon-message").length, 1, "Open failures should display a message");
 
-            assert.ok(testLog.error.contains('["AJAX request returned %d: %s",404,"/test/data/not-a-real-file"]'),
-               "AJAX failures should be logged to the console");
+            assert.ok(testLog.error.contains('["HTTP 404 attempting to load TileSource: /test/data/not-a-real-file"]'),
+                "'open-failed' fired after AJAX error handler prints error to the console.'");
 
             done();
         });

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -1152,6 +1152,36 @@
     });
 
     // ----------
+    QUnit.test( 'Viewer: event count test with \'tile-drawing\'', function (assert) {
+        var done = assert.async();
+        assert.ok(viewer.numberOfHandlers('tile-drawing') === 0,
+            "'tile-drawing' event is empty by default.");
+
+        var tileDrawing = function ( event ) {
+            viewer.removeHandler( 'tile-drawing', tileDrawing );
+            assert.ok(viewer.numberOfHandlers('tile-drawing') === 0,
+                "'tile-drawing' deleted: count is 0.");
+            viewer.close();
+            done();
+        };
+
+        var tileDrawingDummy = function ( event ) {};
+
+        viewer.addHandler( 'tile-drawing', tileDrawing );
+        assert.ok(viewer.numberOfHandlers('tile-drawing') === 1,
+            "'tile-drawing' event set to 1.");
+
+        viewer.addHandler( 'tile-drawing', tileDrawingDummy );
+        assert.ok(viewer.numberOfHandlers('tile-drawing') === 2,
+            "'tile-drawing' event set to 2.");
+
+        viewer.removeHandler( 'tile-drawing', tileDrawingDummy );
+        assert.ok(viewer.numberOfHandlers('tile-drawing') === 1,
+            "'tile-drawing' deleted once: count is 1.");
+
+        viewer.open( '/test/data/testpattern.dzi' );
+    } );
+
     QUnit.test( 'Viewer: tile-drawing event', function (assert) {
         var done = assert.async();
         var tileDrawing = function ( event ) {


### PR DESCRIPTION
By default, OSD prints an error if ajax call results in an error response code (other than `2xx`). This is a bit problematic since one can use custom error codes to route the behaviour and the console gets bloated by unnecessary error messages (I am having a scenario where tiles are expected to be very unpredictable, and the system can automatically detect that and remove the tiled image: having hundreds identical errors in the console does not help much). Other problem is that each error response generates _two_ error messages, following the _how not to_ scenario:
```
try:
    raise Error("Test error")
except e:
    print(str(e))  # do not print error messages if the routine error handling happens elsewhere
    raise e
```
so the ajax function should print an error only if no error handler is registered, otherwise, it should be the handler's responsibility to do so. Following the future PR I am planning, the user will have also the ability to re-define how tiles are downloaded and thus control the errors completely. 