### PR TITLE
Remove resize handler from viewer when webgl drawer is destroyed

### DIFF
--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -160,6 +160,7 @@
             // unbind our event listeners from the viewer
             this.viewer.removeHandler("tile-ready", this._boundToTileReady);
             this.viewer.removeHandler("image-unloaded", this._boundToImageUnloaded);
+            this.viewer.removeHandler("resize", this._resizeHandler);
 
             // set our webgl context reference to null to enable garbage collection
             this._gl = null;
@@ -839,8 +840,7 @@
 
             this._gl = this._renderingCanvas.getContext('webgl');
 
-            //make the additional canvas elements mirror size changes to the output canvas
-            this.viewer.addHandler("resize", function(){
+            this._resizeHandler = function(){
 
                 if(_this._outputCanvas !== _this.viewer.drawer.canvas){
                     _this._outputCanvas.style.width = _this.viewer.drawer.canvas.clientWidth + 'px';
@@ -861,7 +861,10 @@
 
                 // important - update the size of the rendering viewport!
                 _this._resizeRenderer();
-            });
+            };
+
+            //make the additional canvas elements mirror size changes to the output canvas
+            this.viewer.addHandler("resize", this._resizeHandler);
         }
 
         // private


### PR DESCRIPTION
I was poking around with the viewer in fullscreen in Firefox related to https://github.com/openseadragon/openseadragon/issues/2569 when I noticed a bug: when a viewer is using a `webgl` drawer, and then switched to `canvas` via `viewer.requestDrawer('canvas')`, the original drawer is destroyed but still has a handler attached to the viewer's `resize` event. Calling the handler on the destroyed drawer is problematic. This PR removes the handler when the `webgl` drawer is destroyed which fixes the bug.