### PR TITLE
Ensure tile-loaded event completionCallback is called only once. 

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1655,17 +1655,17 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * @param {XMLHttpRequest|undefined} tileRequest
      */
     _setTileLoaded: function(tile, data, cutoff, tileRequest) {
-        var increment = 0,
+        var stopper = 1,
+            cached = false,
             _this = this;
 
         function getCompletionCallback() {
-            increment++;
             return completionCallback;
         }
 
         function completionCallback() {
-            increment--;
-            if (increment === 0) {
+            stopper--;
+            if (stopper > 0) {
                 tile.loading = false;
                 tile.loaded = true;
                 tile.hasTransparency = _this.source.hasTransparency(
@@ -1678,8 +1678,13 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                         cutoff: cutoff,
                         tiledImage: _this
                     });
+                    cached = true;
                 }
                 _this._needsDraw = true;
+            } else if (tile.context2D && cached) {
+                $.console.error("The tile has been cached, yet tile.context2D was set afterwards." +
+                    " The cache is orphaned now. To avoid this, increase the priority of 'tile-loaded' event " +
+                    "attaching context2D property.");
             }
         }
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1704,8 +1704,6 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
          * when the asynchronous processing of the image is done. The image will be
          * marked as entirely loaded when the callback has been called once for each
          * call to getCompletionCallback.
-         * Note: if you do not process the tile in asynchronous context
-         * (timeout, Promises, async, callbacks such as image.onload ...), do not use this function.
          */
 
         var fallbackCompletion = getCompletionCallback();

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1665,7 +1665,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
 
         function completionCallback() {
             stopper--;
-            if (stopper > 0) {
+            if (stopper >= 0) {
                 tile.loading = false;
                 tile.loaded = true;
                 tile.hasTransparency = _this.source.hasTransparency(


### PR DESCRIPTION
The PR also errors when context2D is set after cache creation.