### PR TITLE
Add test for problems with WebGL and fall back to canvas if needed

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3905,7 +3905,7 @@ function drawWorld( viewer ) {
     viewer.world.draw();
 
     /**
-     * <em>- Needs documentation -</em>
+     * This event is raised any time the viewer has rendered a new frame.
      *
      * @event update-viewport
      * @memberof OpenSeadragon.Viewer


### PR DESCRIPTION
This PR is intended to address problems where the `WebGLDrawer` unexpectedly fails to render, despite being ostensibly supported by the browser (issues https://github.com/openseadragon/openseadragon/issues/2604 and https://github.com/openseadragon/openseadragon/issues/2587).

Now, when a `WebGLDrawer` is created, it creates a small additional viewer and attempts to open and render a small image (from an included dataUrl). If non-zero pixel data is successfully obtained, the drawer can use `webgl`. If not, it will fall back to `CanvasDrawer` internally (like already happens for images tainted by cross-origin issues).

When this happens, a warning is printed to the console, and a new `webgl-error` event is raised by the viewer.

I have tested the code by setting an internal flag and returning at the beginning of the `draw()` call to simulate failure of drawing. However, I do not have any devices/browsers that actually demonstrate the behavior described by the linked issues. If @andreastein or anyone else could test this out, it would be very helpful!