### PR TITLE
Resolved Duplicate IDs in overlay HTML

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -133,14 +133,18 @@
         this.elementWrapper.appendChild(this.element);
 
         if (this.element.id) {
-            this.elementWrapper.id = "overlay-wrapper-" + this.element.id;
+        this.elementWrapper.id = "overlay-wrapper-" + this.element.id;
         } else {
-            this.elementWrapper.id = "overlay-wrapper";
+        this.elementWrapper.id = "overlay-wrapper-" + crypto.randomUUID(); // Ensure unique ID
         }
+
+        // Always add a class for easier selection
+        this.elementWrapper.classList.add("openseadragon-overlay-wrapper");
+
 
         this.style = this.elementWrapper.style;
         this._init(options);
-    };
+        };
 
     /** @lends OpenSeadragon.Overlay.prototype */
     $.Overlay.prototype = {

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -133,10 +133,11 @@
         this.elementWrapper.appendChild(this.element);
 
         if (this.element.id) {
-        this.elementWrapper.id = "overlay-wrapper-" + this.element.id;
-        } else {
-        this.elementWrapper.id = "overlay-wrapper-" + crypto.randomUUID(); // Ensure unique ID
-        }
+    this.elementWrapper.id = "overlay-wrapper-" + this.element.id; // Unique ID if element has one
+}
+// Always add a class for styling & selection
+    this.elementWrapper.classList.add("openseadragon-overlay-wrapper");
+
 
         // Always add a class for easier selection
         this.elementWrapper.classList.add("openseadragon-overlay-wrapper");


### PR DESCRIPTION
Fixed Overlay ID Issue

Ensured that overlay elements always have a unique ID.

If the element has an ID, it's used (overlay-wrapper-[elementID]).

If no ID exists, a random unique ID is generated (crypto.randomUUID()).

Added a class (openseadragon-overlay-wrapper) to all overlays for easier selection.