### PR TITLE
Getter & setter for Viewport.maxZoomPixelRatio

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1789,7 +1789,43 @@ $.Viewport.prototype = {
        */
       this.viewer.raiseEvent('flip', {flipped: state});
       return this;
-    }
+    },
+
+    /**
+     * Gets current max zoom pixel ratio
+     * @function
+     * @returns {Number} Max zoom pixel ratio
+     */
+    getMaxZoomPixelRatio: function() {
+        return this.maxZoomPixelRatio;
+    },
+
+    /**
+     * Sets max zoom pixel ratio
+     * @function
+     * @param {Number} ratio - Max zoom pixel ratio
+     * @param {Boolean} [constraints=false] - Apply constraints after setting ratio;
+     * Takes effect only if current zoom is greater than set max zoom pixel ratio
+     * @param {Boolean} [immediately=false] - Whether to animate to new zoom
+     */
+    setMaxZoomPixelRatio: function(ratio, constraints, immediately) {
+        constraints = constraints || false;
+        immediately = immediately || false;
+
+        $.console.assert(!isNaN(ratio), "[Viewport.setMaxZoomPixelRatio] ratio must be a number");
+
+        if (isNaN(ratio)) {
+            return;
+        }
+
+        this.maxZoomPixelRatio = ratio;
+
+        if (constraints) {
+            if (this.getZoom() > this.getMaxZoom()) {
+                this.applyConstraints(immediately);
+            }
+        }
+    },
 
 };
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1804,13 +1804,11 @@ $.Viewport.prototype = {
      * Sets max zoom pixel ratio
      * @function
      * @param {Number} ratio - Max zoom pixel ratio
-     * @param {Boolean} [constraints=false] - Apply constraints after setting ratio;
+     * @param {Boolean} [applyConstraints=true] - Apply constraints after setting ratio;
      * Takes effect only if current zoom is greater than set max zoom pixel ratio
      * @param {Boolean} [immediately=false] - Whether to animate to new zoom
      */
-    setMaxZoomPixelRatio: function(ratio, constraints, immediately) {
-        constraints = constraints || false;
-        immediately = immediately || false;
+    setMaxZoomPixelRatio: function(ratio, applyConstraints = true, immediately = false) {
 
         $.console.assert(!isNaN(ratio), "[Viewport.setMaxZoomPixelRatio] ratio must be a number");
 
@@ -1820,7 +1818,7 @@ $.Viewport.prototype = {
 
         this.maxZoomPixelRatio = ratio;
 
-        if (constraints) {
+        if (applyConstraints) {
             if (this.getZoom() > this.getMaxZoom()) {
                 this.applyConstraints(immediately);
             }

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -1407,4 +1407,25 @@
       viewer.open(DZI_PATH);
     });
 
+    QUnit.test('setMaxZoomPixelRatio', function(assert) {
+      var done = assert.async();
+      var openHandler = function(event) {
+          viewer.removeHandler('open', openHandler);
+          var viewport = viewer.viewport;
+
+          for (var i = 0; i < testZoomLevels.length; i++) {
+              viewport.setMaxZoomPixelRatio(testZoomLevels[i])
+              assert.equal(viewport.getMaxZoomPixelRatio(), testZoomLevels[i], "Max zoom pixel ratio is set correctly.");
+          }
+
+          viewport.zoomTo(viewport.getMaxZoom())
+          viewport.setMaxZoomPixelRatio(testZoomLevels[0], true)
+          assert.equal(viewport.getZoom(), viewport.getMaxZoom(), "Zoom should be adjusted to max zoom level.");
+
+          done();
+      };
+      viewer.addHandler('open', openHandler);
+      viewer.open(DZI_PATH);
+    });
+
 })();


### PR DESCRIPTION
resolves #1359 
added getter & setter for maxZoomPixelRatio

I have included applyConstraints in the setter to adjust the zoom level if the new max ratio results in a smaller zoom level. Is this intuitive enough?