### PR TITLE
Fixes #2219 TypeError: Cannot set property buttons of [object Object] which has only a getter when initializing OpenSeaDragon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openseadragon",
-    "version": "3.1.0",
+    "version": "3.2.0-pre",
     "description": "Provides a smooth, zoomable user interface for HTML/Javascript.",
     "keywords": [
         "image",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openseadragon",
-    "version": "3.2.0-pre",
+    "version": "3.1.0",
     "description": "Provides a smooth, zoomable user interface for HTML/Javascript.",
     "keywords": [
         "image",

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -181,9 +181,6 @@ $.Viewer = function( options ) {
         //TODO: rename navImages to uiImages
         navImages:      null,
 
-        //interface button controls
-        buttons:        null,
-
         //TODO: this is defunct so safely remove it
         profiler:       null
 


### PR DESCRIPTION
Removes adding buttons as `null` to the Viewer object, to avoid overriding a `getter` without a `setter` for the buttons deprecation warning. 

I've created an Issue [here](https://github.com/openseadragon/openseadragon/issues/2219) 