### PR TITLE
Fix #2517

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -80,8 +80,6 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         // Canvas default is "true", so this will only be changed if user specifies "false" in the options or via setImageSmoothinEnabled.
         this._imageSmoothingEnabled = true;
 
-        this._viewportFlipped = false;
-
         // Since the tile-drawn and tile-drawing events are fired by this drawer, make sure handlers can be added for them
         this.viewer.allowEventHandler("tile-drawn");
         this.viewer.allowEventHandler("tile-drawing");
@@ -118,8 +116,8 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         this._prepareNewFrame(); // prepare to draw a new frame
         if(this.viewer.viewport.getFlip() !== this._viewportFlipped){
             this._flip();
-            this._viewportFlipped = !this._viewportFlipped;
         }
+        console.log('draw', this._viewportFlipped);
         for(const tiledImage of tiledImages){
             if (tiledImage.opacity !== 0) {
                 this._drawTiles(tiledImage);
@@ -187,6 +185,10 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         );
 
         context.restore();
+    }
+
+    get _viewportFlipped(){
+        return this.context.getTransform().a < 0;
     }
 
     /**
@@ -961,6 +963,7 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         context.translate(point.x, 0);
         context.scale(-1, 1);
         context.translate(-point.x, 0);
+        console.log('flipped');
     }
 
     // private

--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -117,7 +117,6 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         if(this.viewer.viewport.getFlip() !== this._viewportFlipped){
             this._flip();
         }
-        console.log('draw', this._viewportFlipped);
         for(const tiledImage of tiledImages){
             if (tiledImage.opacity !== 0) {
                 this._drawTiles(tiledImage);
@@ -187,6 +186,10 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         context.restore();
     }
 
+    /**
+     * Test whether the current context is flipped or not
+     * @private
+     */
     get _viewportFlipped(){
         return this.context.getTransform().a < 0;
     }
@@ -963,7 +966,6 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
         context.translate(point.x, 0);
         context.scale(-1, 1);
         context.translate(-point.x, 0);
-        console.log('flipped');
     }
 
     // private


### PR DESCRIPTION
As noted in https://github.com/openseadragon/openseadragon/issues/2517, resizing a `canvas`-based viewer while the viewport is flipped is buggy. This is because resizing the canvas itself resets the context2d, so the internal `_viewportFlipped` flag gets out of sync with the actual state of the canvas.

I first tried adding an event handler for the `resize` event and resetting the flag there. This led to a different sort of buggy behavior because sometimes that event gets fired but the canvas context isn't reset. (I'm not entirely sure why, or if it is platform dependent. I'm using Chrome in MacOS.)

To do this more reliably, I switched from manually keeping a flag to reading this directly from the state of the Context2d transform matrix. In my testing it is working reliably now.