### PR TITLE
Fix #2623

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2551,8 +2551,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         var currentPixelDensityRatio = $.getCurrentPixelDensityRatio();
         if (previusPixelDensityRatio !== currentPixelDensityRatio) {
             $.pixelDensityRatio = currentPixelDensityRatio;
-            this.world.resetItems();
-            this.forceRedraw();
+            this.forceResize();
         }
     },
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2542,8 +2542,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
     },
 
     /**
-     * Update pixel density ratio, clears all tiles and triggers updates for
-     * all items if the ratio has changed.
+     * Update pixel density ratio and forces a resize operation.
      * @private
      */
      _updatePixelDensityRatio: function() {


### PR DESCRIPTION
The issue described in #2623 is due to all the tiles being unloaded when a pixel density ratio change is detected, and attempting to draw the world again with the old tiles which no longer have data.

In my testing (using browser zoom to trigger this), getting rid of the unloading & redrawing steps fixes it, and forcing a resize should address anything with a mismatch between the old and new pixel density ratio on the drawer canvases.

In my testing, nothing appears to break by removing the old "unload" step; however, I'm not entirely sure what that part of the code was intended to address. @iangilman @Aiosa @Tobio89 can you test to see if this works on your setups?