### PR TITLE
Remove displayRegion transform

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -347,7 +347,6 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
     },
 
     setDisplayTransform: function(rule) {
-      setElementTransform(this.displayRegion, rule);
       setElementTransform(this.canvas, rule);
       setElementTransform(this.element, rule);
     },


### PR DESCRIPTION
ref #2612

- Remove display region transform in `setFlip()` as it is not needed for flipping and was overriding existing rotation transforms.
