### PR TITLE
Mark image-unloaded and tile-ready events as private

### DIFF
--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -283,6 +283,7 @@
                         * @memberof OpenSeadragon.Viewer
                         * @type {object}
                         * @property {CanvasRenderingContext2D} context2D - The context that is being unloaded
+                        * @private
                         */
                         viewer.raiseEvent("image-unloaded", {
                             context2D: this.levels[i].context2D

--- a/src/tilecache.js
+++ b/src/tilecache.js
@@ -270,6 +270,7 @@ $.TileCache.prototype = {
                  * @memberof OpenSeadragon.Viewer
                  * @type {object}
                  * @property {CanvasRenderingContext2D} context2D - The context that is being unloaded
+                 * @private
                  */
                 tiledImage.viewer.raiseEvent("image-unloaded", {
                     context2D: context2D,

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2076,6 +2076,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                  * @property {OpenSeadragon.Tile} tile - The tile which has been loaded.
                  * @property {OpenSeadragon.TiledImage} tiledImage - The tiled image of the loaded tile.
                  * @property {XMLHttpRequest} tileRequest - The AJAX request that loaded this tile (if applicable).
+                 * @private
                  */
                 _this.viewer.raiseEvent("tile-ready", {
                     tile: tile,


### PR DESCRIPTION
Makes events related to tile/image status private to allow easier removal in the future once they are obsolete, per https://github.com/openseadragon/openseadragon/pull/2407#issuecomment-2231368965