### PR TITLE
Update Travis to use latest Node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Specify dist until Travis CI default Runner OS updates to one
+# with glibc version required by newer Node versions
+# See: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+dist: focal
 language: node_js
 sudo: false
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Specify dist until Travis CI default Runner OS updates to one
 # with glibc version required by newer Node versions
 # See: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-dist: focal
+dist: jammy
 language: node_js
 sudo: false
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "16.14.2"
+  - lts/*
 before_install:
   - npm install -g grunt-cli


### PR DESCRIPTION
Update CI config to use the most recent LTS.

For some other possible values, see: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions

Closes #2305 