### PR TITLE
Rotation api reconciliation

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -617,7 +617,6 @@ $.Viewport.prototype = {
 
         var bounds = this.getBoundsNoRotate();
         var constrainedBounds = this._applyBoundaryConstraints(bounds);
-        this._raiseConstraintsEvent(immediately);
 
         if (bounds.x !== constrainedBounds.x ||
             bounds.y !== constrainedBounds.y ||
@@ -913,17 +912,15 @@ $.Viewport.prototype = {
     },
 
     /**
-     * Rotates this viewport to the angle specified. Alias for rotateTo.
+     * Rotates this viewport to the angle specified.
      * @function
      * @param {Number} degrees The degrees to set the rotation to.
-     * @param {OpenSeadragon.Point} [pivot] (Optional) point in viewport coordinates
-     * around which the rotation should be performed. Defaults to the center of the viewport.
      * @param {Boolean} [immediately=false] Whether to animate to the new angle
      * or rotate immediately.
      * * @returns {OpenSeadragon.Viewport} Chainable.
      */
-    setRotation: function(degrees, pivot, immediately) {
-        return this.rotateTo(degrees, pivot, immediately);
+    setRotation: function(degrees, immediately) {
+        return this.rotateTo(degrees, null, immediately);
     },
 
     /**
@@ -936,6 +933,20 @@ $.Viewport.prototype = {
         return current ?
             this.degreesSpring.current.value :
             this.degreesSpring.target.value;
+    },
+
+    /**
+     * Rotates this viewport to the angle specified around a pivot point. Alias for rotateTo.
+     * @function
+     * @param {Number} degrees The degrees to set the rotation to.
+     * @param {OpenSeadragon.Point} [pivot] (Optional) point in viewport coordinates
+     * around which the rotation should be performed. Defaults to the center of the viewport.
+     * @param {Boolean} [immediately=false] Whether to animate to the new angle
+     * or rotate immediately.
+     * * @returns {OpenSeadragon.Viewport} Chainable.
+     */
+    setRotationWithPivot: function(degrees, pivot, immediately) {
+        return this.rotateTo(degrees, pivot, immediately);
     },
 
     /**

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -617,6 +617,7 @@ $.Viewport.prototype = {
 
         var bounds = this.getBoundsNoRotate();
         var constrainedBounds = this._applyBoundaryConstraints(bounds);
+        this._raiseConstraintsEvent(immediately);
 
         if (bounds.x !== constrainedBounds.x ||
             bounds.y !== constrainedBounds.y ||

--- a/test/modules/drawer.js
+++ b/test/modules/drawer.js
@@ -46,7 +46,7 @@
         });
 
         viewer.addHandler('open', function handler(event) {
-            viewer.viewport.setRotation(30, null, true);
+            viewer.viewport.setRotation(30, true);
             Util.spyOnce(viewer.drawer.context, 'rotate', function() {
                 assert.ok(true, 'drawing with new rotation');
                 done();

--- a/test/modules/units.js
+++ b/test/modules/units.js
@@ -212,13 +212,13 @@
                 checkPoint(assert, ' after zoom and pan');
 
                 //Restore rotation
-                viewer.viewport.setRotation(0, null, true);
+                viewer.viewport.setRotation(0, true);
                 done();
             });
             viewer.viewport.zoomTo(0.8).panTo(new OpenSeadragon.Point(0.1, 0.2));
         });
 
-        viewer.viewport.setRotation(45, null, true);
+        viewer.viewport.setRotation(45, true);
         viewer.open([{
                 tileSource: "/test/data/testpattern.dzi"
             }, {

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -247,7 +247,7 @@
         function openHandler() {
             viewer.removeHandler('open', openHandler);
             var viewport = viewer.viewport;
-            viewport.setRotation(-675, null, true);
+            viewport.setRotation(-675, true);
             Util.assertRectangleEquals(
                 assert,
                 viewport.getHomeBoundsNoRotate(),
@@ -269,7 +269,7 @@
         function openHandler() {
             viewer.removeHandler('open', openHandler);
             var viewport = viewer.viewport;
-            viewport.setRotation(-675, null, true);
+            viewport.setRotation(-675, true);
             Util.assertRectangleEquals(
                 assert,
                 viewport.getHomeBounds(),
@@ -533,7 +533,7 @@
         var openHandler = function() {
             viewer.removeHandler('open', openHandler);
             var viewport = viewer.viewport;
-            viewport.setRotation(45, null, true);
+            viewport.setRotation(45, true);
             viewport.fitBounds(new OpenSeadragon.Rect(1, 1, 1, 1), true);
             viewport.applyConstraints(true);
             var bounds = viewport.getBounds();
@@ -557,7 +557,7 @@
             var viewport = viewer.viewport;
 
             viewport.setFlip(true);
-            viewport.setRotation(45, null, true);
+            viewport.setRotation(45, true);
 
             viewport.fitBounds(new OpenSeadragon.Rect(1, 1, 1, 1), true);
             viewport.applyConstraints(true);
@@ -659,7 +659,7 @@
         var openHandler = function(event) {
             viewer.removeHandler('open', openHandler);
             var viewport = viewer.viewport;
-            viewport.setRotation(45, null, true);
+            viewport.setRotation(45, true);
 
             for(var i = 0; i < testRectsFitBounds.length; i++){
                 var rect = testRectsFitBounds[i];
@@ -1066,12 +1066,12 @@
             var viewport = viewer.viewport;
 
             assert.propEqual(viewport.getRotation, 0, "Original rotation should be 0 degrees");
-            viewport.setRotation(90, null, true);
+            viewport.setRotation(90, true);
             assert.propEqual(viewport.getRotation, 90, "Rotation should be 90 degrees");
-            viewport.setRotation(-75, null, true);
+            viewport.setRotation(-75, true);
             assert.propEqual(viewport.getRotation, -75, "Rotation should be -75 degrees");
 
-            viewport.setRotation(0, null, true);
+            viewport.setRotation(0, true);
             assert.strictEqual(viewport.getRotation(true), 0, 'viewport has default current rotation');
             assert.strictEqual(viewport.getRotation(false), 0, 'viewport has default target rotation');
 
@@ -1079,7 +1079,7 @@
             assert.strictEqual(viewport.getRotation(true), 0, 'current rotation is not changed');
             assert.strictEqual(viewport.getRotation(false), 33, 'target rotation is set correctly');
 
-            viewport.setRotation(200, null, true);
+            viewport.setRotation(200, true);
             assert.strictEqual(viewport.getRotation(true), 200, 'current rotation is set correctly');
             assert.strictEqual(viewport.getRotation(false), 200, 'target rotation is set correctly');
 
@@ -1099,9 +1099,9 @@
             viewport.setFlip(true);
 
             assert.propEqual(viewport.getRotation, 0, "Original flipped rotation should be 0 degrees");
-            viewport.setRotation(90, null, true);
+            viewport.setRotation(90, true);
             assert.propEqual(viewport.getRotation, 90, "Flipped rotation should be 90 degrees");
-            viewport.setRotation(-75, null, true);
+            viewport.setRotation(-75, true);
             assert.propEqual(viewport.getRotation, -75, "Flipped rotation should be -75 degrees");
 
             done();


### PR DESCRIPTION
Reverts API of `Viewport.setRotation` back to `(degrees, immediately)` to match `TiledImage` API. Adds new API `Viewport.setRotationWithPivot(degrees, pivot, immediately)` as an alias for `rotateTo`, as discussed in https://github.com/openseadragon/openseadragon/pull/2233#issuecomment-1335984094