### PR TITLE
Fixed issue with MouseTracker where hasGestureHandlers and hasScrollHandler values were not getting updated upon dynamically adding/removing handlers.

### DIFF
--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -386,10 +386,9 @@
 
         /**
          * Do we currently have any assigned gesture handlers.
-         * @function
          * @returns {Boolean} Do we currently have any assigned gesture handlers.
          */
-        hasGestureHandlers: function () {
+        get hasGestureHandlers() {
             return !!(this.pressHandler ||
                       this.nonPrimaryPressHandler ||
                       this.releaseHandler ||
@@ -403,10 +402,9 @@
 
         /**
          * Do we currently have a scroll handler.
-         * @function
          * @returns {Boolean} Do we currently have a scroll handler.
          */
-        hasScrollHandler: function () {
+        get hasScrollHandler() {
             return !!this.scrollHandler;
         },
 
@@ -2855,7 +2853,7 @@
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
-                eventInfo.preventGesture = !tracker.hasGestureHandlers();
+                eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
                 break;
             case 'pointerover':
@@ -2873,22 +2871,22 @@
             case 'pointerdown':
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
-                eventInfo.preventDefault = false; // updatePointerDown() may set true (tracker.hasGestureHandlers())
-                eventInfo.preventGesture = !tracker.hasGestureHandlers();
+                eventInfo.preventDefault = false; // updatePointerDown() may set true (tracker.hasGestureHandlers)
+                eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
                 break;
             case 'pointerup':
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
-                eventInfo.preventGesture = !tracker.hasGestureHandlers();
+                eventInfo.preventGesture = !tracker.hasGestureHandlers;
                 eventInfo.stopPropagation = false;
                 break;
             case 'wheel':
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false; // handleWheelEvent() may set true
-                eventInfo.preventGesture = !tracker.hasScrollHandler();
+                eventInfo.preventGesture = !tracker.hasScrollHandler;
                 eventInfo.stopPropagation = false;
                 break;
             case 'gotpointercapture':

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -277,8 +277,6 @@
             sentDragEvent:         false
         };
 
-        this.hasScrollHandler = !!this.scrollHandler;
-
         if ( $.MouseTracker.havePointerEvents ) {
             $.setElementPointerEvents( this.element, 'auto' );
         }
@@ -401,6 +399,15 @@
                       this.dragHandler ||
                       this.dragEndHandler ||
                       this.pinchHandler);
+        },
+
+        /**
+         * Do we currently have a scroll handler.
+         * @function
+         * @returns {Boolean} Do we currently have a scroll handler.
+         */
+        hasScrollHandler: function () {
+            return !!this.scrollHandler;
         },
 
         /**
@@ -2881,7 +2888,7 @@
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false; // handleWheelEvent() may set true
-                eventInfo.preventGesture = !tracker.hasScrollHandler;
+                eventInfo.preventGesture = !tracker.hasScrollHandler();
                 eventInfo.stopPropagation = false;
                 break;
             case 'gotpointercapture':

--- a/src/mousetracker.js
+++ b/src/mousetracker.js
@@ -277,11 +277,6 @@
             sentDragEvent:         false
         };
 
-        this.hasGestureHandlers = !!( this.pressHandler || this.nonPrimaryPressHandler ||
-                                this.releaseHandler || this.nonPrimaryReleaseHandler ||
-                                this.clickHandler || this.dblClickHandler ||
-                                this.dragHandler || this.dragEndHandler ||
-                                this.pinchHandler );
         this.hasScrollHandler = !!this.scrollHandler;
 
         if ( $.MouseTracker.havePointerEvents ) {
@@ -389,6 +384,23 @@
             }
 
             return count;
+        },
+
+        /**
+         * Do we currently have any assigned gesture handlers.
+         * @function
+         * @returns {Boolean} Do we currently have any assigned gesture handlers.
+         */
+        hasGestureHandlers: function () {
+            return !!(this.pressHandler ||
+                      this.nonPrimaryPressHandler ||
+                      this.releaseHandler ||
+                      this.nonPrimaryReleaseHandler ||
+                      this.clickHandler ||
+                      this.dblClickHandler ||
+                      this.dragHandler ||
+                      this.dragEndHandler ||
+                      this.pinchHandler);
         },
 
         /**
@@ -2836,7 +2848,7 @@
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
-                eventInfo.preventGesture = !tracker.hasGestureHandlers;
+                eventInfo.preventGesture = !tracker.hasGestureHandlers();
                 eventInfo.stopPropagation = false;
                 break;
             case 'pointerover':
@@ -2854,15 +2866,15 @@
             case 'pointerdown':
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
-                eventInfo.preventDefault = false; // updatePointerDown() may set true (tracker.hasGestureHandlers)
-                eventInfo.preventGesture = !tracker.hasGestureHandlers;
+                eventInfo.preventDefault = false; // updatePointerDown() may set true (tracker.hasGestureHandlers())
+                eventInfo.preventGesture = !tracker.hasGestureHandlers();
                 eventInfo.stopPropagation = false;
                 break;
             case 'pointerup':
                 eventInfo.isStoppable = true;
                 eventInfo.isCancelable = true;
                 eventInfo.preventDefault = false;
-                eventInfo.preventGesture = !tracker.hasGestureHandlers;
+                eventInfo.preventGesture = !tracker.hasGestureHandlers();
                 eventInfo.stopPropagation = false;
                 break;
             case 'wheel':


### PR DESCRIPTION
Previously, creating MouseTrackers without any initial gesture handlers cased dynamically added gesture handlers to fail to work properly; we assigned a value to hasGestureHandlers and hasScrollHandler during construction and never reassigned or updated it as we added/removed handlers dynamically. By changing these properties to a function on the prototype, we now get the most up to date value for hasGestureHandleres and hasScrollHandler at the moment they are checked.