### PR TITLE
add guard against caching a tile twice

### DIFF
--- a/src/tilecache.js
+++ b/src/tilecache.js
@@ -132,6 +132,10 @@ $.TileCache.prototype = {
         $.console.assert( options.tile.cacheKey, "[TileCache.cacheTile] options.tile.cacheKey is required" );
         $.console.assert( options.tiledImage, "[TileCache.cacheTile] options.tiledImage is required" );
 
+        if( options.tile.cacheImageRecord ){
+            // the tile has already been cached
+            return;
+        }
         var cutoff = options.cutoff || 0;
         var insertionIndex = this._tilesLoaded.length;
 


### PR DESCRIPTION
Possible simple fix for https://github.com/openseadragon/openseadragon/issues/2277

Just checks whether `tile.cacheImageRecord` exists, and avoids adding a duplicate entry if so. I have not done much testing yet on this.