### PR TITLE
fix(citation): Fixed style issues for citation.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,7 @@ authors:
     description: Homepage
   - type: url
     value: 'https://github.com/openseadragon/openseadragon'
-    description: "Repository"
+    description: Repository
 repository-code: 'https://github.com/openseadragon/openseadragon'
 url: 'https://openseadragon.github.io/'
 abstract: "An open-source, web-based viewer for high-resolution zoomable images, implemented in pure JavaScript, for desktop and mobile."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,33 +1,30 @@
-# This CITATION.cff file was generated with cffinit.
-# Visit https://bit.ly/cffinit to generate yours today!
-
 cff-version: 1.2.0
 title: OpenSeadragon
 message: "If you use this software, please cite it using the metadata from this file."
 type: software
 authors:
-  - given-names: "Ian"
-    family-names: "Gilman"
-    email: "ian@iangilman.com"
-  - given-names: "Aseem"
-    family-names: "Kishore"
-  - given-names: "Chris"
-    family-names: "Thatcher"
-  - given-names: "Mark"
-    family-names: "Salsbery"
-  - given-names: "Antoine"
-    family-names: "Vandecreme"
-  - given-names:  "Thomas"
-    family-names: "Pearce"
- identifiers:
+  - given-names: Ian
+    family-names: Gilman
+    email: ian@iangilman.com
+  - given-names: Aseem
+    family-names: Kishore
+  - given-names: Chris
+    family-names: Thatcher
+  - given-names: Mark
+    family-names: Salsbery
+  - given-names: Antoine
+    family-names: Vandecreme
+  - given-names: Thomas
+    family-names: Pearce
+identifiers:
   - type: url
-    value: 'https://openseadragon.github.io/'
+    value: https://openseadragon.github.io/
     description: Homepage
   - type: url
-    value: 'https://github.com/openseadragon/openseadragon'
+    value: https://github.com/openseadragon/openseadragon
     description: Repository
-repository-code: 'https://github.com/openseadragon/openseadragon'
-url: 'https://openseadragon.github.io/'
+repository-code: https://github.com/openseadragon/openseadragon
+url: https://openseadragon.github.io/
 abstract: "An open-source, web-based viewer for high-resolution zoomable images, implemented in pure JavaScript, for desktop and mobile."
 keywords:
   - javascript
@@ -39,4 +36,4 @@ keywords:
   - iiif
 license: BSD-3-Clause
 version: 4.1.1
-date-released: '2024-04-01'
+date-released: 2024-04-01

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,37 +3,32 @@
 
 cff-version: 1.2.0
 title: OpenSeadragon
-message: >-
-  If you use this software, please cite it using the
-  metadata from this file.
+message: "If you use this software, please cite it using the metadata from this file."
 type: software
 authors:
-  - given-names: Ian
-    family-names: Gilman
-    email: ian@iangilman.com
-  - given-names: Aseem
-    family-names: Kishore
-  - given-names: Chris
-    family-names: Thatcher
-  - given-names: Mark
-    family-names: Salsbery
-  - given-names: Antoine
-    family-names: Vandecreme
-  - given-names:  Thomas
-    family-names: Pearce
+  - given-names: "Ian"
+    family-names: "Gilman"
+    email: "ian@iangilman.com"
+  - given-names: "Aseem"
+    family-names: "Kishore"
+  - given-names: "Chris"
+    family-names: "Thatcher"
+  - given-names: "Mark"
+    family-names: "Salsbery"
+  - given-names: "Antoine"
+    family-names: "Vandecreme"
+  - given-names:  "Thomas"
+    family-names: "Pearce"
  identifiers:
   - type: url
     value: 'https://openseadragon.github.io/'
     description: Homepage
   - type: url
     value: 'https://github.com/openseadragon/openseadragon'
-    description: Repository
+    description: "Repository"
 repository-code: 'https://github.com/openseadragon/openseadragon'
 url: 'https://openseadragon.github.io/'
-abstract: >-
-  An open-source, web-based viewer for high-resolution
-  zoomable images, implemented in pure JavaScript, for
-  desktop and mobile.
+abstract: "An open-source, web-based viewer for high-resolution zoomable images, implemented in pure JavaScript, for desktop and mobile."
 keywords:
   - javascript
   - image


### PR DESCRIPTION
Hello,

This pull request will fix the current citation.cff file in order to allow direct copy-paste APA and Bibtex style citation.

How it is right now:
![image](https://github.com/openseadragon/openseadragon/assets/78832141/c77db97a-60b3-449e-a174-f19c1a887e31)

This is what the fix will look like:
![image](https://github.com/openseadragon/openseadragon/assets/78832141/eaeea3cc-d6ec-4672-bd90-c1474793af69)


Thanks! For more info about citation please read #2509 