### PR TITLE
Provide deafult getTileHashKey implementation for "TileSource" object if missing

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -129,7 +129,7 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, aja
     this.ajaxHeaders = ajaxHeaders;
 
     if (cacheKey === undefined) {
-        $.console.error("Tile constructor needs 'cacheKey' variable: creation tile cache" +
+        $.console.warn("Tile constructor needs 'cacheKey' variable: creation tile cache" +
             " in Tile class is deprecated. TileSource.prototype.getTileHashKey will be used.");
         cacheKey = $.TileSource.prototype.getTileHashKey(level, x, y, url, ajaxHeaders, postData);
     }

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -688,11 +688,14 @@ $.TileSource.prototype = {
      * @param {*} postData data the tile was fetched with (type depends on getTilePostData(..) return type)
      */
     getTileHashKey: function(level, x, y, url, ajaxHeaders, postData) {
-        if (ajaxHeaders) {
-            return url + "+" + JSON.stringify(ajaxHeaders);
-        } else {
-            return url;
+        function withHeaders(hash) {
+            return ajaxHeaders ? hash + "+" + JSON.stringify(ajaxHeaders) : hash;
         }
+
+        if (typeof url !== "string") {
+            return withHeaders(level + "/" + x + "_" + y);
+        }
+        return withHeaders(url);
     },
 
     /**

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1398,11 +1398,6 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             options.ajaxHeaders = $.extend({}, this.ajaxHeaders, options.ajaxHeaders);
         }
 
-        if (!$.isFunction(options.tileSource.getTileHashKey)) {
-            //silently add custom implementation
-            options.tileSource.getTileHashKey = $.TileSource.prototype.getTileHashKey;
-        }
-
         var myQueueItem = {
             options: options
         };

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1398,6 +1398,11 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             options.ajaxHeaders = $.extend({}, this.ajaxHeaders, options.ajaxHeaders);
         }
 
+        if (!$.isFunction(options.tileSource.getTileHashKey)) {
+            //silently add custom implementation
+            options.tileSource.getTileHashKey = $.TileSource.prototype.getTileHashKey;
+        }
+
         var myQueueItem = {
             options: options
         };


### PR DESCRIPTION
I thought that TileSource always inherits from OpenSeadragon.TileSource - but `getTileHashKey` was not getting there. There might be an issue with other functions (cache, etc...) that might not get carried over to every TileSource opened by the viewer. Maybe, each tileSource should be forced to inherit `OpenSeadragon.TileSource` prototype. Please let me know if so, I would change the code to inspect the inheritance and possibly extend it. For now, the bug https://github.com/openseadragon/openseadragon/issues/2188 should be fixed.
