### PR TITLE
Add an AJAX concurrency limiter for tile source requests

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -312,6 +312,10 @@
   *     it is set to 0 allowing the browser to make the maximum number of
   *     image requests in parallel as allowed by the browsers policy.
   *
+  * @property {Number} [tileSourceLoaderLimit=0]
+  *     The maximum number of tile source requests to make concurrently. By default
+  *     it is set to 0 allowing an unlimited number of concurrent requests.
+  *
   * @property {Number} [clickTimeThreshold=300]
   *      The number of milliseconds within which a pointer down-up event combination
   *      will be treated as a click gesture.
@@ -792,7 +796,7 @@ function OpenSeadragon( options ){
         requestFuncs: [],
         numRequests: 0,
         numActiveRequests: 0,
-        maxConcurrency: 50,
+        maxConcurrency: 0,
     };
 
     /**
@@ -1339,6 +1343,7 @@ function OpenSeadragon( options ){
 
             //PERFORMANCE SETTINGS
             imageLoaderLimit:       0,
+            tileSourceLoaderLimit:  0,
             maxImageCacheCount:     200,
             timeout:                30000,
             useCanvas:              true,  // Use canvas element for drawing if available
@@ -2339,6 +2344,10 @@ function OpenSeadragon( options ){
         },
 
         queueAjaxRequest: function (request, sendRequestFunc) {
+            if(!$.ajaxQueue.maxConcurrency) {
+                sendRequestFunc();
+            }
+
             var oldOnStateChange = request.onreadystatechange;
 
             var onCompleteRequest = function() {

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -312,7 +312,7 @@
   *     it is set to 0 allowing the browser to make the maximum number of
   *     image requests in parallel as allowed by the browsers policy.
   *
-  * @property {Number} [tileSourceLoaderLimit=0]
+  * @property {Number} [ajaxLoaderLimit=0]
   *     The maximum number of tile source requests to make concurrently. By default
   *     it is set to 0 allowing an unlimited number of concurrent requests.
   *
@@ -1343,7 +1343,7 @@ function OpenSeadragon( options ){
 
             //PERFORMANCE SETTINGS
             imageLoaderLimit:       0,
-            tileSourceLoaderLimit:  0,
+            ajaxLoaderLimit:        0,
             maxImageCacheCount:     200,
             timeout:                30000,
             useCanvas:              true,  // Use canvas element for drawing if available

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -1472,12 +1472,17 @@ function OpenSeadragon( options ){
          * Global settings, shared across all viewers.
          * @static
          * @type {Object}
-         * @property {Number} ajaxLoaderLimit The maximum number of ajax requests to make concurrently. By default it is set to 0 allowing an unlimited number of concurrent requests.
+         * @property {Number} ajaxLoaderLimit The maximum number of AJAX requests to make concurrently. By default it is set to 0 allowing an unlimited number of concurrent requests.
          */
         settings: {
             ajaxLoaderLimit: 0
         },
 
+        /**
+         * Sets the global concurrency limit for AJAX requests
+         * @function
+         * @param {Number} maxNumAjaxRequests The maximum number of AJAX requests to make concurrently. Setting this to 0 will allow an unlimited number of requests.
+         */
         setAjaxLoaderLimit: function ( maxNumAjaxRequests ) {
             if( maxNumAjaxRequests < 0) {
                 throw new Error("The ajax loader limit must be >= 0");

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -394,6 +394,10 @@ $.Viewer = function( options ) {
         timeout: options.timeout
     });
 
+    // TODO: Instantiating a viewer shouldn't have
+    // a side effect on the global queue
+    $.ajaxQueue.maxConcurrency = options.tileSourceLoaderLimit;
+
     // Create the tile cache
     this.tileCache = new $.TileCache({
         maxImageCacheCount: this.maxImageCacheCount

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -396,7 +396,7 @@ $.Viewer = function( options ) {
 
     // TODO: Instantiating a viewer shouldn't have
     // a side effect on the global queue
-    $.ajaxQueue.maxConcurrency = options.tileSourceLoaderLimit;
+    $.ajaxQueue.ajaxLoaderLimit = options.ajaxLoaderLimit;
 
     // Create the tile cache
     this.tileCache = new $.TileCache({

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -394,10 +394,6 @@ $.Viewer = function( options ) {
         timeout: options.timeout
     });
 
-    // TODO: Instantiating a viewer shouldn't have
-    // a side effect on the global queue
-    $.ajaxQueue.ajaxLoaderLimit = options.ajaxLoaderLimit;
-
     // Create the tile cache
     this.tileCache = new $.TileCache({
         maxImageCacheCount: this.maxImageCacheCount


### PR DESCRIPTION
This is a proof-of-concept for a new viewer option which attempts to address #2241

For very large sessions it's easy to hit a browser's concurrent network requests limit, causing it to cancel a bunch of tile source ajax requests, it would be nice to have an option similar to `imageLoaderLimit` to avoid this case.

I'm opening this as a draft now; I added this feature without much care for style or the existing project structure, but thought it would be a good jumping off point for discussion about how to properly implement this!

This is a quick-and-dirty addition based on this gist: https://gist.github.com/Terrance/158a4c436baa64c4324803467844b00f