### PR TITLE
Fix/mobile outline removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openseadragon",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "openseadragon",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "license": "BSD-3-Clause",
             "devDependencies": {
                 "eslint-plugin-compat": "^4.1.2",

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -266,7 +266,7 @@ $.Viewer = function( options ) {
     this.canvas               = $.makeNeutralElement( "div" );
     this.canvas.className = "openseadragon-canvas";
 
-    // Inject mobile-only CSS to remove focus outline
+    // Injecting mobile-only CSS to remove focus outline
     if (!document.querySelector('style[data-openseadragon-mobile-css]')) {
         var style = document.createElement('style');
         style.setAttribute('data-openseadragon-mobile-css', 'true');

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -267,13 +267,17 @@ $.Viewer = function( options ) {
     this.canvas.className = "openseadragon-canvas";
 
     // Inject mobile-only CSS to remove focus outline
-    if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
-        const style = document.createElement('style');
-        style.innerHTML = `
-      .openseadragon-canvas:focus {
-        outline: none !important;
-      }
-    `;
+    if (typeof window !== 'undefined' &&
+        window.matchMedia &&
+        window.matchMedia('(hover: none)').matches) {
+
+        var style = document.createElement('style');
+        style.textContent =
+            '@media (hover: none) {' +
+            '    .openseadragon-canvas:focus {' +
+            '        outline: none !important;' +
+            '    }' +
+            '}';
         document.head.appendChild(style);
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -267,11 +267,9 @@ $.Viewer = function( options ) {
     this.canvas.className = "openseadragon-canvas";
 
     // Inject mobile-only CSS to remove focus outline
-    if (typeof window !== 'undefined' &&
-        window.matchMedia &&
-        window.matchMedia('(hover: none)').matches) {
-
+    if (!document.querySelector('style[data-openseadragon-mobile-css]')) {
         var style = document.createElement('style');
+        style.setAttribute('data-openseadragon-mobile-css', 'true');
         style.textContent =
             '@media (hover: none) {' +
             '    .openseadragon-canvas:focus {' +

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -264,8 +264,19 @@ $.Viewer = function( options ) {
 
     this.element              = this.element || document.getElementById( this.id );
     this.canvas               = $.makeNeutralElement( "div" );
-
     this.canvas.className = "openseadragon-canvas";
+
+    // Inject mobile-only CSS to remove focus outline
+    if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
+        const style = document.createElement('style');
+        style.innerHTML = `
+      .openseadragon-canvas:focus {
+        outline: none !important;
+      }
+    `;
+        document.head.appendChild(style);
+    }
+
     (function( style ){
         style.width    = "100%";
         style.height   = "100%";


### PR DESCRIPTION
This PR injects a CSS rule via JavaScript to remove the focus outline on .openseadragon-canvas for touch devices using the (hover: none) media query. It follows the project's guideline of not using a separate CSS file and improves UX on mobile by preventing unwanted focus rings. Tested on mobile and desktop devices.