### PR TITLE
Fix wrong center point on pinch zoom

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3289,9 +3289,6 @@ function onCanvasPinch( event ) {
         if ( gestureSettings.pinchToZoom &&
                     (!canvasPinchEventArgs.preventDefaultPanAction || !canvasPinchEventArgs.preventDefaultZoomAction) ) {
             centerPt = this.viewport.pointFromPixel( event.center, true );
-            if ( !canvasPinchEventArgs.preventDefaultZoomAction ) {
-                this.viewport.zoomBy( event.distance / event.lastDistance, centerPt, true );
-            }
             if ( gestureSettings.zoomToRefPoint && !canvasPinchEventArgs.preventDefaultPanAction ) {
                 lastCenterPt = this.viewport.pointFromPixel( event.lastCenter, true );
                 panByPt = lastCenterPt.minus( centerPt );
@@ -3302,6 +3299,9 @@ function onCanvasPinch( event ) {
                     panByPt.y = 0;
                 }
                 this.viewport.panBy(panByPt, true);
+            }
+            if ( !canvasPinchEventArgs.preventDefaultZoomAction ) {
+                this.viewport.zoomBy( event.distance / event.lastDistance, centerPt, true );
             }
             this.viewport.applyConstraints();
         }


### PR DESCRIPTION
When doing pinch to zoom, we need to pan first and then zoom, so that the center point is correct (i.e. the center of the two touch positions).
Otherwise, the pan is computed on the unzoomed coordinates, giving an impression of zooming toward the center.
See issue https://github.com/openseadragon/openseadragon/issues/2141