### PR TITLE
Added navigator's region rotation

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -224,8 +224,6 @@ $.Navigator = function( options ){
     this.displayRegionContainer.appendChild(this.displayRegion);
     this.element.getElementsByTagName('div')[0].appendChild(this.displayRegionContainer);
 
-    this._navigatorRotate = options.navigatorRotate;
-
     function rotate(degrees, immediately) {
         _setTransformRotate(_this.displayRegionContainer, degrees);
         _setTransformRotate(_this.displayRegion, -degrees);
@@ -399,7 +397,7 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
             bottomright = this.viewport.pixelFromPointNoRotate(bounds.getBottomRight(), false)
                 .minus( this.totalBorderWidths );
 
-            if (!this._navigatorRotate) {
+            if (!this.navigatorRotate) {
                 var degrees = viewport.getRotation(true);
                 _setTransformRotate(this.displayRegion, -degrees);
             }

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -224,6 +224,8 @@ $.Navigator = function( options ){
     this.displayRegionContainer.appendChild(this.displayRegion);
     this.element.getElementsByTagName('div')[0].appendChild(this.displayRegionContainer);
 
+    this._navigatorRotate = options.navigatorRotate;
+
     function rotate(degrees, immediately) {
         _setTransformRotate(_this.displayRegionContainer, degrees);
         _setTransformRotate(_this.displayRegion, -degrees);
@@ -396,6 +398,11 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
             topleft     = this.viewport.pixelFromPointNoRotate(bounds.getTopLeft(), false);
             bottomright = this.viewport.pixelFromPointNoRotate(bounds.getBottomRight(), false)
                 .minus( this.totalBorderWidths );
+
+            if (!this._navigatorRotate) {
+                var degrees = viewport.getRotation(true);
+                _setTransformRotate(this.displayRegion, -degrees);
+            }
 
             //update style for navigator-box
             var style = this.displayRegion.style;

--- a/test/demo/rotating-navigator-region.html
+++ b/test/demo/rotating-navigator-region.html
@@ -20,7 +20,6 @@
     </div>
     <div id="contentDiv" class="openseadragon1"></div>
     <script type="text/javascript">
-
         var viewer = OpenSeadragon({
             // debugMode: true,
             id: "contentDiv",
@@ -29,6 +28,7 @@
             showNavigator: true,
             navigatorRotate: false
         });
+        viewer.viewport.setRotation(45)
     </script>
 </body>
 </html>

--- a/test/demo/rotating-navigator-region.html
+++ b/test/demo/rotating-navigator-region.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OpenSeadragon Basic Demo</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+    <style type="text/css">
+
+        .openseadragon1 {
+            width: 800px;
+            height: 600px;
+        }
+
+    </style>
+</head>
+<body>
+    <div>
+        Simple demo page. The navigator region is expected to rotate when the image is rotated.
+        The default behaviour is to keep the region still as the image below it rotates.
+    </div>
+    <div id="contentDiv" class="openseadragon1"></div>
+    <script type="text/javascript">
+
+        var viewer = OpenSeadragon({
+            // debugMode: true,
+            id: "contentDiv",
+            prefixUrl: "../../build/openseadragon/images/",
+            tileSources: "../data/testpattern.dzi",
+            showNavigator: true,
+            navigatorRotate: false
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
As discussed in https://github.com/openseadragon/openseadragon/issues/2353, when the `navigatorRotate` option is set to `false`, rotate the navigator's region accordigly to the image rotation.