### PR TITLE
Add ESLint plugin for linting browser compatibility

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+defaults, IE 11

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,1 @@
-defaults, IE 11
+defaults

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
     "root": true,
+    "plugins": ["compat"],
     "extends": [
-        "eslint:recommended"
+        "eslint:recommended",
+        "plugin:compat/recommended"
     ],
     "env": {
         "es6": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "4.0.0",
             "license": "BSD-3-Clause",
             "devDependencies": {
+                "eslint-plugin-compat": "^4.1.2",
                 "grunt": "^1.6.1",
                 "grunt-contrib-clean": "^2.0.1",
                 "grunt-contrib-compress": "^2.0.0",
@@ -121,6 +122,12 @@
             "version": "1.2.1",
             "dev": true,
             "license": "BSD-3-Clause"
+        },
+        "node_modules/@mdn/browser-compat-data": {
+            "version": "5.2.36",
+            "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.36.tgz",
+            "integrity": "sha512-cS+xbp4jq+W04pFqw5639Grzj82JevJZst4b55Mk2NGc9wY7uXD6hlM6H0hkK5mLKXXZKsT1xq79W6LsSG4crw==",
+            "dev": true
         },
         "node_modules/@types/node": {
             "version": "18.11.9",
@@ -416,6 +423,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/ast-metadata-inferer": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+            "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+            "dev": true,
+            "dependencies": {
+                "@mdn/browser-compat-data": "^3.3.14"
+            }
+        },
+        "node_modules/ast-metadata-inferer/node_modules/@mdn/browser-compat-data": {
+            "version": "3.3.14",
+            "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
+            "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+            "dev": true
+        },
         "node_modules/async": {
             "version": "1.5.2",
             "dev": true,
@@ -633,6 +655,34 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/browserslist": {
+            "version": "4.21.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+            "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                }
+            ],
+            "dependencies": {
+                "caniuse-lite": "^1.0.30001449",
+                "electron-to-chromium": "^1.4.284",
+                "node-releases": "^2.0.8",
+                "update-browserslist-db": "^1.0.10"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "dev": true,
@@ -715,6 +765,22 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001456",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001456.tgz",
+            "integrity": "sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                }
+            ]
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -1162,6 +1228,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/electron-to-chromium": {
+            "version": "1.4.302",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.302.tgz",
+            "integrity": "sha512-Uk7C+7aPBryUR1Fwvk9VmipBcN9fVsqBO57jV2ZjTm+IZ6BMNqu7EDVEg2HxCNufk6QcWlFsBkhQyQroB2VWKw==",
+            "dev": true
+        },
         "node_modules/encodeurl": {
             "version": "1.0.2",
             "dev": true,
@@ -1199,6 +1271,15 @@
             "dev": true,
             "dependencies": {
                 "string-template": "~0.2.1"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/escape-html": {
@@ -1363,6 +1444,88 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-plugin-compat": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.1.2.tgz",
+            "integrity": "sha512-DNrQgDi5L4mAL4FdFboKBlSRg6MWfd75eA7K91lMjtP5ryN+O11qT2FDn7Z6zqy6sZ4sJawUR5V75qzB6l0CBg==",
+            "dev": true,
+            "dependencies": {
+                "@mdn/browser-compat-data": "^5.2.34",
+                "ast-metadata-inferer": "^0.7.0",
+                "browserslist": "^4.21.5",
+                "caniuse-lite": "^1.0.30001451",
+                "find-up": "^5.0.0",
+                "lodash.memoize": "4.1.2",
+                "semver": "7.3.8"
+            },
+            "engines": {
+                "node": ">=16.x"
+            },
+            "peerDependencies": {
+                "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-compat/node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-compat/node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-compat/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-compat/node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint-scope": {
@@ -3975,6 +4138,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+            "dev": true
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "dev": true,
@@ -4344,6 +4513,12 @@
             "engines": {
                 "node": ">=0.12.0"
             }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+            "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+            "dev": true
         },
         "node_modules/nopt": {
             "version": "3.0.6",
@@ -4783,6 +4958,12 @@
             "version": "1.2.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -5617,9 +5798,10 @@
             "dev": true
         },
         "node_modules/semver": {
-            "version": "7.3.5",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -6349,6 +6531,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/update-browserslist-db": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+            "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                }
+            ],
+            "dependencies": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
+            },
+            "bin": {
+                "browserslist-lint": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "dev": true,
@@ -6555,6 +6763,18 @@
                 "fd-slicer": "~1.1.0"
             }
         },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/zip-stream": {
             "version": "4.1.0",
             "dev": true,
