### PR TITLE
Fix Ajax headers not propagated to navigator

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -517,6 +517,7 @@ $.Viewer = function( options ) {
             drawer:            this.drawer.getType(),
             loadTilesWithAjax: this.loadTilesWithAjax,
             ajaxHeaders:       this.ajaxHeaders,
+            ajaxWithCredentials: this.ajaxWithCredentials,
         });
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -515,6 +515,8 @@ $.Viewer = function( options ) {
             crossOriginPolicy: this.crossOriginPolicy,
             animationTime:     this.animationTime,
             drawer:            this.drawer.getType(),
+            loadTilesWithAjax: this.loadTilesWithAjax,
+            ajaxHeaders:       this.ajaxHeaders,
         });
     }
 


### PR DESCRIPTION
fixes #2502

simple fix to propagate ajax headers to navigator

I noticed that `setAjaxHeaders` already propagates the headers using an argument, as seen here
https://github.com/eug-L/openseadragon/blob/834ed6ede5d35d8a06ddcc51d216b3e2453da65a/src/viewer.js#L1126