### PR TITLE
Allow Using ES6 Syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,11 +6,11 @@
         "plugin:compat/recommended"
     ],
     "env": {
-        "es6": false,
+        "es6": true,
         "browser": true
     },
     "parserOptions": {
-        "ecmaVersion": 5,
+        "ecmaVersion": 6,
         "sourceType": "script",
         "ecmaFeatures": {
             "globalReturn": false,


### PR DESCRIPTION
Given that #2286 has been marked as resolved, and IE 11 support is no longer an official requirement, I thought perhaps it was time to (formally) allow 'New' JavaScript in OSD.

To this end, I've bumped ESLint's parser options to support ES6 syntax, which allows developers to start using a number of [features](http://es6-features.org/#Constants) associated with modern JavaScript. A few that might be useful here would include:
- [Arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
- [Template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#string_interpolation)
- [Enhanced object literals](https://blog.webdevsimplified.com/2021-02/javascript-enhanced-object-literals/)
- [Classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_Classes) (!)
- [The newer incarnations of modules in general](https://ui.dev/javascript-modules-iifes-commonjs-esmodules) (!)

Note that this PR just adjusts the settings that allow the newer syntax, and includes no further changes or refactorings. My thinking was that then developers could begin (slowly) incorporating code with the modern syntax into their changes/PRs, and more wide-reaching refactorings (potentially needing coordination) could be implemented at a later time (e.g. #2299).

#### Before/After:

Before this changes, the linter would not allow (couldn't parse) code like this:
```javascript
    // ...
    fullScreenApi.requestFullScreen = function( element ) {
        const impl = "W3C Standard";
        return element.requestFullscreen().then(() => {
            console.info(`Fullscreen request succeeded for: ${impl}!`);
        });
    };
    // ...
```

After these changes it runs to completion with no errors.
