### PR TITLE
Fix `this` scoping

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1456,7 +1456,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                     lowestLevel
                 );
                 _this._isBlending = _this._isBlending || tileIsBlending;
-                _this._needsDraw = _this._needsDraw || tileIsBlending || this._wasBlending;
+                _this._needsDraw = _this._needsDraw || tileIsBlending || _this._wasBlending;
             }
         }
 

--- a/src/world.js
+++ b/src/world.js
@@ -261,7 +261,7 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
     draw: function() {
         this.viewer.drawer.draw(this._items);
         this._needsDraw = false;
-        this._items.forEach(function(item){
+        this._items.forEach((item) => {
             this._needsDraw = item.setDrawn() || this._needsDraw;
         });
     },


### PR DESCRIPTION
While testing the WebGL renderer we ran into a couple of places where `this` scoping was being lost.  With these changes, after a rebuild it seemed to work okay.