### PR TITLE
apply only zoom constraint by default for scroll events

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3371,7 +3371,7 @@ function onCanvasScroll( event ) {
                     factor,
                     gestureSettings.zoomToRefPoint ? this.viewport.pointFromPixel( event.position, true ) : null
                 );
-                this.viewport.applyZoomConstraints();
+                this.viewport.applyConstraints();
             }
         }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3371,7 +3371,7 @@ function onCanvasScroll( event ) {
                     factor,
                     gestureSettings.zoomToRefPoint ? this.viewport.pointFromPixel( event.position, true ) : null
                 );
-                this.viewport.applyConstraints();
+                this.viewport.applyZoomConstraints();
             }
         }
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -506,7 +506,7 @@ $.Viewport.prototype = {
             var leftDx = this._contentBoundsNoRotate.x - boundsRight + horizontalThreshold;
             var rightDx = contentRight - newBounds.x - horizontalThreshold;
 
-            if (horizontalThreshold > this._contentBoundsNoRotate.width) {
+            if (horizontalThreshold > this._contentBoundsNoRotate.width && horizontalThreshold <= 1) {
                 newBounds.x += (leftDx + rightDx) / 2;
             } else if (rightDx < 0) {
                 newBounds.x += rightDx;
@@ -524,7 +524,7 @@ $.Viewport.prototype = {
             var topDy = this._contentBoundsNoRotate.y - boundsBottom + verticalThreshold;
             var bottomDy = contentBottom - newBounds.y - verticalThreshold;
 
-            if (verticalThreshold > this._contentBoundsNoRotate.height) {
+            if (verticalThreshold > this._contentBoundsNoRotate.height && verticalThreshold <= 1) {
                 newBounds.y += (topDy + bottomDy) / 2;
             } else if (bottomDy < 0) {
                 newBounds.y += bottomDy;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -592,6 +592,25 @@ $.Viewport.prototype = {
     },
 
     /**
+     * Enforces the minZoom, maxZoom constraints by zooming to the closest acceptable zoom.
+     * @function
+     * @param {Boolean} [immediately=false]
+     * @return {OpenSeadragon.Viewport} Chainable.
+     * @fires OpenSeadragon.Viewer.event:constrain
+     */
+    applyZoomConstraints: function(immediately) {
+        var actualZoom = this.getZoom();
+        var constrainedZoom = this._applyZoomConstraints(actualZoom);
+
+        if (actualZoom !== constrainedZoom) {
+            this.zoomTo(constrainedZoom, this.zoomPoint, immediately);
+        }
+
+        this._raiseConstraintsEvent(immediately);
+        return this;
+    },
+
+    /**
      * Equivalent to {@link OpenSeadragon.Viewport#applyConstraints}
      * @function
      * @param {Boolean} [immediately=false]

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -592,25 +592,6 @@ $.Viewport.prototype = {
     },
 
     /**
-     * Enforces the minZoom, maxZoom constraints by zooming to the closest acceptable zoom.
-     * @function
-     * @param {Boolean} [immediately=false]
-     * @return {OpenSeadragon.Viewport} Chainable.
-     * @fires OpenSeadragon.Viewer.event:constrain
-     */
-    applyZoomConstraints: function(immediately) {
-        var actualZoom = this.getZoom();
-        var constrainedZoom = this._applyZoomConstraints(actualZoom);
-
-        if (actualZoom !== constrainedZoom) {
-            this.zoomTo(constrainedZoom, this.zoomPoint, immediately);
-        }
-
-        this._raiseConstraintsEvent(immediately);
-        return this;
-    },
-
-    /**
      * Equivalent to {@link OpenSeadragon.Viewport#applyConstraints}
      * @function
      * @param {Boolean} [immediately=false]

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -500,36 +500,62 @@ $.Viewport.prototype = {
         if (this.wrapHorizontal) {
             //do nothing
         } else {
-            var horizontalThreshold = this.visibilityRatio * newBounds.width;
             var boundsRight = newBounds.x + newBounds.width;
             var contentRight = this._contentBoundsNoRotate.x + this._contentBoundsNoRotate.width;
-            var leftDx = this._contentBoundsNoRotate.x - boundsRight + horizontalThreshold;
-            var rightDx = contentRight - newBounds.x - horizontalThreshold;
 
-            if (horizontalThreshold > this._contentBoundsNoRotate.width && horizontalThreshold <= 1) {
-                newBounds.x += (leftDx + rightDx) / 2;
-            } else if (rightDx < 0) {
-                newBounds.x += rightDx;
-            } else if (leftDx > 0) {
-                newBounds.x += leftDx;
+            var horizontalThreshold, leftDx, rightDx;
+            if (newBounds.width > this._contentBoundsNoRotate.width) {
+                horizontalThreshold = this.visibilityRatio * this._contentBoundsNoRotate.width;
+                leftDx = this._contentBoundsNoRotate.x - newBounds.x + horizontalThreshold;
+                rightDx = contentRight - boundsRight - horizontalThreshold;
+
+                if (rightDx > 0) {
+                    newBounds.x += rightDx;
+                } else if (leftDx < 0) {
+                    newBounds.x += leftDx;
+                }
+            } else {
+                horizontalThreshold = this.visibilityRatio * newBounds.width;
+                leftDx = this._contentBoundsNoRotate.x - boundsRight + horizontalThreshold;
+                rightDx = contentRight - newBounds.x - horizontalThreshold;
+                if (horizontalThreshold > this._contentBoundsNoRotate.width) {
+                    newBounds.x += (leftDx + rightDx) / 2;
+                } else if (rightDx < 0) {
+                    newBounds.x += rightDx;
+                } else if (leftDx > 0) {
+                    newBounds.x += leftDx;
+                }
             }
         }
 
         if (this.wrapVertical) {
             //do nothing
         } else {
-            var verticalThreshold   = this.visibilityRatio * newBounds.height;
             var boundsBottom = newBounds.y + newBounds.height;
             var contentBottom = this._contentBoundsNoRotate.y + this._contentBoundsNoRotate.height;
-            var topDy = this._contentBoundsNoRotate.y - boundsBottom + verticalThreshold;
-            var bottomDy = contentBottom - newBounds.y - verticalThreshold;
 
-            if (verticalThreshold > this._contentBoundsNoRotate.height && verticalThreshold <= 1) {
-                newBounds.y += (topDy + bottomDy) / 2;
-            } else if (bottomDy < 0) {
-                newBounds.y += bottomDy;
-            } else if (topDy > 0) {
-                newBounds.y += topDy;
+            var verticalThreshold, topDy, bottomDy;
+            if (newBounds.height > this._contentBoundsNoRotate.height) {
+                verticalThreshold = this.visibilityRatio * this._contentBoundsNoRotate.height;
+                topDy = this._contentBoundsNoRotate.y - newBounds.y + verticalThreshold;
+                bottomDy = contentBottom - boundsBottom - verticalThreshold;
+
+                if (bottomDy > 0) {
+                    newBounds.y += bottomDy;
+                } else if (topDy < 0) {
+                    newBounds.y += topDy;
+                }
+            } else {
+                verticalThreshold = this.visibilityRatio * newBounds.height;
+                topDy = this._contentBoundsNoRotate.y - boundsBottom + verticalThreshold;
+                bottomDy = contentBottom - newBounds.y - verticalThreshold;
+                if (verticalThreshold > this._contentBoundsNoRotate.height) {
+                    newBounds.y += (topDy + bottomDy) / 2;
+                } else if (bottomDy < 0) {
+                    newBounds.y += bottomDy;
+                } else if (topDy > 0) {
+                    newBounds.y += topDy;
+                }
             }
         }
 


### PR DESCRIPTION
I've noticed sometimes when I zoom out all the away and further, the image will be recentered even if the entire image is visible, which I thought respects the visibility ratio setting. The change here is to preserved the pan location and only apply the zoom constraint. Or maybe this doesn't make sense?