### PR TITLE
workaround tile edge smoothing maxZoom + flip

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1965,7 +1965,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             imageZoom > this.smoothTileEdgesMinZoom &&
             !this.iOSDevice &&
             this.getRotation(true) % 360 === 0 && // TODO: support tile edge smoothing with tiled image rotation.
-            this._drawer.viewer.viewport.getFlip() === false && // TODO: support tile edge smoothing with tiled image flip.
+            this._drawer.viewer.viewport.getFlip() === false && // TODO: support tile edge smoothing with viewport flip.
             $.supportsCanvas && this.viewer.useCanvas) {
             // When zoomed in a lot (>100%) the tile edges are visible.
             // So we have to composite them at ~100% and scale them up together.

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1964,8 +1964,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         if (lastDrawn.length > 1 &&
             imageZoom > this.smoothTileEdgesMinZoom &&
             !this.iOSDevice &&
-            this.getRotation(true) % 360 === 0 && // TODO: support tile edge smoothing with tiled image rotation.
-            this._drawer.viewer.viewport.getFlip() === false && // TODO: support tile edge smoothing with viewport flip.
+            this.getRotation(true) % 360 === 0 && // TODO: support tile edge smoothing with tiled image rotation (viewport rotation is not a problem).
+            this._drawer.viewer.viewport.getFlip() === false && // TODO: support tile edge smoothing with viewport flip (tiled image flip is not a problem).
             $.supportsCanvas && this.viewer.useCanvas) {
             // When zoomed in a lot (>100%) the tile edges are visible.
             // So we have to composite them at ~100% and scale them up together.

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1965,6 +1965,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             imageZoom > this.smoothTileEdgesMinZoom &&
             !this.iOSDevice &&
             this.getRotation(true) % 360 === 0 && // TODO: support tile edge smoothing with tiled image rotation.
+            this._drawer.viewer.viewport.getFlip() === false && // TODO: support tile edge smoothing with tiled image flip.
             $.supportsCanvas && this.viewer.useCanvas) {
             // When zoomed in a lot (>100%) the tile edges are visible.
             // So we have to composite them at ~100% and scale them up together.


### PR DESCRIPTION
## related to issue #1900 

Currently, if I zoom too much in the image there is a feature to smooth the tile edge for prettier rendering. However, if the image is flipped, it disables the flip and the image seems to flip by itself on zoom.

An identified workaround is to set the option `smoothTileEdgesMinZoom` to `infinity`. It works fine but it disable totally the tile edge smoothing feature.

The idea is to disable the tile edge smoothing feature if the image is flipped, in order to avoid this unwelcome flip when zooming too much.

The same workaround has been implemented in the past for the rotated images.

I did not succeed to run this modified source on an example project, so I didn't test it. However I've implemented the same fix in the OSD version I use locally for my project (v2.4) and it worked without visible side effect.

@mainteners Can you please take a look to ensure there is no regression with this contribution ?