### PR TITLE
Support placeholderFillStyle in WebGLDrawer, and other fixes

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -402,9 +402,7 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
 
             this._drawRectangle(placeholderRect, fillStyle, useSketch);
         }
-        if(!window.draw){
-            lastDrawn = [];
-        }
+
         var subPixelRoundingRule = determineSubPixelRoundingRule(tiledImage.subPixelRoundingForTransparency);
 
         var shouldRoundPositionAndSize = false;

--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -382,9 +382,9 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
             }
             usedClip = true;
         }
-
+        tiledImage._hasOpaqueTile = false;
         if ( tiledImage.placeholderFillStyle && tiledImage._hasOpaqueTile === false ) {
-            var placeholderRect = this.viewportToDrawerRectangle(tiledImage.getBounds(true));
+            let placeholderRect = this.viewportToDrawerRectangle(tiledImage.getBoundsNoRotate(true));
             if (sketchScale) {
                 placeholderRect = placeholderRect.times(sketchScale);
             }
@@ -392,7 +392,7 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
                 placeholderRect = placeholderRect.translate(sketchTranslate);
             }
 
-            var fillStyle = null;
+            let fillStyle = null;
             if ( typeof tiledImage.placeholderFillStyle === "function" ) {
                 fillStyle = tiledImage.placeholderFillStyle(tiledImage, this.context);
             }
@@ -402,7 +402,9 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
 
             this._drawRectangle(placeholderRect, fillStyle, useSketch);
         }
-
+        if(!window.draw){
+            lastDrawn = [];
+        }
         var subPixelRoundingRule = determineSubPixelRoundingRule(tiledImage.subPixelRoundingForTransparency);
 
         var shouldRoundPositionAndSize = false;

