### PR TITLE
Fix "Viewer.buttons is deprecated" warning issue

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1101,8 +1101,13 @@ function OpenSeadragon( options ){
             if ( options !== null || options !== undefined ) {
                 // Extend the base object
                 for ( name in options ) {
-                    src = target[ name ];
-                    copy = Object.getOwnPropertyDescriptor(options, name).value;
+                    var descriptor = Object.getOwnPropertyDescriptor(options, name);
+                    if (descriptor.get || descriptor.set) {
+                        Object.defineProperty(target, name, descriptor);
+                        continue;
+                    }
+
+                    copy = descriptor.value;
 
                     // Prevent never-ending loop
                     if ( target === copy ) {
@@ -1111,6 +1116,8 @@ function OpenSeadragon( options ){
 
                     // Recurse if we're merging plain objects or arrays
                     if ( deep && copy && ( OpenSeadragon.isPlainObject( copy ) || ( copyIsArray = OpenSeadragon.isArray( copy ) ) ) ) {
+                        src = target[ name ];
+
                         if ( copyIsArray ) {
                             copyIsArray = false;
                             clone = src && OpenSeadragon.isArray( src ) ? src : [];

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1102,7 +1102,7 @@ function OpenSeadragon( options ){
                 // Extend the base object
                 for ( name in options ) {
                     src = target[ name ];
-                    copy = options[ name ];
+                    copy = Object.getOwnPropertyDescriptor(options, name).value;
 
                     // Prevent never-ending loop
                     if ( target === copy ) {


### PR DESCRIPTION
Removes the erroneous `Viewer.buttons is deprecated; Please use Viewer.buttonGroup` warning. See explanation in #2193 ...