### PR TITLE
Optimization: matrix multiplication.

### DIFF
--- a/src/matrix3.js
+++ b/src/matrix3.js
@@ -1,3 +1,5 @@
+/* eslint-disable one-var-declaration-per-line */
+
 /*
  * OpenSeadragon - Mat3
  *
@@ -136,8 +138,8 @@ class Mat3{
      * @returns {OpenSeadragon.Mat3} A rotation matrix
      */
     static makeRotation(angleInRadians) {
-        var c = Math.cos(angleInRadians);
-        var s = Math.sin(angleInRadians);
+        const c = Math.cos(angleInRadians);
+        const s = Math.sin(angleInRadians);
         return new Mat3([
             c, -s, 0,
             s, c, 0,
@@ -171,24 +173,13 @@ class Mat3{
         let a = this.values;
         let b = other.values;
 
-        var a00 = a[0 * 3 + 0];
-        var a01 = a[0 * 3 + 1];
-        var a02 = a[0 * 3 + 2];
-        var a10 = a[1 * 3 + 0];
-        var a11 = a[1 * 3 + 1];
-        var a12 = a[1 * 3 + 2];
-        var a20 = a[2 * 3 + 0];
-        var a21 = a[2 * 3 + 1];
-        var a22 = a[2 * 3 + 2];
-        var b00 = b[0 * 3 + 0];
-        var b01 = b[0 * 3 + 1];
-        var b02 = b[0 * 3 + 2];
-        var b10 = b[1 * 3 + 0];
-        var b11 = b[1 * 3 + 1];
-        var b12 = b[1 * 3 + 2];
-        var b20 = b[2 * 3 + 0];
-        var b21 = b[2 * 3 + 1];
-        var b22 = b[2 * 3 + 2];
+        const a00 = a[0 * 3 + 0], a01 = a[0 * 3 + 1], a02 = a[0 * 3 + 2];
+        const a10 = a[1 * 3 + 0], a11 = a[1 * 3 + 1], a12 = a[1 * 3 + 2];
+        const a20 = a[2 * 3 + 0], a21 = a[2 * 3 + 1], a22 = a[2 * 3 + 2];
+        const b00 = b[0 * 3 + 0], b01 = b[0 * 3 + 1], b02 = b[0 * 3 + 2];
+        const b10 = b[1 * 3 + 0], b11 = b[1 * 3 + 1], b12 = b[1 * 3 + 2];
+        const b20 = b[2 * 3 + 0], b21 = b[2 * 3 + 1], b22 = b[2 * 3 + 2];
+
         return new Mat3([
             b00 * a00 + b01 * a10 + b02 * a20,
             b00 * a01 + b01 * a11 + b02 * a21,
@@ -200,6 +191,119 @@ class Mat3{
             b20 * a01 + b21 * a11 + b22 * a21,
             b20 * a02 + b21 * a12 + b22 * a22,
         ]);
+    }
+
+    /**
+     * Sets the values of the matrix.
+     * @param a00 top left
+     * @param a01 top middle
+     * @param a02 top right
+     * @param a10 middle left
+     * @param a11 middle middle
+     * @param a12 middle right
+     * @param a20 bottom left
+     * @param a21 bottom middle
+     * @param a22 bottom right
+     */
+    setValues(a00, a01, a02,
+              a10, a11, a12,
+              a20, a21, a22) {
+        this.values[0] = a00;
+        this.values[1] = a01;
+        this.values[2] = a02;
+        this.values[3] = a10;
+        this.values[4] = a11;
+        this.values[5] = a12;
+        this.values[6] = a20;
+        this.values[7] = a21;
+        this.values[8] = a22;
+    }
+
+    /**
+     * Scaling & translation only changes certain values, no need to compute full matrix multiplication.
+     * @memberof OpenSeadragon.Mat3
+     * @returns {OpenSeadragon.Mat3} The result of matrix multiplication
+     */
+    scaleAndTranslate(sx, sy, tx, ty) {
+        const a = this.values;
+        const a00 = a[0];
+        const a01 = a[1];
+        const a02 = a[2];
+        const a10 = a[3];
+        const a11 = a[4];
+        const a12 = a[5];
+        return new Mat3([
+            sx * a00,
+            sx * a01,
+            sx * a02,
+            sy * a10,
+            sy * a11,
+            sy * a12,
+            tx * a00 + ty * a10,
+            tx * a01 + ty * a11,
+            tx * a02 + ty * a12,
+        ]);
+    }
+
+    /**
+     * Scaling & translation only changes certain values, no need to compute full matrix multiplication.
+     * Optimization: in case the original matrix can be thrown away, optimize instead by computing in-place.
+     * @memberof OpenSeadragon.Mat3
+     */
+    scaleAndTranslateSelf(sx, sy, tx, ty) {
+        const a = this.values;
+
+        const m00 = a[0], m01 = a[1], m02 = a[2];
+        const m10 = a[3], m11 = a[4], m12 = a[5];
+
+        a[0] = sx * m00;
+        a[1] = sx * m01;
+        a[2] = sx * m02;
+
+        a[3] = sy * m10;
+        a[4] = sy * m11;
+        a[5] = sy * m12;
+
+        a[6] = tx * m00 + ty * m10 + a[6];
+        a[7] = tx * m01 + ty * m11 + a[7];
+        a[8] = tx * m02 + ty * m12 + a[8];
+    }
+
+    /**
+     * Move and translate another matrix by self. 'this' matrix must be scale & translate matrix.
+     * Optimization: in case the original matrix can be thrown away, optimize instead by computing in-place.
+     * Used for optimization: we have
+     * A) THIS matrix, carrying scale and translation,
+     * B) OTHER general matrix to scale and translate.
+     * Since THIS matrix is unique per tile, we can optimize the operation by:
+     *  - move & scale OTHER by THIS, and
+     *  - store the result to THIS, since we don't need to keep the scaling and translation, but
+     *    we need to keep the original OTHER matrix (for each tile within tiled image).
+     * @param {OpenSeadragon.Mat3} other the matrix to scale and translate by this matrix and accept values from
+     * @memberof OpenSeadragon.Mat3
+     */
+    scaleAndTranslateOtherSetSelf(other) {
+        const a = other.values;
+        const out = this.values;
+
+        // Read scale and translation values from 'this'
+        const sx = out[0]; // scale X (this[0])
+        const sy = out[4]; // scale Y (this[4])
+        const tx = out[6]; // translate X
+        const ty = out[7]; // translate Y
+
+        // Compute result = this * other, store into this.values (in-place)
+        out[0] = sx * a[0];
+        out[1] = sx * a[1];
+        out[2] = sx * a[2];
+
+        out[3] = sy * a[3];
+        out[4] = sy * a[4];
+        out[5] = sy * a[5];
+
+        out[6] = tx * a[0] + ty * a[3] + a[6];
+        out[7] = tx * a[1] + ty * a[4] + a[7];
+        out[8] = tx * a[2] + ty * a[5] + a[8];
     }
 }
 

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -733,12 +733,11 @@
             attribute vec2 a_output_position;
             attribute vec2 a_texture_position;
 
-            uniform mat3 u_matrix;
-
             varying vec2 v_texture_position;
 
             void main() {
-                gl_Position = vec4(u_matrix * vec3(a_output_position, 1), 1);
+                // Transform to clip space
+                gl_Position = vec4(vec3(a_output_position * 2.0 - 0.5, 1), 1);
 
                 v_texture_position = a_texture_position;
             }
@@ -772,7 +771,6 @@
                 shaderProgram: program,
                 aOutputPosition: gl.getAttribLocation(program, 'a_output_position'),
                 aTexturePosition: gl.getAttribLocation(program, 'a_texture_position'),
-                uMatrix: gl.getUniformLocation(program, 'u_matrix'),
                 uImage: gl.getUniformLocation(program, 'u_image'),
                 uOpacityMultiplier: gl.getUniformLocation(program, 'u_opacity_multiplier'),
                 bufferOutputPosition: gl.createBuffer(),
@@ -789,10 +787,6 @@
             gl.bindBuffer(gl.ARRAY_BUFFER, this._secondPass.bufferTexturePosition);
             gl.bufferData(gl.ARRAY_BUFFER, this._unitQuad, gl.DYNAMIC_DRAW); // bind data statically here since it's unchanging
             gl.enableVertexAttribArray(this._secondPass.aTexturePosition);
-
-            // set the matrix that transforms the framebuffer to clip space  // todo delete
-            let matrix = $.Mat3.makeScaling(2, 2).multiply($.Mat3.makeTranslation(-0.5, -0.5));
-            gl.uniformMatrix3fv(this._secondPass.uMatrix, false, matrix.values);
         }
 
         // private

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -733,8 +733,6 @@
             attribute vec2 a_output_position;
             attribute vec2 a_texture_position;
 
-            uniform mat3 u_matrix;
-
             varying vec2 v_texture_position;
 
             void main() {
@@ -773,7 +771,6 @@
                 shaderProgram: program,
                 aOutputPosition: gl.getAttribLocation(program, 'a_output_position'),
                 aTexturePosition: gl.getAttribLocation(program, 'a_texture_position'),
-                uMatrix: gl.getUniformLocation(program, 'u_matrix'),
                 uImage: gl.getUniformLocation(program, 'u_image'),
                 uOpacityMultiplier: gl.getUniformLocation(program, 'u_opacity_multiplier'),
                 bufferOutputPosition: gl.createBuffer(),

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -733,11 +733,13 @@
             attribute vec2 a_output_position;
             attribute vec2 a_texture_position;
 
+            uniform mat3 u_matrix;
+
             varying vec2 v_texture_position;
 
             void main() {
-                // Transform to clip space
-                gl_Position = vec4(vec3(a_output_position * 2.0 - 0.5, 1), 1);
+                // Transform to clip space (0:1 --> -1:1)
+                gl_Position = vec4(vec3(a_output_position * 2.0 - 1.0, 1), 1);
 
                 v_texture_position = a_texture_position;
             }
@@ -771,6 +773,7 @@
                 shaderProgram: program,
                 aOutputPosition: gl.getAttribLocation(program, 'a_output_position'),
                 aTexturePosition: gl.getAttribLocation(program, 'a_texture_position'),
+                uMatrix: gl.getUniformLocation(program, 'u_matrix'),
                 uImage: gl.getUniformLocation(program, 'u_image'),
                 uOpacityMultiplier: gl.getUniformLocation(program, 'u_opacity_multiplier'),
                 bufferOutputPosition: gl.createBuffer(),


### PR DESCRIPTION
When implementing advanceed renderer, one of optimizations I arrived at are optimizations on matrices. Since for now we will try to develop the renderer as a plugin, necessary optimizations are added in this PR & WebGL renderer gets the optimization applied where it's simple to do. <strike>Missing optimization on  WebGL renderer is that `_calculateOverlapFraction` can be also cached and not computed each frame (unless tile position changes which should not happen IMHO).</strike>