### PR TITLE
In webgl drawer, fall back to canvas drawer for tiled images with tainted data

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -139,6 +139,7 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         this.canvas.height = 1;
         this.sketchCanvas = null;
         this.sketchContext = null;
+        this.container.removeChild(this.canvas);
     }
 
     /**

--- a/src/drawerbase.js
+++ b/src/drawerbase.js
@@ -280,6 +280,37 @@ OpenSeadragon.DrawerBase = class DrawerBase{
         });
     }
 
+    /**
+     * Called by implementations to fire the drawer-error event
+     * @private
+     */
+    _raiseDrawerErrorEvent(tiledImage, errorMessage){
+        if(!this.viewer) {
+            return;
+        }
+
+        /**
+        *  Raised when a tiled image is drawn to the canvas. Used internally for testing.
+        *  The update-viewport event is preferred if you want to know when a frame has been drawn.
+        *
+        * @event drawer-error
+        * @memberof OpenSeadragon.Viewer
+        * @type {object}
+        * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+        * @property {OpenSeadragon.TiledImage} tiledImage - Which TiledImage is being drawn.
+        * @property {OpenSeadragon.DrawerBase} drawer - The drawer that raised the error.
+        * @property {String} error - A message describing the error.
+        * @property {?Object} userData - Arbitrary subscriber-defined object.
+        * @private
+        */
+        this.viewer.raiseEvent( 'drawer-error', {
+            tiledImage: tiledImage,
+            drawer: this,
+            error: errorMessage,
+        });
+    }
+
+
 };
 
 }( OpenSeadragon ));

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -126,7 +126,7 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
      * Destroy the drawer (unload current loaded tiles)
      */
     destroy() {
-        this.canvas.innerHTML = "";
+        this.container.removeChild(this.canvas);
     }
 
     /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -166,6 +166,7 @@ $.TiledImage = function( options ) {
         _lastDrawn:     [],    // array of tiles that were last fetched by the drawer
         _isBlending:    false, // Are any tiles still being blended?
         _wasBlending:   false, // Were any tiles blending before the last draw?
+        _isTainted:     false, // Has a Tile been found with tainted data?
         //configurable settings
         springStiffness:                   $.DEFAULT_SETTINGS.springStiffness,
         animationTime:                     $.DEFAULT_SETTINGS.animationTime,
@@ -324,6 +325,25 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
     setDrawn: function(){
         this._needsDraw = this._isBlending || this._wasBlending;
         return this._needsDraw;
+    },
+
+    /**
+     * Set the internal _isTainted flag for this TiledImage. Lazy loaded - not
+     * checked each time a Tile is loaded, but can be set if a consumer of the
+     * tiles (e.g. a Drawer) discovers a Tile to have tainted data so that further
+     * checks are not needed and alternative rendering strategies can be used.
+     * @private
+     */
+    setTainted(isTainted){
+        this._isTainted = isTainted;
+    },
+
+    /**
+     * @private
+     * @returns {Boolean} whether the TiledImage has been marked as tainted
+     */
+    isTainted(){
+        return this._isTainted;
     },
 
     /**

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -456,7 +456,7 @@ $.Viewer = function( options ) {
 
     this.drawer = null;
     for (const drawerCandidate of drawerCandidates){
-        let success = this.requestDrawer(drawerCandidate, true, false);
+        let success = this.requestDrawer(drawerCandidate, {mainDrawer: true, redrawImmediately: false});
         if(success){
             break;
         }
@@ -931,13 +931,24 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     /**
      * Request a drawer for this viewer, as a supported string or drawer constructor.
      * @param {String | OpenSeadragon.DrawerBase} drawerCandidate The type of drawer to try to construct.
-     * @param { Boolean } [mainDrawer] Whether to use this as the viewer's main drawer. Default = true.
-     * @param { Boolean } [redrawImmediately] Whether to immediately draw a new frame. Only used if mainDrawer = true. Default = true.
-     * @param { Object } [drawerOptions] Options for this drawer. If falsey, defaults to viewer.drawerOptions
+     * @param { Object } options
+     * @param { Boolean } [options.mainDrawer] Whether to use this as the viewer's main drawer. Default = true.
+     * @param { Boolean } [options.redrawImmediately] Whether to immediately draw a new frame. Only used if options.mainDrawer = true. Default = true.
+     * @param { Object } [options.drawerOptions] Options for this drawer. Defaults to viewer.drawerOptions.
      * for this viewer type. See {@link OpenSeadragon.Options}.
-     * @returns {Object | Boolean} The drawer that was created, or false if the requestd drawer is not supported
+     * @returns {Object | Boolean} The drawer that was created, or false if the requested drawer is not supported
      */
-    requestDrawer(drawerCandidate, mainDrawer = true, redrawImmediately = true, drawerOptions = null){
+    requestDrawer(drawerCandidate, options){
+        const defaultOpts = {
+            mainDrawer: true,
+            redrawImmediately: true,
+            drawerOptions: null
+        };
+        options = $.extend(true, defaultOpts, options);
+        const mainDrawer = options.mainDrawer;
+        const redrawImmediately = options.redrawImmediately;
+        const drawerOptions = options.drawerOptions;
+
         const oldDrawer = this.drawer;
 
         let Drawer = null;

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -231,7 +231,7 @@
          */
         _getBackupCanvasDrawer(){
             if(!this._backupCanvasDrawer){
-                this._backupCanvasDrawer = this.viewer.requestDrawer('canvas', false);
+                this._backupCanvasDrawer = this.viewer.requestDrawer('canvas', {mainDrawer: false});
                 this._backupCanvasDrawer.canvas.style.setProperty('visibility', 'hidden');
             }
 

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -93,8 +93,10 @@
             this._backupCanvasDrawer = null;
 
             // Add listeners for events that require modifying the scene or camera
-            this.viewer.addHandler("tile-ready", ev => this._tileReadyHandler(ev));
-            this.viewer.addHandler("image-unloaded", ev => this._imageUnloadedHandler(ev));
+            this._boundToTileReady = ev => this._tileReadyHandler(ev);
+            this._boundToImageUnloaded = ev => this._imageUnloadedHandler(ev);
+            this.viewer.addHandler("tile-ready", this._boundToTileReady);
+            this.viewer.addHandler("image-unloaded", this._boundToImageUnloaded);
 
             // Reject listening for the tile-drawing and tile-drawn events, which this drawer does not fire
             this.viewer.rejectEventHandler("tile-drawn", "The WebGLDrawer does not raise the tile-drawn event");
@@ -154,6 +156,10 @@
             if(ext){
                 ext.loseContext();
             }
+
+            // unbind our event listeners from the viewer
+            this.viewer.removeHandler("tile-ready", this._boundToTileReady);
+            this.viewer.removeHandler("image-unloaded", this._boundToImageUnloaded);
 
             // set our webgl context reference to null to enable garbage collection
             this._gl = null;

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -231,11 +231,7 @@
          */
         _getBackupCanvasDrawer(){
             if(!this._backupCanvasDrawer){
-                this._backupCanvasDrawer = new $.CanvasDrawer({
-                    viewer: this.viewer,
-                    viewport: this.viewport,
-                    element: this.container,
-                });
+                this._backupCanvasDrawer = this.viewer.requestDrawer('canvas', false);
                 this._backupCanvasDrawer.canvas.style.setProperty('visibility', 'hidden');
             }
 
@@ -882,6 +878,7 @@
                 if(!wasTainted){
                     tiledImage.setTainted(true);
                     $.console.warn('WebGL cannot be used to draw this TiledImage because it has tainted data. Does crossOriginPolicy need to be set?');
+                    this._raiseDrawerErrorEvent(tiledImage, 'Tainted data cannot be used by the WebGLDrawer. Falling back to CanvasDrawer for this TiledImage.');
                 }
                 return;
             }

--- a/test/demo/drawercomparison.js
+++ b/test/demo/drawercomparison.js
@@ -49,7 +49,7 @@ let viewer2 = window.viewer2 = OpenSeadragon({
     minZoomImageRatio:0.01,
     maxZoomPixelRatio:100,
     smoothTileEdgesMinZoom:1.1,
-    // crossOriginPolicy: 'Anonymous',
+    crossOriginPolicy: 'Anonymous',
     ajaxWithCredentials: false,
     // maxImageCacheCount: 30,
     drawer:drawer2,

--- a/test/demo/drawercomparison.js
+++ b/test/demo/drawercomparison.js
@@ -49,7 +49,7 @@ let viewer2 = window.viewer2 = OpenSeadragon({
     minZoomImageRatio:0.01,
     maxZoomPixelRatio:100,
     smoothTileEdgesMinZoom:1.1,
-    crossOriginPolicy: 'Anonymous',
+    // crossOriginPolicy: 'Anonymous',
     ajaxWithCredentials: false,
     // maxImageCacheCount: 30,
     drawer:drawer2,


### PR DESCRIPTION
Displaying images from cross-origin sources that don't have CORS enabled because of viewer config (or server settings, I guess) is a problem for the new `WebGLDrawer` - tainted data cannot be uploaded to `WebGL`. See https://github.com/openseadragon/openseadragon/issues/2470 for example.

This PR adds the ability for the `WebGLDrawer` to detect and lazily instantiate a hidden `CanvasDrawer` to use for `TiledImage`s that have tainted data. The `WebGLDrawer` will still draw any images it can, and both tainted and non-tainted images can be rendered in the same viewer. When this happens, a warning message is logged to the console.

To test, visit the `drawercomparison` demo. In the source, comment out `crossOriginPolicy` for the viewer with `drawer: 'webgl'` here:
https://github.com/openseadragon/openseadragon/blob/f7d86ac244826416d3090fbef86968f17fc40fe8/test/demo/drawercomparison.js#L52
Toggle on the Duomo image (which is cross-origin), and a `CanvasDrawer` will be created and used for rendering specifically this image.
