### PR TITLE
Fix duplicate overlay wrapper IDs

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -132,11 +132,17 @@
         this.element = options.element;
         this.elementWrapper.appendChild(this.element);
 
+        // Create the overlay wrapper
+        this.elementWrapper = document.createElement('div');
+        this.elementWrapper.appendChild(this.element);
+
+        // Assign a unique ID only if the overlay element has an id
         if (this.element.id) {
             this.elementWrapper.id = "overlay-wrapper-" + this.element.id;
-        } else {
-            this.elementWrapper.id = "overlay-wrapper";
         }
+        // Always add a class for styling and selection purposes
+        this.elementWrapper.className = "openseadragon-overlay-wrapper";
+
 
         this.style = this.elementWrapper.style;
         this._init(options);


### PR DESCRIPTION
This PR fixes [issue #2682](https://github.com/openseadragon/openseadragon/issues/2682) where overlays without an id were causing multiple overlay wrapper <div> elements to have the same default id, violating HTML uniqueness rules.

Changes in this PR:

The code now creates a new overlay wrapper <div> and appends the overlay element to it.
It assigns a unique id ("overlay-wrapper-" + element.id) only if the overlay element has an id.
A CSS class "openseadragon-overlay-wrapper" is always added for consistent styling.
Testing:

Verified that overlays with an id receive a unique wrapper id.
Verified that overlays without an id do not receive a duplicate default id.
Ran the test suite locally (npx grunt test) and all tests passed.
Additional Notes:
This change maintains backward compatibility for overlays that already have an id.