### PR TITLE
Add `setAjaxHeaders` method to Viewer and TiledImage

### DIFF
--- a/src/buttongroup.js
+++ b/src/buttongroup.js
@@ -115,7 +115,7 @@ $.ButtonGroup.prototype = {
     /**
      * Adds the given button to this button group.
      *
-     * @functions
+     * @function
      * @param {OpenSeadragon.Button} button
      */
     addButton: function( button ){

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1013,6 +1013,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * TODO
      */
     setAjaxHeaders: function(ajaxHeaders, propagate){
+        if (propagate === undefined) {
+            propagate = true;
+        }
 
         // use same headers if provided 'ajaxHeaders' is invalid (useful for propagation)
         if ($.isPlainObject(ajaxHeaders)) {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1012,23 +1012,30 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     /**
      * TODO
      */
-    setAjaxHeaders: function(ajaxHeaders, propagate){
+    setAjaxHeaders: function(ajaxHeaders, propagate) {
+        if (ajaxHeaders === null) {
+            ajaxHeaders = {};
+        }
+        if (!$.isPlainObject(ajaxHeaders)) {
+            console.error('[TiledImage.setAjaxHeaders] Ignoring invalid headers, must be a plain object');
+            return;
+        }
+
+        this._ownAjaxHeaders = ajaxHeaders;
+        this._updateAjaxHeaders(propagate);
+    },
+
+    // private
+    _updateAjaxHeaders: function(propagate) {
         if (propagate === undefined) {
             propagate = true;
         }
 
-        // use same headers if provided 'ajaxHeaders' is invalid (useful for propagation)
-        if ($.isPlainObject(ajaxHeaders)) {
-            this._ownAjaxHeaders = ajaxHeaders;
-        } else {
-            ajaxHeaders = this._ownAjaxHeaders;
-        }
-
         // merge with viewer's headers
         if ($.isPlainObject(this.viewer.ajaxHeaders)) {
-            this.ajaxHeaders = $.extend({}, this.viewer.ajaxHeaders, ajaxHeaders);
+            this.ajaxHeaders = $.extend({}, this.viewer.ajaxHeaders, this._ownAjaxHeaders);
         } else {
-            this.ajaxHeaders = ajaxHeaders;
+            this.ajaxHeaders = this._ownAjaxHeaders;
         }
 
         // propagate header updates to all tiles and queued imageloader jobs

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1010,7 +1010,18 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     },
 
     /**
-     * TODO
+     * Update headers to include when making AJAX requests.
+     *
+     * Unless `propagate` is set to false (which is likely only useful in rare circumstances),
+     * the updated headers are propagated to all tiles and queued image loader jobs.
+     *
+     * Note that the rules for merging headers still apply, i.e. headers returned by
+     * {@link OpenSeadragon.TileSource#getTileAjaxHeaders} take precedence over
+     * the headers here in the tiled image (`TiledImage.ajaxHeaders`).
+     *
+     * @function
+     * @param {Object} ajaxHeaders Updated AJAX headers, which will be merged over any headers specified in {@link OpenSeadragon.Options}.
+     * @param {Boolean} [propagate=true] Whether to propagate updated headers to existing tiles and queued image loader jobs.
      */
     setAjaxHeaders: function(ajaxHeaders, propagate) {
         if (ajaxHeaders === null) {
@@ -1022,11 +1033,24 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         }
 
         this._ownAjaxHeaders = ajaxHeaders;
-        this._updateAjaxHeaders(propagate);
+        this.updateAjaxHeaders(propagate);
     },
 
-    // private
-    _updateAjaxHeaders: function(propagate) {
+    /**
+     * Update headers to include when making AJAX requests.
+     *
+     * This function has the same effect as calling {@link OpenSeadragon.TiledImage#setAjaxHeaders},
+     * expect that the headers for this tiled image do not change. This is especially useful
+     * for propagating updated headers from {@link OpenSeadragon.TileSource#getTileAjaxHeaders}
+     * to existing tiles.
+     *
+     * Note that `TiledImage.ajaxHeaders` might still change if {@link OpenSeadragon.Viewer#setAjaxHeaders}
+     * was previously called without propagating the updated headers (not recommended).
+     *
+     * @function
+     * @param {Boolean} [propagate=true] Whether to propagate updated headers to existing tiles and queued image loader jobs.
+     */
+    updateAjaxHeaders: function(propagate) {
         if (propagate === undefined) {
             propagate = true;
         }
@@ -1038,7 +1062,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             this.ajaxHeaders = this._ownAjaxHeaders;
         }
 
-        // propagate header updates to all tiles and queued imageloader jobs
+        // propagate header updates to all tiles and queued image loader jobs
         if (propagate) {
             var numTiles, xMod, yMod, tile;
 
@@ -1063,8 +1087,6 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                 }
             }
 
-            // TODO: good enough? running jobs are not stored anywhere
-            //       maybe look through this._imageLoader.failedTiles and restart jobs? but which ones?
             for (var i = 0; i < this._imageLoader.jobQueue.length; i++) {
                 var job = this._imageLoader.jobQueue[i];
                 job.loadWithAjax = job.tile.loadWithAjax;

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1033,24 +1033,22 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         }
 
         this._ownAjaxHeaders = ajaxHeaders;
-        this.updateAjaxHeaders(propagate);
+        this._updateAjaxHeaders(propagate);
     },
 
     /**
      * Update headers to include when making AJAX requests.
      *
      * This function has the same effect as calling {@link OpenSeadragon.TiledImage#setAjaxHeaders},
-     * expect that the headers for this tiled image do not change. This is especially useful
+     * except that the headers for this tiled image do not change. This is especially useful
      * for propagating updated headers from {@link OpenSeadragon.TileSource#getTileAjaxHeaders}
      * to existing tiles.
      *
-     * Note that `TiledImage.ajaxHeaders` might still change if {@link OpenSeadragon.Viewer#setAjaxHeaders}
-     * was previously called without propagating the updated headers (not recommended).
-     *
+     * @private
      * @function
      * @param {Boolean} [propagate=true] Whether to propagate updated headers to existing tiles and queued image loader jobs.
      */
-    updateAjaxHeaders: function(propagate) {
+    _updateAjaxHeaders: function(propagate) {
         if (propagate === undefined) {
             propagate = true;
         }

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1030,19 +1030,21 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
 
         // propagate header updates to all tiles and queued imageloader jobs
         if (propagate) {
+            var numTiles, xMod, yMod, tile;
 
-            for (const [level, levelTiles] of Object.entries(this.tilesMatrix)) {
-                const numTiles = this.source.getNumTiles(level);
+            for (var level in this.tilesMatrix) {
+                numTiles = this.source.getNumTiles(level);
 
-                for (const [x, rowTiles] of Object.entries(levelTiles)) {
-                    const xMod = ( numTiles.x + ( x % numTiles.x ) ) % numTiles.x;
+                for (var x in this.tilesMatrix[level]) {
+                    xMod = ( numTiles.x + ( x % numTiles.x ) ) % numTiles.x;
 
-                    for (const [y, tile] of Object.entries(rowTiles)) {
-                        const yMod = ( numTiles.y + ( y % numTiles.y ) ) % numTiles.y;
+                    for (var y in this.tilesMatrix[level][x]) {
+                        yMod = ( numTiles.y + ( y % numTiles.y ) ) % numTiles.y;
+                        tile = this.tilesMatrix[level][x][y];
 
                         tile.loadWithAjax = this.loadTilesWithAjax;
                         if (tile.loadWithAjax) {
-                            const tileAjaxHeaders = this.source.getTileAjaxHeaders( level, xMod, yMod );
+                            var tileAjaxHeaders = this.source.getTileAjaxHeaders( level, xMod, yMod );
                             tile.ajaxHeaders = $.extend({}, this.ajaxHeaders, tileAjaxHeaders);
                         } else {
                             tile.ajaxHeaders = null;
@@ -1053,7 +1055,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
 
             // TODO: good enough? running jobs are not stored anywhere
             //       maybe look through this._imageLoader.failedTiles and restart jobs? but which ones?
-            for (const job of this._imageLoader.jobQueue) {
+            for (var i = 0; i < this._imageLoader.jobQueue.length; i++) {
+                var job = this._imageLoader.jobQueue[i];
                 job.loadWithAjax = job.tile.loadWithAjax;
                 job.ajaxHeaders = job.tile.loadWithAjax ? job.tile.ajaxHeaders : null;
             }

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -663,6 +663,10 @@ $.TileSource.prototype = {
      * The headers returned here will override headers specified at the Viewer or TiledImage level.
      * Specifying a falsy value for a header will clear its existing value set at the Viewer or
      * TiledImage level (if any).
+     *
+     * Note that the headers of existing tiles don't automatically change when this function
+     * returns updated headers. To do that, you need to call {@link OpenSeadragon.TiledImage#updateAjaxHeaders}.
+     *
      * @function
      * @param {Number} level
      * @param {Number} x

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -665,7 +665,8 @@ $.TileSource.prototype = {
      * TiledImage level (if any).
      *
      * Note that the headers of existing tiles don't automatically change when this function
-     * returns updated headers. To do that, you need to call {@link OpenSeadragon.TiledImage#updateAjaxHeaders}.
+     * returns updated headers. To do that, you need to call {@link OpenSeadragon.Viewer#setAjaxHeaders}
+     * and propagate the changes.
      *
      * @function
      * @param {Number} level

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1010,7 +1010,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
         if (propagate) {
             for (var i = 0; i < this.world.getItemCount(); i++) {
-                this.world.getItemAt(i).updateAjaxHeaders(true);
+                this.world.getItemAt(i)._updateAjaxHeaders(true);
             }
 
             if (this.navigator) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -982,6 +982,10 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * TODO
      */
     setAjaxHeaders: function(ajaxHeaders, propagate){
+        if (propagate === undefined) {
+            propagate = true;
+        }
+
         if ($.isPlainObject(ajaxHeaders)) {
             this.ajaxHeaders = ajaxHeaders;
         }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -966,7 +966,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * Turns debugging mode on or off for this viewer.
      *
      * @function
-     * @param {Boolean} true to turn debug on, false to turn debug off.
+     * @param {Boolean} debugMode true to turn debug on, false to turn debug off.
      */
     setDebugMode: function(debugMode){
 
@@ -1015,7 +1015,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     /**
      * Adds the given button to this viewer.
      *
-     * @functions
+     * @function
      * @param {OpenSeadragon.Button} button
      */
     addButton: function( button ){

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -981,18 +981,23 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     /**
      * TODO
      */
-    setAjaxHeaders: function(ajaxHeaders, propagate){
+    setAjaxHeaders: function(ajaxHeaders, propagate) {
+        if (ajaxHeaders === null) {
+            ajaxHeaders = {};
+        }
+        if (!$.isPlainObject(ajaxHeaders)) {
+            console.error('[Viewer.setAjaxHeaders] Ignoring invalid headers, must be a plain object');
+            return;
+        }
         if (propagate === undefined) {
             propagate = true;
         }
 
-        if ($.isPlainObject(ajaxHeaders)) {
-            this.ajaxHeaders = ajaxHeaders;
-        }
+        this.ajaxHeaders = ajaxHeaders;
 
         if (propagate) {
             for (var i = 0; i < this.world.getItemCount(); i++) {
-                this.world.getItemAt(i).setAjaxHeaders(null, true);
+                this.world.getItemAt(i)._updateAjaxHeaders(true);
             }
 
             if (this.referenceStrip && this.referenceStrip.miniViewers) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -992,12 +992,12 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
         if (propagate) {
             for (var i = 0; i < this.world.getItemCount(); i++) {
-                this.world.getItemAt(i).setAjaxHeaders(null, propagate);
+                this.world.getItemAt(i).setAjaxHeaders(null, true);
             }
 
             if (this.referenceStrip && this.referenceStrip.miniViewers) {
                 for (var key in this.referenceStrip.miniViewers) {
-                    this.referenceStrip.miniViewers[key].setAjaxHeaders(this.ajaxHeaders, propagate);
+                    this.referenceStrip.miniViewers[key].setAjaxHeaders(this.ajaxHeaders, true);
                 }
             }
         }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -979,6 +979,21 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     },
 
     /**
+     * TODO
+     */
+    setAjaxHeaders: function(ajaxHeaders, propagate){
+        if ($.isPlainObject(ajaxHeaders)) {
+            this.ajaxHeaders = ajaxHeaders;
+        }
+
+        if (propagate) {
+            for (var i = 0; i < this.world.getItemCount(); i++) {
+                this.world.getItemAt(i).setAjaxHeaders(null, propagate);
+            }
+        }
+    },
+
+    /**
      * Adds the given button to this viewer.
      *
      * @functions
@@ -1401,7 +1416,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * @param {Object} [options.ajaxHeaders]
      *      A set of headers to include when making tile AJAX requests.
      *      Note that these headers will be merged over any headers specified in {@link OpenSeadragon.Options}.
-     *      Specifying a falsy value for a header will clear its existing value set at the Viewer level (if any).
+     *      Is this outdated? -> Specifying a falsy value for a header will clear its existing value set at the Viewer level (if any).
      * requests.
      * @param {Function} [options.success] A function that gets called when the image is
      * successfully added. It's passed the event object which contains a single property:
@@ -1450,10 +1465,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         if (options.loadTilesWithAjax === undefined) {
             options.loadTilesWithAjax = this.loadTilesWithAjax;
         }
-        if (options.ajaxHeaders === undefined || options.ajaxHeaders === null) {
-            options.ajaxHeaders = this.ajaxHeaders;
-        } else if ($.isPlainObject(options.ajaxHeaders) && $.isPlainObject(this.ajaxHeaders)) {
-            options.ajaxHeaders = $.extend({}, this.ajaxHeaders, options.ajaxHeaders);
+        if (!$.isPlainObject(options.ajaxHeaders)) {
+            options.ajaxHeaders = {};
         }
 
         var myQueueItem = {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -979,7 +979,20 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     },
 
     /**
-     * TODO
+     * Update headers to include when making AJAX requests.
+     *
+     * Unless `propagate` is set to false (which is likely only useful in rare circumstances),
+     * the updated headers are propagated to all tiled images, each of which will subsequently
+     * propagate the changed headers to all their tiles.
+     * If applicable, the headers of the viewer's navigator and reference strip will also be updated.
+     *
+     * Note that the rules for merging headers still apply, i.e. headers returned by
+     * {@link OpenSeadragon.TileSource#getTileAjaxHeaders} take precedence over
+     * `TiledImage.ajaxHeaders`, which take precedence over the headers here in the viewer.
+     *
+     * @function
+     * @param {Object} ajaxHeaders Updated AJAX headers.
+     * @param {Boolean} [propagate=true] Whether to propagate updated headers to tiled images, etc.
      */
     setAjaxHeaders: function(ajaxHeaders, propagate) {
         if (ajaxHeaders === null) {
@@ -1435,7 +1448,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * @param {Object} [options.ajaxHeaders]
      *      A set of headers to include when making tile AJAX requests.
      *      Note that these headers will be merged over any headers specified in {@link OpenSeadragon.Options}.
-     * requests.
+     *      Specifying a falsy value for a header will clear its existing value set at the Viewer level (if any).
      * @param {Function} [options.success] A function that gets called when the image is
      * successfully added. It's passed the event object which contains a single property:
      * "item", which is the resulting instance of TiledImage.

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -990,6 +990,12 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             for (var i = 0; i < this.world.getItemCount(); i++) {
                 this.world.getItemAt(i).setAjaxHeaders(null, propagate);
             }
+
+            if (this.referenceStrip && this.referenceStrip.miniViewers) {
+                for (var key in this.referenceStrip.miniViewers) {
+                    this.referenceStrip.miniViewers[key].setAjaxHeaders(this.ajaxHeaders, propagate);
+                }
+            }
         }
     },
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -997,7 +997,11 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
         if (propagate) {
             for (var i = 0; i < this.world.getItemCount(); i++) {
-                this.world.getItemAt(i)._updateAjaxHeaders(true);
+                this.world.getItemAt(i).updateAjaxHeaders(true);
+            }
+
+            if (this.navigator) {
+                this.navigator.setAjaxHeaders(this.ajaxHeaders, true);
             }
 
             if (this.referenceStrip && this.referenceStrip.miniViewers) {
@@ -1431,7 +1435,6 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * @param {Object} [options.ajaxHeaders]
      *      A set of headers to include when making tile AJAX requests.
      *      Note that these headers will be merged over any headers specified in {@link OpenSeadragon.Options}.
-     *      Is this outdated? -> Specifying a falsy value for a header will clear its existing value set at the Viewer level (if any).
      * requests.
      * @param {Function} [options.success] A function that gets called when the image is
      * successfully added. It's passed the event object which contains a single property:

--- a/test/modules/ajax-tiles.js
+++ b/test/modules/ajax-tiles.js
@@ -306,7 +306,7 @@
         viewer.open(customTileSource);
     });
 
-    QUnit.test('TileImage headers can be updated', function(assert) {
+    QUnit.test('TiledImage headers can be updated', function(assert) {
         var done = assert.async();
 
         var tileSourceHeaders = {

--- a/test/modules/ajax-tiles.js
+++ b/test/modules/ajax-tiles.js
@@ -346,7 +346,7 @@
             assert.deepEqual(evt.tiledImage.ajaxHeaders, OpenSeadragon.extend({}, viewer.ajaxHeaders, newHeaders2));
             assert.deepEqual(evt.tile.ajaxHeaders, OpenSeadragon.extend({}, viewer.ajaxHeaders, newHeaders2, tileSourceHeaders));
             // set new TiledImage headers but do not propagate to Tile
-            evt.tiledImage.setAjaxHeaders({}, false);
+            evt.tiledImage.setAjaxHeaders(null, false);
             viewer.addHandler('tile-loaded', tileLoaded4);
         };
 

--- a/test/modules/ajax-tiles.js
+++ b/test/modules/ajax-tiles.js
@@ -245,4 +245,130 @@
             tileSource: staticHeaderTileSource
         });
     });
+
+    QUnit.test('Viewer headers can be updated', function(assert) {
+        var done = assert.async();
+
+        var newHeaders = {
+            'X-Viewer-Header': 'ViewerHeaderValue-Updated',
+            'X-Viewer-Header2': 'ViewerHeaderValue2'
+        }
+        var newHeaders2 = {
+            Range: 'test',
+        }
+
+        var tileLoaded = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded);
+            // set new Viewer headers and propagate to TiledImage and Tile
+            viewer.setAjaxHeaders(newHeaders);
+            viewer.addHandler('tile-loaded', tileLoaded2);
+        };
+
+        var tileLoaded2 = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded2);
+            assert.deepEqual(viewer.ajaxHeaders, newHeaders);
+            assert.deepEqual(evt.tiledImage.ajaxHeaders, newHeaders);
+            assert.deepEqual(
+                evt.tile.ajaxHeaders,
+                OpenSeadragon.extend(
+                    {}, viewer.ajaxHeaders, evt.tiledImage.ajaxHeaders,
+                    { Range: getTileRangeHeader(evt.tile.level, evt.tile.x, evt.tile.y) }
+                )
+            );
+            // set new Viewer headers and propagate to TiledImage and Tile
+            viewer.setAjaxHeaders(newHeaders2, true);
+            viewer.addHandler('tile-loaded', tileLoaded3);
+        };
+
+        var tileLoaded3 = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded3);
+            assert.deepEqual(viewer.ajaxHeaders, newHeaders2);
+            assert.deepEqual(evt.tiledImage.ajaxHeaders, newHeaders2);
+            assert.equal(evt.tile.ajaxHeaders['X-Viewer-Header'], undefined);
+            assert.equal(evt.tile.ajaxHeaders['X-Viewer-Header2'], undefined);
+            // 'Range' header entry set per tile and must not be overwritten by Viewer header
+            assert.equal(evt.tile.ajaxHeaders.Range, getTileRangeHeader(evt.tile.level, evt.tile.x, evt.tile.y));
+            // set new Viewer headers but do not propagate to TiledImage and Tile
+            viewer.setAjaxHeaders(newHeaders, false);
+            viewer.addHandler('tile-loaded', tileLoaded4);
+        };
+
+        var tileLoaded4 = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded4);
+            assert.deepEqual(viewer.ajaxHeaders, newHeaders);
+            assert.deepEqual(evt.tiledImage.ajaxHeaders, newHeaders2);
+            assert.equal(evt.tile.ajaxHeaders['X-Viewer-Header'], undefined);
+            assert.equal(evt.tile.ajaxHeaders['X-Viewer-Header2'], undefined);
+            done();
+        };
+
+        viewer.addHandler('tile-loaded', tileLoaded);
+        viewer.open(customTileSource);
+    });
+
+    QUnit.test('TileImage headers can be updated', function(assert) {
+        var done = assert.async();
+
+        var tileSourceHeaders = {
+            'X-Tile-Header': 'TileHeaderValue'
+        }
+        var newHeaders = {
+            'X-TiledImage-Header': 'TiledImageHeaderValue-Updated',
+            'X-TiledImage-Header2': 'TiledImageHeaderValue2'
+        }
+        var newHeaders2 = {
+            'X-Viewer-Header': 'ViewerHeaderValue-Updated',
+            'X-Tile-Header': 'TileHeaderValue-Updated'
+        }
+
+        var tileLoaded = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded);
+            // set new TiledImage headers and propagate to Tile
+            evt.tiledImage.setAjaxHeaders(newHeaders);
+            viewer.addHandler('tile-loaded', tileLoaded2);
+        };
+
+        var tileLoaded2 = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded2);
+            assert.deepEqual(viewer.ajaxHeaders, { 'X-Viewer-Header': 'ViewerHeaderValue' });
+            assert.deepEqual(evt.tiledImage._ownAjaxHeaders, newHeaders);
+            assert.deepEqual(evt.tiledImage.ajaxHeaders, OpenSeadragon.extend({}, viewer.ajaxHeaders, newHeaders));
+            assert.deepEqual(evt.tile.ajaxHeaders, OpenSeadragon.extend({}, viewer.ajaxHeaders, newHeaders, tileSourceHeaders));
+            // set new TiledImage headers (that overwrite header entries of Viewer and Tile) and propagate to Tile
+            evt.tiledImage.setAjaxHeaders(newHeaders2, true);
+            viewer.addHandler('tile-loaded', tileLoaded3);
+        };
+
+        var tileLoaded3 = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded3);
+            assert.deepEqual(viewer.ajaxHeaders, { 'X-Viewer-Header': 'ViewerHeaderValue' });
+            assert.deepEqual(evt.tiledImage._ownAjaxHeaders, newHeaders2);
+            assert.deepEqual(evt.tiledImage.ajaxHeaders, OpenSeadragon.extend({}, viewer.ajaxHeaders, newHeaders2));
+            assert.deepEqual(evt.tile.ajaxHeaders, OpenSeadragon.extend({}, viewer.ajaxHeaders, newHeaders2, tileSourceHeaders));
+            // set new TiledImage headers but do not propagate to Tile
+            evt.tiledImage.setAjaxHeaders({}, false);
+            viewer.addHandler('tile-loaded', tileLoaded4);
+        };
+
+        var tileLoaded4 = function tileLoaded(evt) {
+            viewer.removeHandler('tile-loaded', tileLoaded4);
+            assert.deepEqual(viewer.ajaxHeaders, { 'X-Viewer-Header': 'ViewerHeaderValue' });
+            assert.deepEqual(evt.tiledImage._ownAjaxHeaders, {});
+            assert.deepEqual(evt.tiledImage.ajaxHeaders, viewer.ajaxHeaders);
+            assert.deepEqual(evt.tile.ajaxHeaders, OpenSeadragon.extend({}, viewer.ajaxHeaders, newHeaders2, tileSourceHeaders));
+            done();
+        };
+
+        viewer.addHandler('tile-loaded', tileLoaded);
+        viewer.addTiledImage({
+            ajaxHeaders: {
+                'X-TiledImage-Header': 'TiledImageHeaderValue'
+            },
+            tileSource: OpenSeadragon.extend({}, customTileSource, {
+                getTileAjaxHeaders: function() {
+                    return tileSourceHeaders;
+                }
+            }),
+        });
+    });
 })();


### PR DESCRIPTION
See #1748 for background.

- ~~I haven't yet tested this at all.~~
- There is a breaking change for those who directly use `new TiledImage(...)` (instead of the recommended `Viewer.open(...)` or `Viewer.addTiledImage(...)`) **and** set `ajaxHeaders` options for both `Viewer` and `TiledImage`. Previously, `new TiledImage(options)` didn't merge `options.ajaxHeaders` with `Viewer.ajaxHeaders`, but now it does.