### PR TITLE
partial bugfix for #2312

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1962,6 +1962,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                         if (sketchScale) {
                             clipPoint = clipPoint.times(sketchScale);
                         }
+                        if (sketchTranslate) {
+                            clipPoint = clipPoint.plus(sketchTranslate);
+                        }
                         return clipPoint;
                     });
                 });


### PR DESCRIPTION
This PR fixes https://github.com/openseadragon/openseadragon/issues/2312 (in part), by fixing the translation problems caused by using the sketch canvas when composing tiles with cropping polygons enabled.

Note that blurring at the edges of the cropping polygons is not fixed, and will require refactoring the cropping operation to happen at the time of drawing onto the main canvas rather than when creating the sketch canvas.