### PR TITLE
Fix #2454, add webp to supported image formats

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2607,7 +2607,8 @@ function OpenSeadragon( options ){
          *      jpg:  true,
          *      png:  true,
          *      tif:  false,
-         *      wdp:  false
+         *      wdp:  false,
+         *      webp: true
          * }
          * </code></pre>
          * @function
@@ -2673,7 +2674,8 @@ function OpenSeadragon( options ){
             jpg:  true,
             png:  true,
             tif:  false,
-            wdp:  false
+            wdp:  false,
+            webp: true
         },
         URLPARAMS = {};
 

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -2613,8 +2613,8 @@ function OpenSeadragon( options ){
          * </code></pre>
          * @function
          * @example
-         * // sets webp as supported and png as unsupported
-         * setImageFormatsSupported({webp: true, png: false});
+         * // sets bmp as supported and png as unsupported
+         * setImageFormatsSupported({bmp: true, png: false});
          * @param {Object} formats An object containing format extensions as
          * keys and booleans as values.
          */


### PR DESCRIPTION
This PR adds webp to the default image formats supported.