--- a/src/spring.js
+++ b/src/spring.js
@@ -212,7 +212,7 @@ $.Spring.prototype = {
     update: function() {
         this.current.time  = $.now();
 
-        var startValue, targetValue;
+        let startValue, targetValue;
         if (this._exponential) {
             startValue = this.start._logValue;
             targetValue = this.target._logValue;
@@ -221,23 +221,25 @@ $.Spring.prototype = {
             targetValue = this.target.value;
         }
 
-        var currentValue = (this.current.time >= this.target.time) ?
-            targetValue :
-            startValue +
-                ( targetValue - startValue ) *
-                transform(
-                    this.springStiffness,
-                    ( this.current.time - this.start.time ) /
-                    ( this.target.time - this.start.time )
-                );
-
-        if (this._exponential) {
-            this.current.value = Math.exp(currentValue);
+        if(this.current.time >= this.target.time){
+            this.current.value = this.target.value;
         } else {
-            this.current.value = currentValue;
+            let currentValue = startValue +
+                    ( targetValue - startValue ) *
+                    transform(
+                        this.springStiffness,
+                        ( this.current.time - this.start.time ) /
+                        ( this.target.time - this.start.time )
+                    );
+
+            if (this._exponential) {
+                this.current.value = Math.exp(currentValue);
+            } else {
+                this.current.value = currentValue;
+            }
         }
 
-        return currentValue !== targetValue;
+        return this.current.value !== this.target.value;
     },
 
     /**

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -239,6 +239,10 @@
 
                 let tilesToDraw = tiledImage.getTilesToDraw();
 
+                if ( tiledImage.placeholderFillStyle && tiledImage._hasOpaqueTile === false ) {
+                     this._drawPlaceholder(tiledImage);
+                }
+
                 if(tilesToDraw.length === 0 || tiledImage.getOpacity() === 0){
                     return;
                 }
@@ -1075,6 +1079,30 @@
             }
 
             context.restore();
+        }
+
+        _drawPlaceholder(tiledImage){
+
+            const bounds = tiledImage.getBounds(true);
+            const rect = this.viewportToDrawerRectangle(tiledImage.getBounds(true));
+            const context = this._outputContext;
+
+            let fillStyle;
+            if ( typeof tiledImage.placeholderFillStyle === "function" ) {
+                fillStyle = tiledImage.placeholderFillStyle(tiledImage, context);
+            }
+            else {
+                fillStyle = tiledImage.placeholderFillStyle;
+            }
+
+            context.save();
+            context.fillStyle = fillStyle;
+            context.translate(rect.x, rect.y);
+            context.rotate(Math.PI / 180 * bounds.degrees);
+            context.translate(-rect.x, -rect.y);
+            context.fillRect(rect.x, rect.y, rect.width, rect.height);
+            context.restore();
+
         }
 
         // private

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -242,7 +242,10 @@
                 if ( tiledImage.placeholderFillStyle && tiledImage._hasOpaqueTile === false ) {
                      this._drawPlaceholder(tiledImage);
                 }
-
+                this._drawPlaceholder(tiledImage);
+                if(!window.draw){
+                    return;
+                }
                 if(tilesToDraw.length === 0 || tiledImage.getOpacity() === 0){
                     return;
                 }
@@ -1095,13 +1098,13 @@
                 fillStyle = tiledImage.placeholderFillStyle;
             }
 
-            context.save();
+            this._offsetForRotation({degrees: this.viewer.viewport.getRotation(true)});
             context.fillStyle = fillStyle;
             context.translate(rect.x, rect.y);
             context.rotate(Math.PI / 180 * bounds.degrees);
             context.translate(-rect.x, -rect.y);
             context.fillRect(rect.x, rect.y, rect.width, rect.height);
-            context.restore();
+            this._restoreRotationChanges();
 
         }
 

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -242,10 +242,7 @@
                 if ( tiledImage.placeholderFillStyle && tiledImage._hasOpaqueTile === false ) {
                      this._drawPlaceholder(tiledImage);
                 }
-                this._drawPlaceholder(tiledImage);
-                if(!window.draw){
-                    return;
-                }
+
                 if(tilesToDraw.length === 0 || tiledImage.getOpacity() === 0){
                     return;
                 }

--- a/test/demo/tilesource-swap.html
+++ b/test/demo/tilesource-swap.html
@@ -32,17 +32,18 @@
                 type: 'legacy-image-pyramid',
                 levels: [
                     {
-                        url: 'http://openseadragon.github.io/example-images/duomo/duomo_files/8/0_0.jpg',
+                        url: 'https://openseadragon.github.io/example-images/duomo/duomo_files/8/0_0.jpg',
                         width: 218,
                         height: 160
                     }
-                ]
+                ],
+                degrees: 30,
             };
 
             var duomo = {
                 Image: {
                     xmlns: 'http://schemas.microsoft.com/deepzoom/2008',
-                    Url: 'http://openseadragon.github.io/example-images/duomo/duomo_files/',
+                    Url: 'https://openseadragon.github.io/example-images/duomo/duomo_files/',
                     Format: 'jpg',
                     Overlap: '2',
                     TileSize: '256',
@@ -59,10 +60,11 @@
                 tileSources: duomoStandin,
                 minZoomImageRatio: 0.1,
                 defaultZoomLevel: 0.1,
-                zoomPerClick: 1
+                zoomPerClick: 1,
+                crossOriginPolicy: 'Anonymous'
             });
 
-            viewer.addHandler('canvas-click', function(event) {
+            viewer.addOnceHandler('canvas-click', function(event) {
                 if (event.quick) {
                     var standin = viewer.world.getItemAt(0);
                     var standinBounds = standin.getBounds();
@@ -76,13 +78,10 @@
                         index: 0, // Add the new image below the stand-in.
                         success: function(event) {
                             var fullImage = event.item;
-
-                            // The changeover will look better if we wait for the first tile to be drawn.
+                            // The changeover will look better if we wait for the first draw after the changeover.
                             var tileDrawnHandler = function(event) {
-                                if (event.tiledImage === fullImage) {
                                     viewer.removeHandler('update-viewport', tileDrawnHandler);
                                     viewer.world.removeItem(standin);
-                                }
                             };
 
                             viewer.addHandler('update-viewport', tileDrawnHandler);

--- a/test/demo/tilesource-swap.html
+++ b/test/demo/tilesource-swap.html
@@ -64,8 +64,10 @@
                 crossOriginPolicy: 'Anonymous'
             });
 
-            viewer.addOnceHandler('canvas-click', function(event) {
-                if (event.quick) {
+            let swapped = false;
+            viewer.addHandler('canvas-click', function(event) {
+                if (event.quick && !swapped) {
+                    swapped = true;
                     var standin = viewer.world.getItemAt(0);
                     var standinBounds = standin.getBounds();
                     viewer.viewport.fitBounds(standinBounds);


### PR DESCRIPTION
This PR lets the WebGLDrawer honor the `placeholderFillStyle` property for images that haven't loaded yet. In my testing it works with rotated images too - rotating the viewer with `viewer.viewport.setRotation()`, rotating a `TiledImage` individually, and both rotations in combination. This will fix https://github.com/openseadragon/openseadragon/issues/2465.

In my testing I noticed that the `CanvasDrawer` implementation (which wasn't changed during the webgl patch) doesn't appear to work correctly in some circumstances, such as when a `TiledImage` has rotation set on it. ~~I haven't tracked this down further, but it should probably be its own issue.~~ This is fixed by using `getBoundsNoRotate` instead of just `getBounds`.

While debugging to get the `placeholderFillStyle` support working, I figured out why we kept running into floating point issues during the CI tests. The springs weren't settling on their target values sometimes no matter how long the animation ran. Turns out that in exponential mode, the value was updated by a pair of floating point math calls which would leave the spring just a hair shy of its target perpetually. I changed it to just use the target value directly if the time exceeds target time, which fixes this problem - springs should now always end at their target value.

Finally, I noticed that the `tilesource-swap` demo wasn't working with the new `WebGLDrawer` because of tainted canvas issues. I added `crossOriginPolicy: 'Anonymous'` to the viewer config, which fixes the problem.