### PR TITLE
add check for missing webgl context in WebGLDrawer.isSupported()

### DIFF
--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -195,7 +195,7 @@
             let canvasElement = document.createElement( 'canvas' );
             let webglContext = $.isFunction( canvasElement.getContext ) &&
                         canvasElement.getContext( 'webgl' );
-            let ext = webglContext.getExtension('WEBGL_lose_context');
+            let ext = webglContext && webglContext.getExtension('WEBGL_lose_context');
             if(ext){
                 ext.loseContext();
             }


### PR DESCRIPTION
While looking into https://github.com/openseadragon/openseadragon/issues/2556, I noticed an error with how browser support for webgl was being tested and reported. If the context can't be established, it shouldn't have any methods called on it (since it is null).