### PR TITLE
added warning for deprecated method buttons()

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -507,6 +507,12 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         return this.open( tileSource );
     },
 
+    //deprecated
+    get buttons () {
+        $.console.warn('Viewer.buttons is deprecated; Please use Viewer.buttonGroup');
+        return this.buttonGroup;
+    },
+
     /**
      * Open tiled images into the viewer, closing any others.
      * To get the TiledImage instance created by open, add an event listener for


### PR DESCRIPTION
-- Issue #2146 --
Added a warning for the use of deprecated Viewer.buttons method which is now replaced by Viewer.buttonGroup. First time contributing and I'm not sure if this is the right place to put the method in the Viewer prototype so any feedback would be very helpful.