### PR TITLE
Add GitHub Actions for CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,.travis.yml,.jshintrc}]
+[{package.json,.travis.yml,.jshintrc,.github/**/*.yml}]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -1,0 +1,38 @@
+name: 'Pull Request Checks'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'images/**'
+      - '.github/workflows/prs.yml'
+      - '*.json'
+      - '*.js'
+      - '*.css'
+      - '!test/demo/**'
+
+jobs:
+  run_checks:
+    name: Run test tasks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          cache-dependency-path: package.json
+          node-version: lts/*
+
+      - name: Setup environment and install dependencies
+        run: |
+          npm install -g grunt-cli
+          npm ci
+
+      - name: Run tests
+        run: |
+          npm run test
+


### PR DESCRIPTION
GitHub Actions are free for public repositories and do not require requesting credits.

Leave Travis file to allow evaluating alongside GitHub (per comments).