### PR TITLE
Fix #2519

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -143,10 +143,12 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
     }
 
     /**
+     * @param {TiledImage} tiledImage the tiled image that is calling the function
      * @returns {Boolean} Whether this drawer requires enforcing minimum tile overlap to avoid showing seams.
+     * @private
      */
-    minimumOverlapRequired() {
-       return true;
+    minimumOverlapRequired(tiledImage) {
+        return true;
     }
 
 

--- a/src/drawerbase.js
+++ b/src/drawerbase.js
@@ -141,12 +141,13 @@ OpenSeadragon.DrawerBase = class DrawerBase{
     }
 
     /**
+     * @param {TiledImage} tiledImage the tiled image that is calling the function
      * @returns {Boolean} Whether this drawer requires enforcing minimum tile overlap to avoid showing seams.
      * @private
      */
-    minimumOverlapRequired() {
+    minimumOverlapRequired(tiledImage) {
         return false;
-     }
+    }
 
 
     /**

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -86,11 +86,13 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
     }
 
     /**
+     * @param {TiledImage} tiledImage the tiled image that is calling the function
      * @returns {Boolean} Whether this drawer requires enforcing minimum tile overlap to avoid showing seams.
+     * @private
      */
-    minimumOverlapRequired() {
+    minimumOverlapRequired(tiledImage) {
         return true;
-     }
+    }
 
     /**
      * create the HTML element (e.g. canvas, div) that the image will be drawn into

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1706,7 +1706,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             tileCenter = positionT.plus( sizeT.divide( 2 ) ),
             tileSquaredDistance = viewportCenter.squaredDistanceTo( tileCenter );
 
-        if(this.viewer.drawer.minimumOverlapRequired()){
+        if(this.viewer.drawer.minimumOverlapRequired(this)){
             if ( !overlap ) {
                 sizeC = sizeC.plus( new $.Point(1, 1));
             }

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -211,6 +211,16 @@
         }
 
         /**
+         * @param {TiledImage} tiledImage the tiled image that is calling the function
+         * @returns {Boolean} Whether this drawer requires enforcing minimum tile overlap to avoid showing seams.
+         * @private
+         */
+        minimumOverlapRequired(tiledImage) {
+            // return true if the tiled image is tainted, since the backup canvas drawer will be used.
+            return tiledImage.isTainted();
+        }
+
+        /**
         * create the HTML element (canvas in this case) that the image will be drawn into
         * @private
         * @returns {Element} the canvas to draw into


### PR DESCRIPTION
When the `webgl` drawer falls back to `canvas` for tainted data from servers without CORS enabled, seams can appear if the tile source doesn't have overlap (https://github.com/openseadragon/openseadragon/issues/2519).

This PR fixes the issue by requiring minimum overlap specifically for tainted images when using `drawer: 'webgl'`. Checking this for individual `TiledImage`s allows this to work correctly even if a mix of non-tainted and tainted sources are opened within the same viewer.