### PR TITLE
Pause when holding an arrow key

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3970,7 +3970,7 @@ function handleArrowKeys(viewer) {
             if (isDown(code)) {
                 viewer.viewport.panBy(deltaPoint);
                 viewer.viewport.applyConstraints();
-                viewer._keyPanDistance[code] = (viewer._keyPanDistance[code] || 0) + viewer.pixelsPerArrowPress;
+                viewer._keyPanDistance[code] += viewer.pixelsPerArrowPress;
                 if (viewer._keyVirtuallyHeld && viewer._keyVirtuallyHeld[code] && viewer._keyPanDistance[code] >= viewer.minPanDistance) {
                     viewer._keyVirtuallyHeld[code] = false;
                     viewer._keyPanDistance[code] = 0;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3137,11 +3137,10 @@ function onCanvasKeyDown( event ) {
 
     this.raiseEvent('canvas-key', canvasKeyDownEventArgs);
 
-    if (!canvasKeyDownEventArgs.preventDefaultAction) {
-        this._keysDown[canvasKeyDownEventArgs.originalEvent.code] = true; // Mark this key as held down in the viewer's internal tracking object
-    }
-
     if ( !canvasKeyDownEventArgs.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
+
+        this._keysDown[canvasKeyDownEventArgs.originalEvent.code] = true; // Mark this key as held down in the viewer's internal tracking object
+
         switch( event.keyCode ){
             case 38://up arrow/shift uparrow
                 if (!canvasKeyDownEventArgs.preventVerticalPan) {
@@ -4021,70 +4020,46 @@ function handleArrowKeys(viewer) {
      // Use the viewer's configured pan amount
     const pixels = viewer.pixelsPerArrowPress;
     const panDelta = viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(pixels, pixels));
-    const panDelta40 = viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(40, 40));
 
     // Shift key state
     const shift = isDown('Shift') || isDown('ShiftLeft') || isDown('ShiftRight');
 
-    // Up Arrow and Down Arrow
+    // Up Arrow,  Down Arrow, WS Keys
+    // Handle zoom first (should always work regardless of pan settings)
+    if (shift) {
+        if (isDown('ArrowUp') || isDown('KeyW')) {
+            viewer.viewport.zoomBy(1.1);
+            viewer.viewport.applyConstraints();
+            return; // Exit early to prevent panning
+        }
+        if (isDown('ArrowDown') || isDown('KeyS')) {
+            viewer.viewport.zoomBy(0.9);
+            viewer.viewport.applyConstraints();
+            return; // Exit early to prevent panning
+        }
+    }
+
+    // Handle vertical panning (only when not zooming)
     if (!viewer.preventVerticalPan) {
-        if (isDown('ArrowUp')) {
-            if (shift) {
-                viewer.viewport.zoomBy(1.1);
-            } else {
-                viewer.viewport.panBy(new OpenSeadragon.Point(0, -panDelta.y));
-            }
+        if (isDown('ArrowUp') || isDown('KeyW')) {
+            viewer.viewport.panBy(new OpenSeadragon.Point(0, -panDelta.y));
             viewer.viewport.applyConstraints();
         }
-        if (isDown('ArrowDown')) {
-            if (shift) {
-                viewer.viewport.zoomBy(0.9);
-            } else {
-                viewer.viewport.panBy(new OpenSeadragon.Point(0, panDelta.y));
-            }
+        if (isDown('ArrowDown') || isDown('KeyS')) {
+            viewer.viewport.panBy(new OpenSeadragon.Point(0, panDelta.y));
             viewer.viewport.applyConstraints();
         }
     }
 
-    // Left Arrow and Right Arrow
+    // Left Arrow, Right Arrow, AD keys
+    // Handle horizontal panning
     if (!viewer.preventHorizontalPan) {
-        if (isDown('ArrowLeft')) {
+        if (isDown('ArrowLeft') || isDown('KeyA')) {
             viewer.viewport.panBy(new OpenSeadragon.Point(-panDelta.x, 0));
             viewer.viewport.applyConstraints();
         }
-        if (isDown('ArrowRight')) {
+        if (isDown('ArrowRight') || isDown('KeyD')) {
             viewer.viewport.panBy(new OpenSeadragon.Point(panDelta.x, 0));
-            viewer.viewport.applyConstraints();
-        }
-    }
-
-    // WASD
-    if (!viewer.preventVerticalPan) {
-        if (isDown('KeyW')) {
-            if (shift) {
-                viewer.viewport.zoomBy(1.1);
-            } else {
-                viewer.viewport.panBy(new OpenSeadragon.Point(0, -panDelta40.y));
-            }
-            viewer.viewport.applyConstraints();
-        }
-        if (isDown('KeyS')) {
-            if (shift) {
-                viewer.viewport.zoomBy(0.9);
-            } else {
-                viewer.viewport.panBy(new OpenSeadragon.Point(0, panDelta40.y));
-            }
-            viewer.viewport.applyConstraints();
-        }
-    }
-
-    if (!viewer.preventHorizontalPan) {
-        if (isDown('KeyA')) {
-            viewer.viewport.panBy(new OpenSeadragon.Point(-panDelta40.x, 0));
-            viewer.viewport.applyConstraints();
-        }
-        if (isDown('KeyD')) {
-            viewer.viewport.panBy(new OpenSeadragon.Point(panDelta40.x, 0));
             viewer.viewport.applyConstraints();
         }
     }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4126,8 +4126,6 @@ function updateOnce( viewer ) {
     THIS[ viewer.hash ].animating = animated;
 
     //viewer.profiler.endUpdate();
-    viewer.viewport.applyConstraints();
-    viewer.draw();
 }
 
 function drawWorld( viewer ) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4022,7 +4022,6 @@ function handleArrowKeys(viewer) {
     const pixels = viewer.pixelsPerArrowPress;
     const panDelta = viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(pixels, pixels));
     const panDelta40 = viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(40, 40));
-    const rotationIncrement = viewer.rotationIncrement;
 
     // Shift key state
     const shift = isDown('Shift') || isDown('ShiftLeft') || isDown('ShiftRight');
@@ -4100,38 +4099,6 @@ function handleArrowKeys(viewer) {
         viewer.viewport.applyConstraints();
     }
 
-    // Home Reset 0 key
-    if (isDown('Digit0')) {
-        viewer.viewport.goHome();
-        viewer.viewport.applyConstraints();
-    }
-
-    // Rotation Controls
-    if (isDown('KeyR')) {
-        let increment = rotationIncrement;
-        if (shift) {
-            increment *= -1;
-        }
-        if (viewer.viewport.flipped) {
-            increment *= -1;
-        }
-        viewer.viewport.setRotation(viewer.viewport.getRotation() + increment);
-        viewer.viewport.applyConstraints();
-    }
-
-    // Flip Control
-    if (isDown('KeyF')) {
-        viewer.viewport.toggleFlip();
-        viewer.viewport.applyConstraints();
-    }
-
-    // Page Navigation
-    if (isDown('KeyJ')) {
-        viewer.goToPreviousPage();
-    }
-    if (isDown('KeyK')) {
-        viewer.goToNextPage();
-    }
 }
 
 function updateOnce( viewer ) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3109,7 +3109,7 @@ function onCanvasContextMenu( event ) {
  * allowing keyboard navigation logic to respond appropriately to key releases.
  */
 function onCanvasKeyUp(event) {
-    this._keysDown[event.key] = false;
+    this._keysDown[event.originalEvent.code] = false;
 }
 
 function onCanvasKeyDown( event ) {
@@ -3138,8 +3138,7 @@ function onCanvasKeyDown( event ) {
     this.raiseEvent('canvas-key', canvasKeyDownEventArgs);
 
     if (!canvasKeyDownEventArgs.preventDefaultAction) {
-        this._keysDown[event.key] = true; // Mark this key as held down in the viewer's internal tracking object
-        event.preventDefault(); // Prevent the browser's default action for this key
+        this._keysDown[canvasKeyDownEventArgs.originalEvent.code] = true; // Mark this key as held down in the viewer's internal tracking object
     }
 
     if ( !canvasKeyDownEventArgs.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
@@ -4015,8 +4014,8 @@ function doViewerResize(viewer, containerSize){
 function handleArrowKeys(viewer) {
 
     // Helper for key state
-    function isDown(key) {
-        return viewer._keysDown && viewer._keysDown[key];
+    function isDown(code) {
+        return viewer._keysDown && viewer._keysDown[code];
     }
 
      // Use the viewer's configured pan amount


### PR DESCRIPTION
Fix for #1609

1. A new property, _keysDown, was added to the viewer instance to track which keyboard keys are currently pressed. This enables the viewer to respond to continuous key presses, such as holding down an arrow key for smooth panning.

2. The onCanvasKeyDown and onCanvasKeyUp event handlers were implemented and registered. These handlers update the _keysDown property by setting the relevant key to true on keydown and to false on keyup, ensuring accurate tracking of user input.

3. The updateOnce function was modified to check the state of _keysDown for the arrow keys on each update cycle. If any arrow key is pressed, the viewer pans in the corresponding direction by a fixed amount (PAN_SPEED) per frame. This allows for responsive and continuous movement while keys are held.

4. The rest of the updateOnce function remains consistent with OpenSeadragon’s standard update logic, ensuring that the new keyboard panning integrates smoothly with existing features such as resizing, animation events, overlays, and navigator updates.