### PR TITLE
Fix #2264: Navigator display rectangle is off when the page has box-sizing: border-box 

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -184,6 +184,7 @@ $.Navigator = function( options ){
         style.styleFloat    = 'left'; //IE
         style.zIndex        = 999999999;
         style.cursor        = 'default';
+        style.boxSizing     = 'content-box';
     }( this.displayRegion.style, this.borderWidth ));
     $.setElementPointerEventsNone( this.displayRegion );
     $.setElementTouchActionNone( this.displayRegion );


### PR DESCRIPTION
**What is the PR `for?**

- should fix [#2264](https://github.com/openseadragon/openseadragon/issues/2264).
- Adds `box-sizing: content-box` property to the navigator display region.