### PR TITLE
fixed viewport constraint behavior when viewer is rotated

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3049,17 +3049,16 @@ function onCanvasDrag( event ) {
                 this.viewport.centerSpringX.target.value += delta.x;
                 this.viewport.centerSpringY.target.value += delta.y;
 
-                var bounds = this.viewport.getBounds();
                 var constrainedBounds = this.viewport.getConstrainedBounds();
 
                 this.viewport.centerSpringX.target.value -= delta.x;
                 this.viewport.centerSpringY.target.value -= delta.y;
 
-                if (bounds.x !== constrainedBounds.x) {
+                if (constrainedBounds.xConstrained) {
                     event.delta.x = 0;
                 }
 
-                if (bounds.y !== constrainedBounds.y) {
+                if (constrainedBounds.yConstrained) {
                     event.delta.y = 0;
                 }
             }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -802,7 +802,7 @@ $.Viewport.prototype = {
      * Added to improve constrained panning
      * @param {Boolean} current - Pass true for the current location; defaults to false (target location).
      * @returns {OpenSeadragon.Rect} The bounds in viewport coordinates after applying constraints. The returned $.Rect
-     *                               contains additonal properties constraintsApplied, xConstrained and yConstrained.
+     *                               contains additional properties constraintsApplied, xConstrained and yConstrained.
      *                               These flags indicate whether the viewport bounds were modified by the constraints
      *                               of the viewer rectangle, and in which dimension(s).
      */

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -616,7 +616,7 @@ $.Viewport.prototype = {
      * @function
      * @param {Boolean} [immediately=false]
      * @returns {OpenSeadragon.Viewport} Chainable.
-     * @fires OpenSeadragon.Viewer.event:constrain if the
+     * @fires OpenSeadragon.Viewer.event:constrain if constraints were applied
      */
     applyConstraints: function(immediately) {
         var actualZoom = this.getZoom();

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -577,10 +577,11 @@ $.Viewport.prototype = {
 
         }
 
-        var newViewportBounds = this.viewerElementToViewportRectangle(newBounds);
+        var constraintApplied = xConstrained || yConstrained;
+        var newViewportBounds = constraintApplied ? this.viewerElementToViewportRectangle(newBounds) : bounds.clone();
         newViewportBounds.xConstrained = xConstrained;
         newViewportBounds.yConstrained = yConstrained;
-        newViewportBounds.constraintApplied = xConstrained || yConstrained;
+        newViewportBounds.constraintApplied = constraintApplied;
 
         return newViewportBounds;
     },

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -578,7 +578,7 @@ $.Viewport.prototype = {
         }
 
         var constraintApplied = xConstrained || yConstrained;
-        var newViewportBounds = constraintApplied ? this.viewerElementToViewportRectangle(newBounds, false) : bounds.clone();
+        var newViewportBounds = constraintApplied ? this.viewerElementToViewportRectangle(newBounds) : bounds.clone();
         newViewportBounds.xConstrained = xConstrained;
         newViewportBounds.yConstrained = yConstrained;
         newViewportBounds.constraintApplied = constraintApplied;
@@ -811,7 +811,6 @@ $.Viewport.prototype = {
             constrainedBounds;
 
         bounds = this.getBounds(current);
-        // bounds = this.getBoundsNoRotate(current);
 
         constrainedBounds = this._applyBoundaryConstraints(bounds);
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -801,10 +801,10 @@ $.Viewport.prototype = {
      * Returns bounds taking constraints into account
      * Added to improve constrained panning
      * @param {Boolean} current - Pass true for the current location; defaults to false (target location).
-     * @returns {OpenSeadragon.Rect} The bounds after applying constraints. The returned $.Rect contains additonal
-     *                               properties constraintsApplied, xConstrained and yConstrained. These flags indicate
-     *                               whether the viewport bounds were modified by the constraints of the viewer rectangle,
-     *                               and in which dimension(s).
+     * @returns {OpenSeadragon.Rect} The bounds in viewport coordinates after applying constraints. The returned $.Rect
+     *                               contains additonal properties constraintsApplied, xConstrained and yConstrained.
+     *                               These flags indicate whether the viewport bounds were modified by the constraints
+     *                               of the viewer rectangle, and in which dimension(s).
      */
     getConstrainedBounds: function(current) {
         var bounds,

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -483,7 +483,7 @@ $.Viewport.prototype = {
         );
 
         newZoomPixel = this._pixelFromPoint(this.zoomPoint, bounds);
-        deltaZoomPixels = newZoomPixel.minus( oldZoomPixel );
+        deltaZoomPixels = newZoomPixel.minus( oldZoomPixel ).rotate(-this.getRotation(true));
         deltaZoomPoints = deltaZoomPixels.divide( this._containerInnerSize.x * zoom );
 
         return centerTarget.plus( deltaZoomPoints );
@@ -578,7 +578,7 @@ $.Viewport.prototype = {
         }
 
         var constraintApplied = xConstrained || yConstrained;
-        var newViewportBounds = constraintApplied ? this.viewerElementToViewportRectangle(newBounds) : bounds.clone();
+        var newViewportBounds = constraintApplied ? this.viewerElementToViewportRectangle(newBounds, false) : bounds.clone();
         newViewportBounds.xConstrained = xConstrained;
         newViewportBounds.yConstrained = yConstrained;
         newViewportBounds.constraintApplied = constraintApplied;
@@ -811,6 +811,7 @@ $.Viewport.prototype = {
             constrainedBounds;
 
         bounds = this.getBounds(current);
+        // bounds = this.getBoundsNoRotate(current);
 
         constrainedBounds = this._applyBoundaryConstraints(bounds);
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -719,8 +719,6 @@ $.Viewport.prototype = {
             this.zoomTo(currentZoom, null, true);
 
             this.fitBounds(constrainedBounds);
-
-            // this.zoomTo(newZoom, referencePoint, immediately);
         } else {
             var rotatedNewBounds = newBounds.rotate(-this.getRotation());
             var referencePoint = rotatedNewBounds.getTopLeft().times(newZoom)

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -709,8 +709,6 @@ $.Viewport.prototype = {
             return this;
         }
 
-        var referencePoint;
-
         if(constraints){
             this.panTo(center, false);
             this.zoomTo(newZoom, null, false);
@@ -725,7 +723,7 @@ $.Viewport.prototype = {
             // this.zoomTo(newZoom, referencePoint, immediately);
         } else {
             var rotatedNewBounds = newBounds.rotate(-this.getRotation());
-            referencePoint = rotatedNewBounds.getTopLeft().times(newZoom)
+            var referencePoint = rotatedNewBounds.getTopLeft().times(newZoom)
                 .minus(oldBounds.getTopLeft().times(oldZoom))
                 .divide(newZoom - oldZoom);
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -616,7 +616,7 @@ $.Viewport.prototype = {
      * @function
      * @param {Boolean} [immediately=false]
      * @returns {OpenSeadragon.Viewport} Chainable.
-     * @fires OpenSeadragon.Viewer.event:constrain
+     * @fires OpenSeadragon.Viewer.event:constrain if the
      */
     applyConstraints: function(immediately) {
         var actualZoom = this.getZoom();
@@ -627,10 +627,10 @@ $.Viewport.prototype = {
         }
 
         var constrainedBounds = this.getConstrainedBounds(false);
-        this._raiseConstraintsEvent(immediately);
 
         if(constrainedBounds.constraintApplied){
             this.fitBounds(constrainedBounds, immediately);
+            this._raiseConstraintsEvent(immediately);
         }
 
         return this;
@@ -794,7 +794,9 @@ $.Viewport.prototype = {
      * Returns bounds taking constraints into account
      * Added to improve constrained panning
      * @param {Boolean} current - Pass true for the current location; defaults to false (target location).
-     * @returns {OpenSeadragon.Viewport} Chainable.
+     * @returns {OpenSeadragon.Rect} The bounds after applying constraints. The returned $.Rect contains additonal
+     *                               properties xConstrained, yConstrained, constraintsApplied indicating the status
+     *                               of the constraining operation; x and y are in the viewer element coordinate system.
      */
     getConstrainedBounds: function(current) {
         var bounds,

--- a/test/demo/fitboundswithconstraints.html
+++ b/test/demo/fitboundswithconstraints.html
@@ -81,8 +81,9 @@ setTimeout(() => viewport.applyConstraints(), 1000);</pre>
             tileSources: "../data/testpattern.dzi",
             minZoomImageRatio: 0,
             maxZoomPixelRatio: 10,
-            visibilityRatio:1.0,
+            visibilityRatio:1,
             constrainDuringPan:true,
+            // showNavigationControl:false,
         });
 
         viewer.addHandler("open", function(event) {
@@ -147,7 +148,29 @@ setTimeout(() => viewport.applyConstraints(), 1000);</pre>
                 });
             })
 
-            viewer.viewport.zoomTo(0.5, null, true);
+            viewer.viewport.zoomTo(1/2, null, true);
+
+            // viewer.viewport.panBy(new OpenSeadragon.Point(0.5, 0.5).minus(viewer.viewport.pointFromPixel(new OpenSeadragon.Point(0, 0))))
+            // setTimeout(()=>viewer.viewport.contentCoords(),1500);
+            // // setTimeout(()=>{
+            // //     viewer.viewport.rotateBy(-90, new OpenSeadragon.Point(0.5, 0.5));
+            // //     console.log('Rotated by -90')
+            // //     viewer.viewport.contentCoords();
+            // //     setTimeout(()=>{
+            // //         console.log('After rotation');
+            // //         viewer.viewport.contentCoords();
+            // //     },1500);
+            // // }, 2000)
+
+            // setTimeout(()=>{
+            //     viewer.viewport.zoomBy(2, new OpenSeadragon.Point(0.5, 0.5));
+            //     console.log('Zoomed by 2')
+            //     viewer.viewport.contentCoords();
+            //     setTimeout(()=>{
+            //         console.log('After zoom');
+            //         viewer.viewport.contentCoords();
+            //     },1500);
+            // }, 4500)
 
         });
         $('.method').on('click',function(){

--- a/test/demo/fitboundswithconstraints.html
+++ b/test/demo/fitboundswithconstraints.html
@@ -12,9 +12,10 @@
           border:thin black solid;
           margin-right:20px;
       }
-
-      #controls li {
-        cursor: pointer;
+      #buttons button{
+        width:10em;
+        text-align:center;
+        margin:5px;
       }
       .layout{
         display:grid;
@@ -63,7 +64,7 @@ setTimeout(() => viewport.applyConstraints(), 1000);</pre>
             </div>
             <button id="rotate">Rotate the viewer</button>
             <h3>Click to fit overlay bounds:</h3>
-            <ul></ul>
+            <div id="buttons"></div>
             <h4>overlay.getBounds(viewer.viewport):</h4>
             <pre class="bounds">Pick an overlay above to show the bounds</pre>
         </div>
@@ -122,7 +123,8 @@ setTimeout(() => viewport.applyConstraints(), 1000);</pre>
 
             viewer.currentOverlays.forEach(overlay=>{
                 var text = $(overlay.element).text();
-                $('<li>').text(text).appendTo('#controls ul').on('click',()=>{
+                var div=$('<div>').appendTo('#buttons');
+                var buttons=$('<button>').text(text).appendTo(div).on('click',()=>{
 
                     var bounds = overlay.getBounds(viewer.viewport);
                     $('.bounds').text(JSON.stringify(bounds,null,2));

--- a/test/demo/fitboundswithconstraints.html
+++ b/test/demo/fitboundswithconstraints.html
@@ -3,110 +3,159 @@
 <head>
     <title>OpenSeadragon fitBoundsWithConstraints() Demo</title>
     <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
     <style type="text/css">
 
       .openseadragon1 {
           width: 800px;
-          height: 600px;
+          height: 500px;
+          border:thin black solid;
+          margin-right:20px;
       }
 
-      #highlights li {
+      #controls li {
         cursor: pointer;
       }
-
+      .layout{
+        display:grid;
+        grid-template-columns:auto 1fr;
+        padding:10px;
+      }
+      .method{
+        border:medium gray solid;
+        margin:2px;
+        background-color:rgb(240, 240, 240)
+      }
+      .method.selected{
+        border:medium red solid;
+        background-color: lightgoldenrodyellow;
+      }
     </style>
 </head>
 <body>
-    <div>
-        Simple demo page to show 'viewport.fitBounds().applyConstraints()' issue.
+    <div class="layout">
+        <div id="contentDiv" class="openseadragon1"></div>
+        <div id="controls">
+            <div>
+                Simple demo page to show viewport.fitBounds() with and without constraints. The viewer
+                is set up with visibilityRatio = 1 and constrainDuringPan = true to clearly demonstrate the
+                constraints.
+            </div>
+
+            <h3>Pick a method to use:</h3>
+            <div>
+                <div class="method selected" data-value="0">
+                    <pre>viewport.fitBounds(bounds); //Ignores constraints</pre>
+                </div>
+                <div class="method" data-value="1">
+                    <pre>viewport.fitBoundsWithConstraints(bounds);</pre>
+                </div>
+                <div class="method" data-value="4">
+                    <pre>viewport.fitBoundsWithConstraints(bounds, true); //immediate</pre>
+                </div>
+                <div class="method" data-value="2">
+                    <pre>//Initially ignore constraints
+viewport.fitBounds(bounds);
+
+//Apply constraints after 1 second delay
+setTimeout(() => viewport.applyConstraints(), 1000);</pre>
+                </div>
+            </div>
+            <button id="rotate">Rotate the viewer</button>
+            <h3>Click to fit overlay bounds:</h3>
+            <ul></ul>
+            <h4>overlay.getBounds(viewer.viewport):</h4>
+            <pre class="bounds">Pick an overlay above to show the bounds</pre>
+        </div>
     </div>
 
-    <div id="contentDiv" class="openseadragon1"></div>
-    <div id="highlights"></div>
-
-    <select onchange="changeMethod(this.value);">
-        <option value=0>viewport.fitBoundsWithConstraints(bounds);</option>
-        <option value=1>viewport.fitBounds(bounds);</option>
-        <option value=2>viewport.fitBounds(bounds).applyConstraints();</option>
-    </select>
-    <input type="button" value="Go home" onclick="goHome()"/>
 
     <script type="text/javascript">
 
-        var _viewer;
+        var viewer;
         var _fittingMethod = 0;
-
-        var _highlights = [
-            {"queryPoint":[0.13789887359998443,0.43710575899579285], "radius":0.004479581945070337,"text":"Pipe"},
-            {"queryPoint":[0.5923298766583593,0.6461653354541856],   "radius":0.013175241014912752,"text":"Fuel here"},
-            {"queryPoint":[0.43920338711232304,0.7483181389302148],  "radius":0.09222668710438928, "text":"Wheel"},
-            {"queryPoint":[0.07341677959486298,0.9028719921872319],  "radius":0.08996845561083797, "text":"Nothing special"}
-        ];
-
-        var generateUniqueHash = (function() {
-            var counter = 0;
-            return function() {
-                return "openseadragon_" + (counter++);
-            };
-        })();
-
-        var _viewer = OpenSeadragon({
-            element: document.getElementById("contentDiv"),
-            showNavigationControl: false,
+        viewer = window.viewer = OpenSeadragon({
+            id: "contentDiv",
             prefixUrl: "../../build/openseadragon/images/",
-            hash: generateUniqueHash(), //this is only needed if you want to instantiate more than one viewer at a time.
-            tileSources: {
-                Image: {
-                    xmlns:    "http://schemas.microsoft.com/deepzoom/2008",
-                    Url:      'http://cdn.photosynth.net/ps2/19d5cf2b-77ed-439f-ac21-d3046320384c/packet/undistorted/img0043/',
-                    Format:   "jpg",
-                    Overlap:  1,
-                    TileSize: 510,
-                    Size: {
-                        Width:  4592,
-                        Height: 3448
+            tileSources: "../data/testpattern.dzi",
+            minZoomImageRatio: 0,
+            maxZoomPixelRatio: 10,
+            visibilityRatio:1.0,
+            constrainDuringPan:true,
+        });
+
+        viewer.addHandler("open", function(event) {
+            var elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "green";
+            elt.style.outline = "3px solid red";
+            elt.style.opacity = "0.7";
+            elt.textContent = "Within the image";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Rect(0.21, 0.21, 0.099, 0.299),
+                rotationMode: OpenSeadragon.OverlayRotationMode.BOUNDING_BOX
+            });
+
+            elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "white";
+            elt.style.opacity = "0.5";
+            elt.style.outline = "5px solid pink";
+            elt.textContent = "Left edge rectangle";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Rect(-0.4, 0.7, 0.7, 0.15)
+            });
+
+            var elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.background = "lightblue";
+            elt.style.outline = "3px solid purple";
+            elt.style.opacity = "0.7";
+            elt.textContent = "Top right square";
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Rect(0.9, -0.1, 0.2, 0.2),
+                rotationMode: OpenSeadragon.OverlayRotationMode.BOUNDING_BOX
+            });
+
+            viewer.currentOverlays.forEach(overlay=>{
+                var text = $(overlay.element).text();
+                $('<li>').text(text).appendTo('#controls ul').on('click',()=>{
+
+                    var bounds = overlay.getBounds(viewer.viewport);
+                    $('.bounds').text(JSON.stringify(bounds,null,2));
+
+                    var _fittingMethod = parseInt($('.method.selected').data('value'));
+
+                    if (_fittingMethod === 0) {
+                        viewer.viewport.fitBounds(bounds, false);
                     }
-                }
-            }
+                    else if (_fittingMethod === 1) {
+                        viewer.viewport.fitBoundsWithConstraints(bounds, false);
+                    }
+                    else if (_fittingMethod === 4) {
+                        viewer.viewport.fitBoundsWithConstraints(bounds, true);
+                    }
+                    else if (_fittingMethod === 2) {
+                        viewer.viewport.fitBounds(bounds, false);
+                        setTimeout(()=>viewer.viewport.applyConstraints(), 1000);
+                    }
+                });
+            })
+
+            viewer.viewport.zoomTo(0.5, null, true);
+
         });
-        _viewer.addHandler("open", function() {
-            var str = "<ul>";
-            for (var i=0; i<_highlights.length; ++i) {
-                var highlight = _highlights[i];
-                str += "<li onclick='gotoHighlight("+i+")'>"+highlight.text+"</li>";
-            }
-            str += "</ul>";
-            document.getElementById("highlights").innerHTML = str;
+        $('.method').on('click',function(){
+            $('.method').removeClass('selected');
+            $(this).addClass('selected');
+        })
+        $("#rotate").click(function() {
+            viewer.viewport.setRotation(viewer.viewport.getRotation() - 22.5);
+            $("#degrees").text(viewer.viewport.getRotation() + "deg");
         });
-
-        function gotoHighlight(index) {
-            var highlight = _highlights[index];
-
-            var viewport = _viewer.viewport;
-            var contentSize = viewport.contentSize;
-            var scaling = 1.0 / viewport.viewportToImageZoom(viewport.getZoom());
-            var radius  = highlight.radius*Math.min(contentSize.x, contentSize.y);/*annotation.accurateRadius*scaling;*/
-            var center      = new OpenSeadragon.Point(contentSize.x*highlight.queryPoint[0], contentSize.y*highlight.queryPoint[1]);
-            var bounds = viewport.imageToViewportRectangle(new OpenSeadragon.Rect(center.x-radius, center.y-radius, radius*2, radius*2));
-
-            if (_fittingMethod === 0) {
-                viewport.fitBoundsWithConstraints(bounds, false);
-            }
-            else if (_fittingMethod === 1) {
-                viewport.fitBounds(bounds, false);
-            }
-            else if (_fittingMethod === 2) {
-                viewport.fitBounds(bounds, false).applyConstraints();
-            }
-        }
-
-        function changeMethod(value) {
-            _fittingMethod = parseInt(value, 10);
-        }
-
-        function goHome() {
-            _viewer.viewport.goHome();
-        }
 
     </script>
 </body>

--- a/test/demo/fitboundswithconstraints.html
+++ b/test/demo/fitboundswithconstraints.html
@@ -83,7 +83,6 @@ setTimeout(() => viewport.applyConstraints(), 1000);</pre>
             maxZoomPixelRatio: 10,
             visibilityRatio:1,
             constrainDuringPan:true,
-            // showNavigationControl:false,
         });
 
         viewer.addHandler("open", function(event) {
@@ -148,29 +147,8 @@ setTimeout(() => viewport.applyConstraints(), 1000);</pre>
                 });
             })
 
-            viewer.viewport.zoomTo(1/2, null, true);
+            viewer.viewport.zoomTo(0.5, null, true);
 
-            // viewer.viewport.panBy(new OpenSeadragon.Point(0.5, 0.5).minus(viewer.viewport.pointFromPixel(new OpenSeadragon.Point(0, 0))))
-            // setTimeout(()=>viewer.viewport.contentCoords(),1500);
-            // // setTimeout(()=>{
-            // //     viewer.viewport.rotateBy(-90, new OpenSeadragon.Point(0.5, 0.5));
-            // //     console.log('Rotated by -90')
-            // //     viewer.viewport.contentCoords();
-            // //     setTimeout(()=>{
-            // //         console.log('After rotation');
-            // //         viewer.viewport.contentCoords();
-            // //     },1500);
-            // // }, 2000)
-
-            // setTimeout(()=>{
-            //     viewer.viewport.zoomBy(2, new OpenSeadragon.Point(0.5, 0.5));
-            //     console.log('Zoomed by 2')
-            //     viewer.viewport.contentCoords();
-            //     setTimeout(()=>{
-            //         console.log('After zoom');
-            //         viewer.viewport.contentCoords();
-            //     },1500);
-            // }, 4500)
 
         });
         $('.method').on('click',function(){

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -539,7 +539,7 @@
             var bounds = viewport.getBounds();
             Util.assertRectangleEquals(
                 assert,
-                new OpenSeadragon.Rect(1.2071067811865466, 0.20710678118654746, Math.sqrt(2), Math.sqrt(2), 45),
+                new OpenSeadragon.Rect(1.0, 0.0, Math.sqrt(2), Math.sqrt(2), 45),
                 bounds,
                 EPSILON,
                 "Viewport.applyConstraints with rotation should move viewport.");
@@ -564,7 +564,7 @@
             var bounds = viewport.getBounds();
             Util.assertRectangleEquals(
                 assert,
-                new OpenSeadragon.Rect(1.2071067811865466, 0.20710678118654746, Math.sqrt(2), Math.sqrt(2), 45),
+                new OpenSeadragon.Rect(1.0, 0.0, Math.sqrt(2), Math.sqrt(2), 45),
                 bounds,
                 EPSILON,
                 "Viewport.applyConstraints flipped and with rotation should move viewport.");


### PR DESCRIPTION
Related to https://github.com/openseadragon/openseadragon/pull/2041, fixes https://github.com/openseadragon/openseadragon/issues/2040

As far as I can tell, this works as expected with different values for `visibilityRatio`, viewport rotations, etc. I don't see a reason it should break anything, but... it would be good to have others test it out, of course.

One thing I haven't changed, but I'm wondering about, is why the `_raiseConstraintsEvent()` is called every time `applyConstraints()` is called, even if no constraints were actually applied... is this desirable? It basically means every navigation event raises the `constrain` event, even if no boundary was hit.
