### PR TITLE
Fix zero opacity case

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -102,7 +102,7 @@ class CanvasDrawer extends $.DrawerBase{
         this._prepareNewFrame(); // prepare to draw a new frame
 
         for(const tiledImage of tiledImages){
-            if (tiledImage.opacity !== 0 || tiledImage._preload) {
+            if (tiledImage.opacity !== 0) {
                 this._drawTiles(tiledImage);
             }
         }

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -89,7 +89,7 @@ class HTMLDrawer extends $.DrawerBase{
         var _this = this;
         this._prepareNewFrame(); // prepare to draw a new frame
         tiledImages.forEach(function(tiledImage){
-            if (tiledImage.opacity !== 0 || tiledImage._preload) {
+            if (tiledImage.opacity !== 0) {
                 _this._drawTiles(tiledImage);
             }
         });

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1434,7 +1434,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         let lowestLevel = tiles.length ? tiles[0].level : 0;
 
         let drawArea = this.getDrawArea();
-        if(!drawArea || this._opacity === 0){
+        if(!drawArea || (this._opacity === 0 && !this._preload)){
             return;
         }
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1020,8 +1020,13 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     /**
      * Get the region of this tiled image that falls within the viewport.
      * @returns {OpenSeadragon.Rect} the region of this tiled image that falls within the viewport.
+     * Returns false for images with opacity==0 unless preload==true
      */
     getDrawArea: function(){
+
+        if( this._opacity === 0 && !this._preload){
+            return false;
+        }
 
         var drawArea = this._viewportToTiledImageRectangle(
             this.viewport.getBoundsWithMargins(true));
@@ -1434,7 +1439,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         let lowestLevel = tiles.length ? tiles[0].level : 0;
 
         let drawArea = this.getDrawArea();
-        if(!drawArea || (this._opacity === 0 && !this._preload)){
+        if(!drawArea){
             return;
         }
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1434,7 +1434,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         let lowestLevel = tiles.length ? tiles[0].level : 0;
 
         let drawArea = this.getDrawArea();
-        if(!drawArea){
+        if(!drawArea || this._opacity === 0){
             return;
         }
 

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -222,7 +222,7 @@
 
                 let tilesToDraw = tiledImage.getTilesToDraw();
 
-                if(tilesToDraw.length === 0){
+                if(tilesToDraw.length === 0 || tiledImage.getOpacity() === 0){
                     return;
                 }
                 let firstTile = tilesToDraw[0];

--- a/test/demo/drawercomparison.js
+++ b/test/demo/drawercomparison.js
@@ -1,5 +1,5 @@
 const sources = {
-    "rainbow":"../data/testpattern.dzi",
+    "rainbow": "../data/testpattern.dzi",
     "leaves":"../data/iiif_2_0_sizes/info.json",
     "bblue":{
         type:'image',

--- a/test/demo/drawercomparison.js
+++ b/test/demo/drawercomparison.js
@@ -1,5 +1,5 @@
 const sources = {
-    "rainbow": "../data/testpattern.dzi",
+    "rainbow":"../data/testpattern.dzi",
     "leaves":"../data/iiif_2_0_sizes/info.json",
     "bblue":{
         type:'image',


### PR DESCRIPTION
This fix checks a `TiledImage` for the case that `opacity === 0` and where `_preload` is false and aborts the tile updates if so, which stops tiles from being loaded for a fully transparent layer. Will fix the undesirable behavior described in https://github.com/openseadragon/openseadragon/issues/2461