### PR TITLE
Typo in hasTransparency check in webgldrawer

### DIFF
--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -314,7 +314,7 @@
                         tiledImage.debugMode
                     );
 
-                    let useTwoPassRendering = useContext2dPipeline || (tiledImage.opacity < 1) || firstTile.hasTransparency;
+                    let useTwoPassRendering = useContext2dPipeline || (tiledImage.opacity < 1) || firstTile.tile.hasTransparency;
 
                     // using the context2d pipeline requires a clean rendering (back) buffer to start
                     if(useContext2dPipeline){


### PR DESCRIPTION
I was trying to get the webgldrawer to `useTwoPassRendering` (to work around a flickering line that appears between tiles). I noticed that setting `hasTransparency` in the tilesource to true should activate the code path, but it wasn't working.  

I looked at `firstTile` in the debugger, and it isn't the tile - it contains a tile:
<img width="345" alt="image" src="https://github.com/user-attachments/assets/bac11725-bdae-42b2-8aed-ba83d56a8a8a" />

So the check should be for `firstTile.tile.hasTransparency` instead of `firstTile.hasTransparency`

