### PR TITLE
Fix TileLoader re-trying up to tileRetryMax

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -234,7 +234,7 @@ $.ImageLoader.prototype = {
  * @param callback - Called once cleanup is finished.
  */
 function completeJob(loader, job, callback) {
-    if (job.errorMsg !== '' && (job.image === null || job.image === undefined) && job.tries < 1 + loader.tileRetryMax) {
+    if (job.errorMsg !== '' && (job.data === null || job.data === undefined) && job.tries < 1 + loader.tileRetryMax) {
         loader.failedTiles.push(job);
     }
     var nextJob;


### PR DESCRIPTION
Despite fetching the tile successfully after the 1st retry, the re-try logic kept on re-trying.
This fixes that part.

Discussed in https://github.com/openseadragon/openseadragon/pull/2238#issuecomment-1412882984

Apologies, this is my first time contributing to an Open-Source project; let me know if I forgot anything.