### PR TITLE
fix problem with click precision on ReferenceStrip

### DIFF
--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -300,7 +300,8 @@ function onStripClick( event ) {
         var page;
 
         if ( 'horizontal' === this.scroll ) {
-            page = Math.floor(event.position.x / this.panelWidth);
+            // +4px fix to solve problem with precision on thumbnail selection if there is a lot of them 
+            page = Math.floor(event.position.x / (this.panelWidth + 4));
         } else {
             page = Math.floor(event.position.y / this.panelHeight);
         }


### PR DESCRIPTION
temporary fix for #1992 . Just adding 4px which works in all use cases.