### PR TITLE
Fixed: Invert overlay scale and rotate on flip

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -230,8 +230,10 @@
   * @property {Boolean} [flipped=false]
   *     Initial flip state.
   *
-  * @property {Boolean} [overlayContentFlipped=false]
-  *     Initial overlay content flip state.
+  * @property {Boolean} [overlayFlipReversal=true]
+  *     When the viewport is flipped (by pressing 'f'), the overlay is flipped using ScaleX.
+  *     Normally, this setting (default true) keeps the overlay's content readable by flipping it back.
+  *     To make the content flip with the overlay, set overlayFlipReversal to false.
   *
   * @property {Number} [minZoomLevel=null]
   *
@@ -1340,7 +1342,7 @@ function OpenSeadragon( options ){
 
             // INITIAL FLIP STATE
             flipped:                    false,
-            overlayContentFlipped:      false,
+            overlayFlipReversal:        true,
 
             // APPEARANCE
             opacity:                           1,

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -230,10 +230,10 @@
   * @property {Boolean} [flipped=false]
   *     Initial flip state.
   *
-  * @property {Boolean} [overlayFlipReversal=true]
+  * @property {Boolean} [overlayPreserveContentDirection=true]
   *     When the viewport is flipped (by pressing 'f'), the overlay is flipped using ScaleX.
   *     Normally, this setting (default true) keeps the overlay's content readable by flipping it back.
-  *     To make the content flip with the overlay, set overlayFlipReversal to false.
+  *     To make the content flip with the overlay, set overlayPreserveContentDirection to false.
   *
   * @property {Number} [minZoomLevel=null]
   *
@@ -1341,8 +1341,8 @@ function OpenSeadragon( options ){
             degrees:                    0,
 
             // INITIAL FLIP STATE
-            flipped:                    false,
-            overlayFlipReversal:        true,
+            flipped:                          false,
+            overlayPreserveContentDirection:  true,
 
             // APPEARANCE
             opacity:                           1,

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -230,6 +230,9 @@
   * @property {Boolean} [flipped=false]
   *     Initial flip state.
   *
+  * @property {Boolean} [overlayContentFlipped=false]
+  *     Initial overlay content flip state.
+  *
   * @property {Number} [minZoomLevel=null]
   *
   * @property {Number} [maxZoomLevel=null]
@@ -1337,6 +1340,7 @@ function OpenSeadragon( options ){
 
             // INITIAL FLIP STATE
             flipped:                    false,
+            overlayContentFlipped:      false,
 
             // APPEARANCE
             opacity:                           1,

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -2,7 +2,7 @@
  * OpenSeadragon - Overlay
  *
  * Copyright (C) 2009 CodePlex Foundation
- * Copyright (C) 2010-2023 OpenSeadragon contributors
+ * Copyright (C) 2010-2024 OpenSeadragon contributors
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -242,6 +242,9 @@
          */
         drawHTML: function(container, viewport) {
             var element = this.element;
+            var text = document.createElement('div');
+            text.textContent = element.textContent;
+            element.textContent = "";
             if (element.parentNode !== container) {
                 //save the source parent for later if we need it
                 element.prevElementParent = element.parentNode;
@@ -274,6 +277,7 @@
                 this.onDraw(position, size, this.element);
             } else {
                 var style = this.style;
+                var textStyle = text.style;
                 style.left = position.x + "px";
                 style.top = position.y + "px";
                 if (this.width !== null) {
@@ -291,9 +295,11 @@
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = "rotate(" + rotate + "deg)";
                     } else if (!rotate && viewport.flipped) {
+                        textStyle[transformProp] = "scaleX(-1)";
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = scale;
                     } else if (rotate && viewport.flipped){
+                        textStyle[transformProp] = "scaleX(-1)";
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = "rotate(" + rotate + "deg)" + scale;
                     } else {
@@ -302,6 +308,7 @@
                     }
                 }
                 style.display = 'block';
+                element.appendChild(text);
             }
         },
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -129,6 +129,7 @@
         }
 
         this.element = options.element;
+        this.element.innerHTML = "<div>" + this.element.innerHTML + "</div>";
         this.style = options.element.style;
         this._init(options);
     };
