### PR TITLE
Fix navigator tests

### DIFF
--- a/test/modules/navigator.js
+++ b/test/modules/navigator.js
@@ -248,14 +248,8 @@
     };
 
     var dragNavigatorBackToCenter = function () {
-        var start = viewer.viewport.getBounds().getTopLeft(),
-            target = new OpenSeadragon.Point(0.5 - viewer.viewport.getBounds().width / 2,
-                     1 / viewer.source.aspectRatio / 2 - viewer.viewport.getBounds().height / 2),
-            delta = target.minus(start);
-        if (viewer.source.aspectRatio < 1) {
-                delta.y *= viewer.source.aspectRatio;
-        }
-        simulateNavigatorDrag(viewer.navigator, delta.x * displayRegionWidth, delta.y * displayRegionHeight);
+        var delta = viewer.viewport.getHomeBounds().getCenter().minus(viewer.viewport.getCenter()).times(displayRegionWidth);
+        simulateNavigatorDrag(viewer.navigator, delta.x, delta.y);
     };
 
     var resizeElement = function ($element, width, height) {

--- a/test/test.html
+++ b/test/test.html
@@ -50,6 +50,6 @@
     <script src="/test/modules/tilesource-dynamic-url.js"></script>
     <!--The navigator tests are the slowest (for now; hopefully they can be sped up)
     so we put them last. -->
-    <!-- The navigator tests are failing right now, so we have them disabled for the moment <script src="/test/modules/navigator.js"></script> -->
+    <script src="/test/modules/navigator.js"></script>
 </body>
 </html>


### PR DESCRIPTION
In my testing, this fixes the navigator tests. The main issue was that the calculated viewport delta (which was actually always correct, I think) was previously scaled by the width and height of the navigator area (for x and y, respectively), instead of just the width. Since only width defines the scales of the images (and height is irrelevant), this was causing issues. I'm a bit confused about why this ever worked, though, since this goes all the way back to the beginning of the file history. Perhaps the tests were previously run with a viewer with equal width and height?

For some reason, with all tests enabled, the test page gets stuck at `tiledimage` for me. Running the navigator test by itself seems to work fine though, and running all of them except `tiledimage` also works fine. 