### PR TITLE
Fix error when opening a tiled image - highest zoom level could not be determined

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1299,13 +1299,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             ))
         );
 
-        if (!highestLevel) {
-            highestLevel = 0;
-        }
-
         // Calculations for the interval of levels to draw
         // can return invalid intervals; fix that here if necessary
-        highestLevel = Math.max(highestLevel, this.source.minLevel || 0);
+        highestLevel = Math.max(highestLevel || 0, this.source.minLevel || 0);
         lowestLevel = Math.min(lowestLevel, highestLevel);
         return {
             lowestLevel: lowestLevel,

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1299,6 +1299,10 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             ))
         );
 
+        if (!highestLevel) {
+            highestLevel = 0;
+        }
+
         // Calculations for the interval of levels to draw
         // can return invalid intervals; fix that here if necessary
         highestLevel = Math.max(highestLevel, this.source.minLevel || 0);


### PR DESCRIPTION
In our configuration while loading a tiled image the following error was thrown. This happen when OSD was loading the first tiled image.

```
global-error-handler.service.ts:15 RangeError: Invalid array length
    at __webpack_modules__.7446.$.TiledImage._updateLevelsForViewport (openseadragon.js:25539:1)
    at __webpack_modules__.7446.$.TiledImage.update (openseadragon.js:24507:1)
    at __webpack_modules__.7446.$.World.update (openseadragon.js:27064:1)
    at updateOnce (openseadragon.js:11711:1)
    at updateMulti (openseadragon.js:11655:1)
    at openseadragon.js:10687:1
```
	
	
Reason for that is that the highest level could not be determinded (its NaN) in _updateLevelsForViewport that is calculated in _getLevelsInterval. 


this.source
```
{
    "_levelRects": {},
    "tilesUrl": "/api/service/curie/v1/tile/5fce4ecc5a7633115825923d/dzi_files/",
    "fileFormat": "png",
    "displayRects": [],
    "events": {},
    "_rejectedEventList": {},
    "width": 3916,
    "height": 3918,
    "tileOverlap": 0,
    "minLevel": 0,
    "maxLevel": 12,
    "Image": {
        "xmlns": "http://schemas.microsoft.com/deepzoom/2008",
        "Url": null,
        "Format": "png",
        "DisplayRect": null,
        "Overlap": 0,
        "TileSize": 256,
        "Size": {
            "Height": 3918,
            "Width": 3916
        }
    },
    "queryParams": "",
    "ajaxWithCredentials": false,
    "ready": true,
    "aspectRatio": 0.9994895354772844,
    "dimensions": {
        "x": 3916,
        "y": 3918
    },
    "_tileHeight": 256,
    "_tileWidth": 256
}
```
currentZeroRatio  -564.8212461695608
this.minPixelRatio  0.5