### PR TITLE
Applied touch rotate fix suggested in #2319

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3422,7 +3422,8 @@ function onCanvasPinch( event ) {
                 event.gesturePoints[0].currentPos.x - event.gesturePoints[1].currentPos.x);
             var angle2 = Math.atan2(event.gesturePoints[0].lastPos.y - event.gesturePoints[1].lastPos.y,
                 event.gesturePoints[0].lastPos.x - event.gesturePoints[1].lastPos.x);
-            this.viewport.setRotation(this.viewport.getRotation() + ((angle1 - angle2) * (180 / Math.PI)));
+            centerPt = this.viewport.pointFromPixel( event.center, true );
+            this.viewport.rotateTo(this.viewport.getRotation(true) + ((angle1 - angle2) * (180 / Math.PI)), centerPt, true);
         }
     }
 }


### PR DESCRIPTION
This PR applies the fix proposed by @pearcetm in issue #2319. I can confirm the fix improves behavior __significantly__.  

Behavior isn't perfect. (If you pinch-rotate, say, in the bottom corner of the image, the rotation doesn't seem to be around the center of the gesture.) But the original problems I described in #2319 are gone.

Thanks for the help @percetm!