@@ -242,9 +243,6 @@
          */
         drawHTML: function(container, viewport) {
             var element = this.element;
-            var text = document.createElement('div');
-            text.textContent = element.textContent;
-            element.textContent = "";
             if (element.parentNode !== container) {
                 //save the source parent for later if we need it
                 element.prevElementParent = element.parentNode;
@@ -257,27 +255,23 @@
                 // least one direction when this.checkResize is set to false.
                 this.size = $.getElementSize(element);
             }
-
             var positionAndSize = this._getOverlayPositionAndSize(viewport);
-
             var position = positionAndSize.position;
             var size = this.size = positionAndSize.size;
-            var rotate;
-            var scale = "";
-            if (viewport.flipped){
-                rotate = -positionAndSize.rotate;
-                scale = " scaleX(-1)";
+            var outerScale = "";
+            if (viewport.overlayContentFlipped) {
+                outerScale = viewport.flipped ? " scaleX(-1)" : " scaleX(1)";
             }
-            else {
-                rotate = positionAndSize.rotate;
-            }
+            var rotate = viewport.flipped ? -positionAndSize.rotate : positionAndSize.rotate;
+            var scale = viewport.flipped ? " scaleX(-1)" : "";
             // call the onDraw callback if it exists to allow one to overwrite
             // the drawing/positioning/sizing of the overlay
             if (this.onDraw) {
                 this.onDraw(position, size, this.element);
             } else {
                 var style = this.style;
-                var textStyle = text.style;
+                var outerElement = element.firstChild;
+                var outerStyle = outerElement.style;
                 style.left = position.x + "px";
                 style.top = position.y + "px";
                 if (this.width !== null) {
@@ -292,23 +286,24 @@
                     'transform');
                 if (transformOriginProp && transformProp) {
                     if (rotate && !viewport.flipped) {
+                        outerStyle[transformProp] = "";
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = "rotate(" + rotate + "deg)";
                     } else if (!rotate && viewport.flipped) {
-                        textStyle[transformProp] = "scaleX(-1)";
+                        outerStyle[transformProp] = outerScale;
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = scale;
                     } else if (rotate && viewport.flipped){
-                        textStyle[transformProp] = "scaleX(-1)";
+                        outerStyle[transformProp] = outerScale;
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = "rotate(" + rotate + "deg)" + scale;
                     } else {
+                        outerStyle[transformProp] = "";
                         style[transformOriginProp] = "";
                         style[transformProp] = "";
                     }
                 }
                 style.display = 'block';
-                element.appendChild(text);
             }
         },
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -261,7 +261,7 @@
             var size = this.size = positionAndSize.size;
             var rotate;
             var scale = "";
-
+            
             if (viewport.flipped){
                 rotate = -positionAndSize.rotate;
                 scale = " scaleX(-1)";
@@ -269,7 +269,6 @@
             else {
                 rotate = positionAndSize.rotate;
             }
-
             // call the onDraw callback if it exists to allow one to overwrite
             // the drawing/positioning/sizing of the overlay
             if (this.onDraw) {
@@ -320,11 +319,9 @@
                     var rect = new $.Rect(position.x, position.y, size.x, size.y);
                     var boundingBox = this._getBoundingBox(rect, viewport.getRotation(true));
                     position = boundingBox.getTopLeft();
-                 
                     if (viewport.flipped){
                         position.x = (viewport.getContainerSize().x - position.x);
                     }
-
                     size = boundingBox.getSize();
                 } else {
                     rotate = viewport.getRotation(true);

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -259,7 +259,7 @@
             var position = positionAndSize.position;
             var size = this.size = positionAndSize.size;
             var outerScale = "";
-            if (viewport.overlayContentFlipped) {
+            if (viewport.overlayPreserveContentDirection) {
                 outerScale = viewport.flipped ? " scaleX(-1)" : " scaleX(1)";
             }
             var rotate = viewport.flipped ? -positionAndSize.rotate : positionAndSize.rotate;

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -259,7 +259,16 @@
 
             var position = positionAndSize.position;
             var size = this.size = positionAndSize.size;
-            var rotate = positionAndSize.rotate;
+            var rotate;
+            var scale = "";
+
+            if (viewport.flipped){
+                rotate = -positionAndSize.rotate;
+                scale = " scaleX(-1)";
+            }
+            else {
+                rotate = positionAndSize.rotate;
+            }
 
             // call the onDraw callback if it exists to allow one to overwrite
             // the drawing/positioning/sizing of the overlay
@@ -282,7 +291,10 @@
                 if (transformOriginProp && transformProp) {
                     if (rotate) {
                         style[transformOriginProp] = this._getTransformOrigin();
-                        style[transformProp] = "rotate(" + rotate + "deg)";
+                        style[transformProp] = "rotate(" + rotate + "deg)" + scale;
+                    } else if (!rotate && viewport.flipped) {
+                        style[transformOriginProp] = this._getTransformOrigin();
+                        style[transformProp] = "scaleX(-1)";
                     } else {
                         style[transformOriginProp] = "";
                         style[transformProp] = "";
@@ -308,12 +320,21 @@
                     var rect = new $.Rect(position.x, position.y, size.x, size.y);
                     var boundingBox = this._getBoundingBox(rect, viewport.getRotation(true));
                     position = boundingBox.getTopLeft();
+                    position = boundingBox.getTopLeft();
+
+                    if (viewport.flipped){
+                        position.x = (viewport.getContainerSize().x - position.x);
+                    }
+
                     size = boundingBox.getSize();
                 } else {
                     rotate = viewport.getRotation(true);
                 }
             }
 
+            if (viewport.flipped) {
+                position.x = (viewport.getContainerSize().x - position.x);
+            }
             return {
                 position: position,
                 size: size,

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -320,8 +320,7 @@
                     var rect = new $.Rect(position.x, position.y, size.x, size.y);
                     var boundingBox = this._getBoundingBox(rect, viewport.getRotation(true));
                     position = boundingBox.getTopLeft();
-                    position = boundingBox.getTopLeft();
-
+                 
                     if (viewport.flipped){
                         position.x = (viewport.getContainerSize().x - position.x);
                     }

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -261,7 +261,6 @@
             var size = this.size = positionAndSize.size;
             var rotate;
             var scale = "";
-            
             if (viewport.flipped){
                 rotate = -positionAndSize.rotate;
                 scale = " scaleX(-1)";

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -270,8 +270,8 @@
                 this.onDraw(position, size, this.element);
             } else {
                 var style = this.style;
-                var outerElement = element.firstChild;
-                var outerStyle = outerElement.style;
+                var innerElement = element.firstChild;
+                var innerStyle = innerElement.style;
                 style.left = position.x + "px";
                 style.top = position.y + "px";
                 if (this.width !== null) {
@@ -286,19 +286,19 @@
                     'transform');
                 if (transformOriginProp && transformProp) {
                     if (rotate && !viewport.flipped) {
-                        outerStyle[transformProp] = "";
+                        innerStyle[transformProp] = "";
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = "rotate(" + rotate + "deg)";
                     } else if (!rotate && viewport.flipped) {
-                        outerStyle[transformProp] = outerScale;
+                        innerStyle[transformProp] = outerScale;
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = scale;
                     } else if (rotate && viewport.flipped){
-                        outerStyle[transformProp] = outerScale;
+                        innerStyle[transformProp] = outerScale;
                         style[transformOriginProp] = this._getTransformOrigin();
                         style[transformProp] = "rotate(" + rotate + "deg)" + scale;
                     } else {
-                        outerStyle[transformProp] = "";
+                        innerStyle[transformProp] = "";
                         style[transformOriginProp] = "";
                         style[transformProp] = "";
                     }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -397,6 +397,7 @@ $.Viewer = function( options ) {
         viewer:                     this,
         degrees:                    this.degrees,
         flipped:                    this.flipped,
+        overlayContentFlipped:      this.overlayContentFlipped,
         navigatorRotate:            this.navigatorRotate,
         homeFillsViewer:            this.homeFillsViewer,
         margins:                    this.viewportMargins,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -383,25 +383,25 @@ $.Viewer = function( options ) {
 
     // Create the viewport
     this.viewport = new $.Viewport({
-        containerSize:              THIS[ this.hash ].prevContainerSize,
-        springStiffness:            this.springStiffness,
-        animationTime:              this.animationTime,
-        minZoomImageRatio:          this.minZoomImageRatio,
-        maxZoomPixelRatio:          this.maxZoomPixelRatio,
-        visibilityRatio:            this.visibilityRatio,
-        wrapHorizontal:             this.wrapHorizontal,
-        wrapVertical:               this.wrapVertical,
-        defaultZoomLevel:           this.defaultZoomLevel,
-        minZoomLevel:               this.minZoomLevel,
-        maxZoomLevel:               this.maxZoomLevel,
-        viewer:                     this,
-        degrees:                    this.degrees,
-        flipped:                    this.flipped,
-        overlayContentFlipped:      this.overlayContentFlipped,
-        navigatorRotate:            this.navigatorRotate,
-        homeFillsViewer:            this.homeFillsViewer,
-        margins:                    this.viewportMargins,
-        silenceMultiImageWarnings:  this.silenceMultiImageWarnings
+        containerSize:                      THIS[ this.hash ].prevContainerSize,
+        springStiffness:                    this.springStiffness,
+        animationTime:                      this.animationTime,
+        minZoomImageRatio:                  this.minZoomImageRatio,
+        maxZoomPixelRatio:                  this.maxZoomPixelRatio,
+        visibilityRatio:                    this.visibilityRatio,
+        wrapHorizontal:                     this.wrapHorizontal,
+        wrapVertical:                       this.wrapVertical,
+        defaultZoomLevel:                   this.defaultZoomLevel,
+        minZoomLevel:                       this.minZoomLevel,
+        maxZoomLevel:                       this.maxZoomLevel,
+        viewer:                             this,
+        degrees:                            this.degrees,
+        flipped:                            this.flipped,
+        overlayPreserveContentDirection:    this.overlayPreserveContentDirection,
+        navigatorRotate:                    this.navigatorRotate,
+        homeFillsViewer:                    this.homeFillsViewer,
+        margins:                            this.viewportMargins,
+        silenceMultiImageWarnings:          this.silenceMultiImageWarnings
     });
 
     this.viewport._setContentBounds(this.world.getHomeBounds(), this.world.getContentFactor());

--- a/test/demo/overlay.html
+++ b/test/demo/overlay.html
@@ -27,7 +27,7 @@
             tileSources: "../data/testpattern.dzi",
             minZoomImageRatio: 0,
             maxZoomPixelRatio: 10,
-            overlayContentFlipped: true  // change this to true to test overlay content flipping
+            overlayPreserveContentDirection: true  // change this to true to test overlay content flipping
         });
 
         viewer.addHandler("open", function(event) {

--- a/test/demo/overlay.html
+++ b/test/demo/overlay.html
@@ -26,7 +26,8 @@
             prefixUrl: "../../build/openseadragon/images/",
             tileSources: "../data/testpattern.dzi",
             minZoomImageRatio: 0,
-            maxZoomPixelRatio: 10
+            maxZoomPixelRatio: 10,
+            overlayContentFlipped: true  // change this to true to test overlay content flipping
         });
 
         viewer.addHandler("open", function(event) {
@@ -40,6 +41,19 @@
                 element: elt,
                 location: new OpenSeadragon.Rect(0.21, 0.21, 0.099, 0.099),
                 rotationMode: OpenSeadragon.OverlayRotationMode.BOUNDING_BOX
+            });
+
+            // test with image of letter B to see that images flip too
+            elt = document.createElement("div");
+            elt.className = "runtime-overlay";
+            elt.style.outline = "1px solid blue";
+            elt.style.height = "100px";
+            elt.innerHTML = "<div><img src='../data/BBlue.png' width='100%' height='100%'/></div>"
+            viewer.addOverlay({
+                element: elt,
+                location: new OpenSeadragon.Point(0.0, 0.0),
+                width: 0.1,
+                height: 0.1
             });
 
             elt = document.createElement("div");


### PR DESCRIPTION
This fix sets the correct position for the overlay upon `viewport.flipped`, it also applies a `ScaleX(-1)` and inverts the degrees for correctly rotating the overlay with the canvas.

The overlay is flipped entirely, this may not be desirable from a content perspective, however, I think people using OSD should invert content themselves because I do not think it is the job of OSD.  This fix is at least a step in the right direction.

Fixes: #2450