### PR TITLE
Bug fix in TiledImage.setClip

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -878,6 +878,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             this._clip = null;
         }
 
+        this._needsUpdate = true;
         this._needsDraw = true;
         /**
          * Raised when the TiledImage's clip is changed.


### PR DESCRIPTION
The demo page at https://codepen.io/imoskvin/pen/yOXqvO demonstrates a bug in the current master branch. Moving the slider all the way to one side or the other of the window will leave a blank space with no tiles, until a navigation action is taken.

This is fixed by setting `_needsUpdate = true` within `TiledImage.setClip`. Without this, the tiles needed to cover the exposed region of the viewport are not recomputed.  To test the solution easily, in the demo codepen, add the following two lines to `imagesClipShared`:
```
leftImage._needsUpdate=true;
rightImage._needsUpdate=true;
```