### PR TITLE
Update viewer.addOverlay doc

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2222,8 +2222,9 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
    /**
      * Adds an html element as an overlay to the current viewport.  Useful for
      * highlighting words or areas of interest on an image or other zoomable
-     * interface. The overlays added via this method are removed when the viewport
-     * is closed which include when changing page.
+     * interface. Unless the viewer has been configured with the preserveOverlays 
+     * option, overlays added via this method are removed when the viewport
+     * is closed (including in sequence mode when changing page).
      * @method
      * @param {Element|String|Object} element - A reference to an element or an id for
      *      the element which will be overlaid. Or an Object specifying the configuration for the overlay.

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2222,7 +2222,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
    /**
      * Adds an html element as an overlay to the current viewport.  Useful for
      * highlighting words or areas of interest on an image or other zoomable
-     * interface. Unless the viewer has been configured with the preserveOverlays 
+     * interface. Unless the viewer has been configured with the preserveOverlays
      * option, overlays added via this method are removed when the viewport
      * is closed (including in sequence mode when changing page).
      * @method


### PR DESCRIPTION
Mention the preserveOverlays option in the `viewer.addOverlay` documentation.