### PR TITLE
Undefined check for obj. descriptor

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1102,12 +1102,17 @@ function OpenSeadragon( options ){
                 // Extend the base object
                 for ( name in options ) {
                     var descriptor = Object.getOwnPropertyDescriptor(options, name);
-                    if (descriptor.get || descriptor.set) {
-                        Object.defineProperty(target, name, descriptor);
-                        continue;
-                    }
 
-                    copy = descriptor.value;
+                    if (descriptor !== undefined) {
+                        if (descriptor.get || descriptor.set) {
+                            Object.defineProperty(target, name, descriptor);
+                            continue;
+                        }
+
+                        copy = descriptor.value;
+                    } else {
+                        $.console.warn('Undefined descriptior obtained for the "' + name + '" property in extended object.');
+                    }
 
                     // Prevent never-ending loop
                     if ( target === copy ) {


### PR DESCRIPTION
The new fix https://github.com/openseadragon/openseadragon/pull/2201 has broken my OpenSeadragon application. I realized we should have an 'undefined" check for [`Object.getOwnPropertyDescriptor()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor). This fixes the issue and logs a warning when it is undefined.
> A property descriptor of the given property if it exists on the object, [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) otherwise.

I get the warning for `removeItem` in my application. I'll have to look into it on my own at some point, but at least this can go in for now. Comments?
