### PR TITLE
fix: links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
 # OpenSeadragon
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/openseadragon/openseadragon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://secure.travis-ci.org/openseadragon/openseadragon.png?branch=master)](http://travis-ci.org/openseadragon/openseadragon)
+
+[![Gitter][gitter-badge]][gitter]
+[![Build Status][build-badge]][build]
 
 An open-source, web-based viewer for zoomable images, implemented in pure JavaScript.
 
-See it in action and get started using it at [http://openseadragon.github.io/](http://openseadragon.github.io/).
+See it in action and get started using it at [https://openseadragon.github.io/][openseadragon].
 
 ## Stable Builds
 
-See the [GitHub releases page](https://github.com/openseadragon/openseadragon/releases).
+See the [GitHub releases page][github-releases].
 
 ## Development
 
-If you want to use OpenSeadragon in your own projects, you can find the latest stable build, API documentation, and example code at [http://openseadragon.github.io/](http://openseadragon.github.io/). If you want to modify OpenSeadragon and/or contribute to its development, read the [contributing guide](https://github.com/openseadragon/openseadragon/blob/master/CONTRIBUTING.md) for instructions.
+If you want to use OpenSeadragon in your own projects, you can find the latest stable build, API documentation, and example code at [https://openseadragon.github.io/][openseadragon]. If you want to modify OpenSeadragon and/or contribute to its development, read the [contributing guide][github-contributing] for instructions.
 
 ## License
 
-OpenSeadragon is released under the New BSD license. For details, see the [LICENSE.txt file](https://github.com/openseadragon/openseadragon/blob/master/LICENSE.txt).
+OpenSeadragon is released under the New BSD license. For details, see the [LICENSE.txt file][github-license].
+
+[openseadragon]: https://openseadragon.github.io/
+[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
+[gitter]: https://gitter.im/openseadragon/openseadragon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[build-badge]: https://secure.travis-ci.org/openseadragon/openseadragon.png?branch=master
+[build]: https://travis-ci.org/openseadragon/openseadragon
+[github-releases]: https://github.com/openseadragon/openseadragon/releases
+[github-contributing]: https://github.com/openseadragon/openseadragon/blob/master/CONTRIBUTING.md
+[github-license]: https://github.com/openseadragon/openseadragon/blob/master/LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenSeadragon
 
-[![Gitter][gitter-badge]][gitter]
-[![Build Status][build-badge]][build]
+<!-- [![Gitter][gitter-badge]][gitter]
+[![Build Status][build-badge]][build] -->
 
 An open-source, web-based viewer for zoomable images, implemented in pure JavaScript.
 
@@ -20,10 +20,10 @@ If you want to use OpenSeadragon in your own projects, you can find the latest s
 OpenSeadragon is released under the New BSD license. For details, see the [LICENSE.txt file][github-license].
 
 [openseadragon]: https://openseadragon.github.io/
-[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
+<!-- [gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
 [gitter]: https://gitter.im/openseadragon/openseadragon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [build-badge]: https://secure.travis-ci.org/openseadragon/openseadragon.png?branch=master
-[build]: https://travis-ci.org/openseadragon/openseadragon
+[build]: https://travis-ci.org/openseadragon/openseadragon -->
 [github-releases]: https://github.com/openseadragon/openseadragon/releases
 [github-contributing]: https://github.com/openseadragon/openseadragon/blob/master/CONTRIBUTING.md
 [github-license]: https://github.com/openseadragon/openseadragon/blob/master/LICENSE.txt


### PR DESCRIPTION
- update `http` to `https`
- move all links at bottom