### PR TITLE
Fix TileLoader re-trying even if successful #2

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -62,7 +62,7 @@ $.ImageJob = function(options) {
 
     /**
      * Data object which will contain downloaded image data.
-     * @member {Image|*} image data object, by default an Image object (depends on TileSource)
+     * @member {Image|*} data data object, by default an Image object (depends on TileSource)
      * @memberof OpenSeadragon.ImageJob#
      */
     this.data = null;
@@ -234,7 +234,7 @@ $.ImageLoader.prototype = {
  * @param callback - Called once cleanup is finished.
  */
 function completeJob(loader, job, callback) {
-    if (job.errorMsg !== '' && (job.image === null || job.image === undefined) && job.tries < 1 + loader.tileRetryMax) {
+    if (job.errorMsg !== '' && (job.data === null || job.data === undefined) && job.tries < 1 + loader.tileRetryMax) {
         loader.failedTiles.push(job);
     }
     var nextJob;

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1621,6 +1621,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             tile.loading = false;
             tile.exists = false;
             return;
+        } else {
+            tile.exists = true;
         }
 
         if ( time < this.lastResetTime ) {


### PR DESCRIPTION
Based on [PR-2287-Fix TileLoader re-trying even if successful](https://github.com/openseadragon/openseadragon/pull/2287)

Tested locally, however now errors appear in case of retry(that are logged in browser). The behaviour seems to work for retrying tiles though.