### PR TITLE
Default value for _updateDrawArea

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1751,7 +1751,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         var viewportCenter = this.viewport.pixelFromPoint(this.viewport.getCenter());
         this._resetCoverage(this.coverage, level);
 
-        var tiles = new Array(0);
+        var tiles = null;
         var tileIndex = 0;
 
         this._visitTiles(level, drawArea, function(tiledImage, x, y, total) {
@@ -1771,7 +1771,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
 
         });
 
-        return tiles;
+        return tiles || [];
     },
 
         /**

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1751,7 +1751,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         var viewportCenter = this.viewport.pixelFromPoint(this.viewport.getCenter());
         this._resetCoverage(this.coverage, level);
 
-        var tiles = null;
+        var tiles = new Array(0);
         var tileIndex = 0;
 
         this._visitTiles(level, drawArea, function(tiledImage, x, y, total) {


### PR DESCRIPTION
`_visitTiles` only calls the provided callback function for each tile it finds meaning when it can't find any it never gets called. This causes `_updateDrawArea` to return null in those cases while a valid list is always expected. Before the tests where updated this caused #2723 to fail as it tried filtering the output in `_updateLevelsForViewport`. 
https://github.com/openseadragon/openseadragon/blob/01b61e1a4d3be265c743cb5dab1d65c1e80f4c52/src/tiledimage.js#L1478