### PR TITLE
Fix panBy immediately with non-zero center spring

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -827,10 +827,14 @@ $.Viewport.prototype = {
      * @fires OpenSeadragon.Viewer.event:pan
      */
     panBy: function( delta, immediately ) {
-        var center = new $.Point(
-            this.centerSpringX.target.value,
-            this.centerSpringY.target.value
-        );
+        var center = new $.Point();
+        if (immediately) {
+            center.x = this.centerSpringX.current.value;
+            center.y = this.centerSpringY.current.value;
+        } else {
+            center.x = this.centerSpringX.target.value;
+            center.y = this.centerSpringY.target.value;
+        }
         return this.panTo( center.plus( delta ), immediately );
     },
 


### PR DESCRIPTION
This pull request fixes the jumpy behavior when flicking on touch devices described in #2696. 

The issue was after flicking the center sprint would have a target set away from its current center. Then dragging would cause `panBy` to be called again with immediately set to true on touch devices. This then would use the target image center causing the image to jump to its finish point.

This needs to be different when immediate is false as you are dragging around the target point.