### PR TITLE
Fix problem with asymmetric viewport margins in webgl drawer

### DIFF
--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -255,9 +255,10 @@
         */
         draw(tiledImages){
             let gl = this._gl;
+            const bounds = this.viewport.getBoundsNoRotateWithMargins(true);
             let view = {
-                bounds: this.viewport.getBoundsNoRotateWithMargins(true),
-                center: this.viewport.getCenter(true),
+                bounds: bounds,
+                center: new OpenSeadragon.Point(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2),
                 rotation: this.viewport.getRotation(true) * Math.PI / 180
             };
 

--- a/test/demo/drawercomparison.js
+++ b/test/demo/drawercomparison.js
@@ -19,10 +19,10 @@ const drawers = {
 }
 
 const viewportMargins = {
-    left: 25,
-    top: 25,
-    right: 25,
-    bottom: 25,
+    left: 100,
+    top: 0,
+    right: 0,
+    bottom: 50,
 };
 
 //Support drawer type from the url


### PR DESCRIPTION
Fixes https://github.com/openseadragon/openseadragon/issues/2599

The problem was that `viewport.getCenter()` was being used to define the center of the drawn area; however, this value does not take the margins into account. When symmetric margins were used the center in "viewport coordinates" matches the center of the bounds. However, with asymmetric margins this is not true. The code now calculates the center of the drawn area directly from the bounds.