### PR TITLE
Fix destroy() to remove only OpenSeadragon-created elements #2662

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -294,9 +294,6 @@ $.Viewer = function( options ) {
 
     this.container.insertBefore( this.canvas, this.container.firstChild );
     this.element.appendChild( this.container );
-
-
-
     //Used for toggling between fullscreen and default container size
     //TODO: these can be closure private and shared across Viewer
     //      instances.
@@ -997,7 +994,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             this.paging.destroy();
         }
 
-        // Remove only the OpenSeadragon-created elements (canvas and container)
+        // Remove both the canvas and container elements added by OpenSeadragon
         // Use removeChild to properly handle SVG or non-HTML elements
 
         if (this.container && this.canvas) {
@@ -1008,8 +1005,6 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                 this.element.removeChild(this.container);
             }
         }
-
-
         this.container.onsubmit = null;
         this.clearControls();
 
@@ -1033,7 +1028,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
         // clear our reference to the main element - they will need to pass it in again, creating a new viewer
         this.element = null;
-        this._createdElements = null;
+        
 
 
         /**

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -294,8 +294,7 @@ $.Viewer = function( options ) {
 
     this.container.insertBefore( this.canvas, this.container.firstChild );
     this.element.appendChild( this.container );
-    this._createdElements = [];
-    this._createdElements.push(this.container);
+    
 
 
     //Used for toggling between fullscreen and default container size

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -995,15 +995,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         }
 
         // Remove both the canvas and container elements added by OpenSeadragon
-        // Use removeChild to properly handle SVG or non-HTML elements
-
-        if (this.container && this.canvas) {
-            if (this.canvas.parentNode === this.container) {
-                this.container.removeChild(this.canvas);
-            }
-            if (this.container.parentNode === this.element) {
-                this.element.removeChild(this.container);
-            }
+        if (this.container && this.container.parentNode === this.element) {
+            this.element.removeChild(this.container);
         }
         this.container.onsubmit = null;
         this.clearControls();

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1022,7 +1022,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
         // clear our reference to the main element - they will need to pass it in again, creating a new viewer
         this.element = null;
-        
+
 
 
         /**

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -294,7 +294,7 @@ $.Viewer = function( options ) {
 
     this.container.insertBefore( this.canvas, this.container.firstChild );
     this.element.appendChild( this.container );
-    
+
 
 
     //Used for toggling between fullscreen and default container size

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -294,6 +294,9 @@ $.Viewer = function( options ) {
 
     this.container.insertBefore( this.canvas, this.container.firstChild );
     this.element.appendChild( this.container );
+    this._createdElements = [];
+    this._createdElements.push(this.container);
+
 
     //Used for toggling between fullscreen and default container size
     //TODO: these can be closure private and shared across Viewer
@@ -998,11 +1001,15 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         // Go through top element (passed to us) and remove all children
         // Use removeChild to make sure it handles SVG or any non-html
         // also it performs better - http://jsperf.com/innerhtml-vs-removechild/15
-        if (this.element){
-            while (this.element.firstChild) {
-                this.element.removeChild(this.element.firstChild);
+        if (this.container && this.canvas) {
+            if (this.canvas.parentNode === this.container) {
+                this.container.removeChild(this.canvas);
+            }
+            if (this.container.parentNode === this.element) {
+                this.element.removeChild(this.container);
             }
         }
+
 
         this.container.onsubmit = null;
         this.clearControls();
@@ -1027,6 +1034,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
         // clear our reference to the main element - they will need to pass it in again, creating a new viewer
         this.element = null;
+        this._createdElements = null;
+
 
         /**
          * Raised when the viewer is destroyed (see {@link OpenSeadragon.Viewer#destroy}).

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -997,9 +997,9 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             this.paging.destroy();
         }
 
-        // Go through top element (passed to us) and remove all children
-        // Use removeChild to make sure it handles SVG or any non-html
-        // also it performs better - http://jsperf.com/innerhtml-vs-removechild/15
+        // Remove only the OpenSeadragon-created elements (canvas and container)
+        // Use removeChild to properly handle SVG or non-HTML elements
+
         if (this.container && this.canvas) {
             if (this.canvas.parentNode === this.container) {
                 this.container.removeChild(this.canvas);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -995,6 +995,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         }
 
         // Remove both the canvas and container elements added by OpenSeadragon
+        // This will also remove its children (like the canvas)
         if (this.container && this.container.parentNode === this.element) {
             this.element.removeChild(this.container);
         }


### PR DESCRIPTION
This Pull Request addresses an issue in the destroy() function of OpenSeadragon.Viewer where all children of the passed-in container element were being removed, even if they were not created by OpenSeadragon.


**PROBLEM** 
When destroying a viewer, destroy() removed all children of the element passed to OpenSeadragon, potentially deleting other UI components unintentionally.

**FIX**
The updated code ensures that destroy() only removes elements created by OpenSeadragon, such as this.container, and leaves any external DOM elements intact.