@@ -6646,6 +6866,12 @@
         },
         "@humanwhocodes/object-schema": {
             "version": "1.2.1",
+            "dev": true
+        },
+        "@mdn/browser-compat-data": {
+            "version": "5.2.36",
+            "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.36.tgz",
+            "integrity": "sha512-cS+xbp4jq+W04pFqw5639Grzj82JevJZst4b55Mk2NGc9wY7uXD6hlM6H0hkK5mLKXXZKsT1xq79W6LsSG4crw==",
             "dev": true
         },
         "@types/node": {
@@ -6845,6 +7071,23 @@
             "version": "1.0.0",
             "dev": true
         },
+        "ast-metadata-inferer": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+            "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+            "dev": true,
+            "requires": {
+                "@mdn/browser-compat-data": "^3.3.14"
+            },
+            "dependencies": {
+                "@mdn/browser-compat-data": {
+                    "version": "3.3.14",
+                    "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
+                    "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+                    "dev": true
+                }
+            }
+        },
         "async": {
             "version": "1.5.2",
             "dev": true
@@ -6992,6 +7235,18 @@
                 "repeat-element": "^1.1.2"
             }
         },
+        "browserslist": {
+            "version": "4.21.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+            "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30001449",
+                "electron-to-chromium": "^1.4.284",
+                "node-releases": "^2.0.8",
+                "update-browserslist-db": "^1.0.10"
+            }
+        },
         "buffer": {
             "version": "5.7.1",
             "dev": true,
@@ -7041,6 +7296,12 @@
         },
         "callsites": {
             "version": "3.1.0",
+            "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001456",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001456.tgz",
+            "integrity": "sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==",
             "dev": true
         },
         "chalk": {
@@ -7356,6 +7617,12 @@
             "version": "1.1.1",
             "dev": true
         },
+        "electron-to-chromium": {
+            "version": "1.4.302",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.302.tgz",
+            "integrity": "sha512-Uk7C+7aPBryUR1Fwvk9VmipBcN9fVsqBO57jV2ZjTm+IZ6BMNqu7EDVEg2HxCNufk6QcWlFsBkhQyQroB2VWKw==",
+            "dev": true
+        },
         "encodeurl": {
             "version": "1.0.2",
             "dev": true
@@ -7384,6 +7651,12 @@
             "requires": {
                 "string-template": "~0.2.1"
             }
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
         },
         "escape-html": {
             "version": "1.0.3",
@@ -7569,6 +7842,60 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-compat": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.1.2.tgz",
+            "integrity": "sha512-DNrQgDi5L4mAL4FdFboKBlSRg6MWfd75eA7K91lMjtP5ryN+O11qT2FDn7Z6zqy6sZ4sJawUR5V75qzB6l0CBg==",
+            "dev": true,
+            "requires": {
+                "@mdn/browser-compat-data": "^5.2.34",
+                "ast-metadata-inferer": "^0.7.0",
+                "browserslist": "^4.21.5",
+                "caniuse-lite": "^1.0.30001451",
+                "find-up": "^5.0.0",
+                "lodash.memoize": "4.1.2",
+                "semver": "7.3.8"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^6.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^5.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^3.0.2"
                     }
                 }
             }
@@ -9227,6 +9554,12 @@
             "version": "4.0.6",
             "dev": true
         },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+            "dev": true
+        },
         "lodash.merge": {
             "version": "4.6.2",
             "dev": true
@@ -9477,6 +9810,12 @@
                 "url": "^0.11.0",
                 "websocket-stream": "^5.0.1"
             }
+        },
+        "node-releases": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+            "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+            "dev": true
         },
         "nopt": {
             "version": "3.0.6",
@@ -9757,6 +10096,12 @@
         },
         "pend": {
             "version": "1.2.0",
+            "dev": true
+        },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
         },
         "picomatch": {
@@ -10316,7 +10661,9 @@
             "dev": true
         },
         "semver": {
-            "version": "7.3.5",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
@@ -10828,6 +11175,16 @@
                 }
             }
         },
+        "update-browserslist-db": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+            "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+            "dev": true,
+            "requires": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
+            }
+        },
         "uri-js": {
             "version": "4.4.1",
             "dev": true,
@@ -10981,6 +11338,12 @@
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
             }
