### PR TITLE
Duplicate ids overlay html 2682

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -133,12 +133,9 @@
         this.elementWrapper.appendChild(this.element);
 
         if (this.element.id) {
-            this.elementWrapper.id = "overlay-wrapper-" + this.element.id;
-        } else {
-            this.elementWrapper.id = "overlay-wrapper-" + crypto.randomUUID(); // Ensure unique ID
+            this.elementWrapper.id = "overlay-wrapper-" + this.element.id; // Unique ID if element has one
         }
-        
-        // Always add a class for easier selection
+        // Always add a class for styling & selection
         this.elementWrapper.classList.add("openseadragon-overlay-wrapper");
         
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -135,8 +135,12 @@
         if (this.element.id) {
             this.elementWrapper.id = "overlay-wrapper-" + this.element.id;
         } else {
-            this.elementWrapper.id = "overlay-wrapper";
+            this.elementWrapper.id = "overlay-wrapper-" + crypto.randomUUID(); // Ensure unique ID
         }
+        
+        // Always add a class for easier selection
+        this.elementWrapper.classList.add("openseadragon-overlay-wrapper");
+        
 
         this.style = this.elementWrapper.style;
         this._init(options);


### PR DESCRIPTION
Fixes #2682

Eliminates duplicate "overlay-wrapper" IDs.

Retains unique IDs where necessary (overlay-wrapper-[element.id]).

Facilitates selection through the class (openseadragon-overlay-wrapper).

Adheres to the mentor’s guidance that a generated ID is unnecessary, as the class is sufficient.
