### PR TITLE
Fixed fullyLoaded test when run in browser

### DIFF
--- a/test/modules/tiledimage.js
+++ b/test/modules/tiledimage.js
@@ -9,6 +9,7 @@
 
             testLog.reset();
 
+            // eslint-disable-next-line new-cap
             viewer = OpenSeadragon({
                 id: 'example',
                 prefixUrl: '/build/openseadragon/images/',
@@ -517,12 +518,17 @@
             var image = viewer.world.getItemAt(0);
             assert.equal(image.getFullyLoaded(), false, 'not fully loaded at first');
 
+            // Zoom out enough that we don't start out with all the tiles loaded.
+            viewer.viewport.zoomBy(0.5, null, true);
+
             var count = 0;
 
             var fullyLoadedChangeHandler = function(event) {
                 if (count === 0) {
                     assert.equal(event.fullyLoaded, true, 'event includes true fullyLoaded property');
                     assert.equal(image.getFullyLoaded(), true, 'image is fully loaded after event');
+
+                    // Zoom in enough that it needs to load some new tiles.
                     viewer.viewport.zoomBy(5, null, true);
                 } else if (count === 1) {
                     assert.equal(event.fullyLoaded, false, 'event includes false fullyLoaded property');


### PR DESCRIPTION
@pearcetm Thank you for the reminder on this one. Looks like it was zoomed in just enough that it had already loaded all the tiles. It must have been right on the edge, so it only failed in the browser and not when run from the command line. 

I'm going to go ahead and merge this, but let me know if you find any issues, or if it doesn't fix it for you, and I'll follow up! 