### PR TITLE
Take zoom constraint into account within _fitBounds

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -711,6 +711,8 @@ $.Viewport.prototype = {
 
         if(constraints){
             this.panTo(center, false);
+
+            newZoom = this._applyZoomConstraints(newZoom);
             this.zoomTo(newZoom, null, false);
 
             var constrainedBounds = this.getConstrainedBounds();


### PR DESCRIPTION
Take zoom constraint into account within _fitBounds when constraints = true and immediately = false

Should fix https://github.com/openseadragon/openseadragon/issues/2292, but more testing would be useful.