### PR TITLE
add loop for re-trying failed tiles [Take 3]

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -50,12 +50,14 @@
  * @param {Function} [options.callback] - Called once image has been downloaded.
  * @param {Function} [options.abort] - Called when this image job is aborted.
  * @param {Number} [options.timeout] - The max number of milliseconds that this image job may take to complete.
+ * @param {Number} [options.tries] - Actual number of the current try.
  */
 $.ImageJob = function(options) {
 
     $.extend(true, this, {
         timeout: $.DEFAULT_SETTINGS.timeout,
-        jobId: null
+        jobId: null,
+        tries: 0
     }, options);
 
     /**
@@ -87,6 +89,8 @@ $.ImageJob.prototype = {
      * @method
      */
     start: function() {
+        this.tries++;
+
         var self = this;
         var selfAbort = this.abort;
 
@@ -138,6 +142,7 @@ $.ImageLoader = function(options) {
         jobLimit:       $.DEFAULT_SETTINGS.imageLoaderLimit,
         timeout:        $.DEFAULT_SETTINGS.timeout,
         jobQueue:       [],
+        failedTiles:    [],
         jobsInProgress: 0
     }, options);
 
@@ -220,7 +225,8 @@ $.ImageLoader.prototype = {
 };
 
 /**
- * Cleans up ImageJob once completed.
+ * Cleans up ImageJob once completed. Restarts job after tileRetryDelay seconds if failed
+ * but max tileRetryMax times
  * @method
  * @private
  * @param loader - ImageLoader used to start job.
@@ -228,6 +234,9 @@ $.ImageLoader.prototype = {
  * @param callback - Called once cleanup is finished.
  */
 function completeJob(loader, job, callback) {
+    if (job.errorMsg != '' && job.image === null && job.tries < 1 + loader.tileRetryMax) {
+        loader.failedTiles.push(job);
+    }
     var nextJob;
 
     loader.jobsInProgress--;
@@ -237,6 +246,16 @@ function completeJob(loader, job, callback) {
         nextJob.start();
         loader.jobsInProgress++;
     }
+
+    if (loader.tileRetryMax > 0 && loader.jobQueue.length === 0) {
+        if ((!loader.jobLimit || loader.jobsInProgress < loader.jobLimit) && loader.failedTiles.length > 0) {
+             nextJob = loader.failedTiles.shift();
+             setTimeout(function () {
+                 nextJob.start();
+             }, loader.tileRetryDelay);
+             loader.jobsInProgress++;
+         }
+     }
 
     callback(job.data, job.errorMsg, job.request);
 }

--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -234,7 +234,7 @@ $.ImageLoader.prototype = {
  * @param callback - Called once cleanup is finished.
  */
 function completeJob(loader, job, callback) {
-    if (job.errorMsg != '' && job.image === null && job.tries < 1 + loader.tileRetryMax) {
+    if (job.errorMsg !== '' && job.image === null && job.tries < 1 + loader.tileRetryMax) {
         loader.failedTiles.push(job);
     }
     var nextJob;

--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -234,7 +234,7 @@ $.ImageLoader.prototype = {
  * @param callback - Called once cleanup is finished.
  */
 function completeJob(loader, job, callback) {
-    if (job.errorMsg !== '' && job.image === null && job.tries < 1 + loader.tileRetryMax) {
+    if (job.errorMsg !== '' && (job.image === null || job.image === undefined) && job.tries < 1 + loader.tileRetryMax) {
         loader.failedTiles.push(job);
     }
     var nextJob;

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -498,6 +498,9 @@
   * @property {Number} [tileRetryMax=0]
   *     The max number of retries when a tile download fails. By default it's 0, so retries are disabled.
   *
+  * @property {Number} [tileRetryDelay=2500]
+  *     Milliseconds to wait after each tile retry if tileRetryMax is set.
+  *
   * @property {Boolean} [useCanvas=true]
   *     Set to false to not use an HTML canvas element for image rendering even if canvas is supported.
   *

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -495,6 +495,9 @@
   * @property {Number} [timeout=30000]
   *     The max number of milliseconds that an image job may take to complete.
   *
+  * @property {Number} [tileRetryMax=0]
+  *     The max number of retries when a tile download fails. By default it's 0, so retries are disabled.
+  *
   * @property {Boolean} [useCanvas=true]
   *     Set to false to not use an HTML canvas element for image rendering even if canvas is supported.
   *

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1354,6 +1354,8 @@ function OpenSeadragon( options ){
             maxImageCacheCount:     200,
             timeout:                30000,
             useCanvas:              true,  // Use canvas element for drawing if available
+            tileRetryMax:           0,
+            tileRetryDelay:         2500,
 
             //INTERFACE RESOURCE SETTINGS
             prefixUrl:              "/images/",

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -393,7 +393,9 @@ $.Viewer = function( options ) {
     // Create the image loader
     this.imageLoader = new $.ImageLoader({
         jobLimit: this.imageLoaderLimit,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tileRetryMax: this.tileRetryMax,
+        tileRetryDelay: this.tileRetryDelay
     });
 
     // Create the tile cache


### PR DESCRIPTION
Based on https://github.com/openseadragon/openseadragon/pull/1627
From @paaddyy who originally wrote it:

I faced some issues with OpenSeadragon in my current project when tiles failed loading when the server is too busy. I missed a functionality to reload the failed tiles and after some research I only found an answer that it isn't possible yet to reload specific tiles.
So I extended the ImageLoader and ImageJob class a bit. If the ImageLoader notices within completeJob that a request failed and the job didn't run more than 3 times, it will re-run the job after a timeout of 2500ms. After 3 times failing it will be handled the normal way.
Do you think it's a good solution?

I also know the "tile-load-failed"-event and the xhr object within the event but i wasn't able to write a suitable solution with that object 😄