### PR TITLE
fully-loaded support for the Viewer

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -267,7 +267,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         if (this.getFullyLoaded()) {
             setTimeout(callback, 1); // Asynchronous execution
         } else {
-            this.addOnceHandler('fully-loaded-change', callback); // Maintain context
+            this.addOnceHandler('fully-loaded-change', function() {
+                callback(); // Maintain context
+            });
         }
     },
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -267,9 +267,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         if (this.getFullyLoaded()) {
             setTimeout(callback, 1); // Asynchronous execution
         } else {
-            this.addOnceHandler('fully-loaded-change', function() {
-                callback.call(this); // Maintain context
-            });
+            this.addOnceHandler('fully-loaded-change', callback); // Maintain context
         }
     },
 

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -257,6 +257,22 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         return this._fullyLoaded;
     },
 
+    /**
+     * Executes the provided callback when the TiledImage is fully loaded. If already loaded,
+     * schedules the callback asynchronously. Otherwise, attaches a one-time event listener
+     * for the 'fully-loaded-change' event.
+     * @param {Function} callback - Function to execute when loading completes
+     */
+    whenFullyLoaded: function(callback) {
+        if (this.getFullyLoaded()) {
+            setTimeout(callback, 1); // Asynchronous execution
+        } else {
+            this.addOnceHandler('fully-loaded-change', function() {
+                callback.call(this); // Maintain context
+            });
+        }
+    },
+
     // private
     _setFullyLoaded: function(flag) {
         if (flag === this._fullyLoaded) {


### PR DESCRIPTION
Fix for the issue #1257 
- Implemented logic to track the viewer's fully-loaded state by checking if all TiledImage instances in the viewer's world are fully loaded using the areAllFullyLoaded() method.
- Added a handler to each TiledImage's fully-loaded-change event to update the viewer's aggregate state and trigger a fully-loaded-change event at the viewer level when the state changes.
- Introduced a whenFullyLoaded(callback) method for both Viewer and TiledImage to allow asynchronous execution of a callback once all required tiles are loaded.