+        },
+        "yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true
         },
         "zip-stream": {
             "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     },
     "scripts": {
         "test": "grunt test",
-        "prepare": "grunt build"
+        "prepare": "grunt build",
+        "lint": "eslint ./src"
     }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     },
     "scripts": {
         "test": "grunt test",
-        "prepare": "grunt build",
-        "lint": "eslint ./src"
+        "prepare": "grunt build"
     }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "url": "https://github.com/openseadragon/openseadragon.git"
     },
     "devDependencies": {
+        "eslint-plugin-compat": "^4.1.2",
         "grunt": "^1.6.1",
         "grunt-contrib-clean": "^2.0.1",
         "grunt-contrib-compress": "^2.0.0",


### PR DESCRIPTION
## Background & Changes

Per #106, it seems there are no explicit definitions for which browsers are supported, be it in manual/documentation or automated form.

It just so happens that [Browserslist](https://github.com/browserslist/browserslist#browserslist-) allows doing exactly that, and can share these configurations among FE tools.

Given the fact that the project is [already](https://github.com/openseadragon/openseadragon/blob/master/.eslintrc.json) leveraging [ESLint](https://github.com/openseadragon/openseadragon/blob/master/package.json#L40) (and not using something like [`babel`](https://babeljs.io/)), I thought perhaps I'd propose adding this support via an ESLint plugin, [eslint-plugin-compat](https://github.com/amilajack/eslint-plugin-compat), which can leverage standard Browserslist configuration methods (as a section in `package.json`, or dedicated `.browserslistrc`, as proposed here)  

With this plugin added, running lint will also look for usages of unsupported ES features, based on the specified list of browsers. 

As an example, if I include IE 8 in the list of supported browsers (for test purposes), I see the following errors:

![image](https://user-images.githubusercontent.com/2937540/219873442-a861f174-5fe2-455b-bf51-fe389bdaec1d.png)

So, these changes would help introduce some further* automated controls for browser compatibility (so long as there is a `lint` step baked into the review/CI pipeline).

*with limitations -- see section below

## Details

### Defining supported browsers

For a list of browsers, I've gone with the 'defaults' query and added IE 11, since it is still expressly supported in OSD v4 (current at the time of creating the PR). My understanding after a couple readings of the discussion in #106 seem to indicate that this looks like it should cover those cases, but an important part of review would be to get feedback on that.

For more details on how to [create a 'query'](https://github.com/browserslist/browserslist#full-list), or even using [custom (GA) data](https://github.com/browserslist/browserslist#custom-usage-data), see the Browserslist documentation and [browsersl.ist](https://browsersl.ist/) for an interactive playground, including explanations.

### Documentation

The utility `browserslist` itself provides means of generating a list of compatible browsers, which could be useful for documentation purposes.

For instance, running [`npx browserslist`](https://github.com/browserslist/browserslist#debug) in the project directory will now generate a list of the supported browsers, which looks like this:
```bash
$ npx browserslist
and_chr 109
and_ff 109
and_qq 13.1
and_uc 13.4
android 109
chrome 110
chrome 109
chrome 108
edge 110
edge 109
edge 108
firefox 110
firefox 109
firefox 108
firefox 102
ie 11
ios_saf 16.3
ios_saf 16.2
ios_saf 16.1
ios_saf 16.0
ios_saf 15.6
ios_saf 14.5-14.8
kaios 2.5
op_mini all
op_mob 73
opera 95
opera 94
safari 16.3
safari 16.2
safari 15.6
samsung 19.0
samsung 18.0
```

(see [docs for further mappings](https://github.com/browserslist/browserslist#browsers))

Further, apply similar changes to previous versions might be helpful in [generating baselines for historical support](https://github.com/openseadragon/openseadragon/issues/106#issuecomment-1412818545) (insofar as this is more significant than IE versions) 

### Limitations

In order to allow ESLint to understand features such as `let` and `const`, I needed to change the `ecmaVersion` of `parserOptions` needs to ES 6 (would apply to more than just the use of this plugin). **As the plugin doesn't lint for features that [could be solved with transpilation (e.g. babel)](https://github.com/amilajack/eslint-plugin-compat/issues/393#issuecomment-677982265), this would complicate transitional/partial adoption, such as introducing ES 6 features like `let` and `const`, while guaranteeing we catch those unsupported in IE 11, like [arrow functions](https://caniuse.com/?search=arrow):**
- Either settings are changed to allow ES 6 parsing, and any gaps in feature support by IE 11 must continue to be manually enforced/reviewed for
- Or the de facto parsing standard would remain at ES 5 to have guaranteed (and 'overly cautious') detection of incompatible APIs until such time as IE 11 support is fully dropped

Beyond that, I didn't see a way to 'opt in' to features like `let` and `const`, while otherwise parsing at an ES 5 level. It seems it should be possible to enable ES 6, while disabling certain features (via further rules), but it will be prone to the same gaps as above, and would be need removed in the foreseeable future anyway, once the jump can be made to ES 6.

### Future Related Work

Note that the changes proposed here would be further supported by continuing/restarting work to run automated browser tests with a provider such as SauceLabs or similar (I found at least #250 and #1887), to verify compatibility more than statically (especially if allowing ES 6 parsing via ESLint prior to formally dropping IE 11 support).

In their current form, these changes wouldn't allow for differing 'tiers' in support ([a suggestion made in an earlier phase of discussion of #106 ](https://github.com/openseadragon/openseadragon/issues/106#issuecomment-18404897)), but it may be possible to do so by adjusting/swapping the config that is applied at lint time (if such requirements still relevant)