### PR TITLE
Fix: Hidden container resize issue (This partially addresses #2659 — handling redraw when the viewer is initialized in a hidden container.)

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -267,7 +267,7 @@ $.Viewer = function( options ) {
     this.canvas.className = "openseadragon-canvas";
 
     // BEGIN: Visibility Redraw Observer
-    if (typeof window.IntersectionObserver !== 'undefined') {
+    if (typeof window.IntersectionObserver !== "undefined") {
         const observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
@@ -281,7 +281,7 @@ $.Viewer = function( options ) {
             });
         }, { threshold: 0.1 });
 
-        observer.observe(_this.container);
+        observer.observe(this.container);
     }
     // END: Visibility Redraw Observer
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -266,6 +266,30 @@ $.Viewer = function( options ) {
     this.canvas               = $.makeNeutralElement( "div" );
     this.canvas.className = "openseadragon-canvas";
 
+    // BEGIN: Visibility Redraw Observer
+    const self = this;
+
+    if (typeof IntersectionObserver !== 'undefined') {
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    const width = self.container.clientWidth;
+                    const height = self.container.clientHeight;
+
+                    if (width > 0 && height > 0) {
+                        self.viewport.resize(width, height, true);
+                        self.forceRedraw();
+                        console.log("[OpenSeadragon] Auto-resized on visibility.");
+                    }
+                }
+            });
+        }, { threshold: 0.1 });
+
+        observer.observe(this.container);
+    }
+    // END: Visibility Redraw Observer
+
+
     // Injecting mobile-only CSS to remove focus outline
     if (!document.querySelector('style[data-openseadragon-mobile-css]')) {
         var style = document.createElement('style');
@@ -854,6 +878,14 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         for (var i = 0; i < tileSources.length; i++) {
             doOne(tileSources[i]);
         }
+
+        setTimeout(() => {
+            if (this.container && this.container.clientWidth > 0 && this.container.clientHeight > 0) {
+                this.viewport.resize(this.container.clientWidth, this.container.clientHeight, true);
+                this.forceRedraw();
+                console.log("[fix-2660] Forced resize and redraw on open.");
+            }
+        }, 100);
 
         return this;
     },

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -267,25 +267,21 @@ $.Viewer = function( options ) {
     this.canvas.className = "openseadragon-canvas";
 
     // BEGIN: Visibility Redraw Observer
-    const self = this;
-
-    if (typeof IntersectionObserver !== 'undefined') {
+    if (typeof window.IntersectionObserver !== 'undefined') {
         const observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
-                    const width = self.container.clientWidth;
-                    const height = self.container.clientHeight;
+                    const width = _this.container.clientWidth;
+                    const height = _this.container.clientHeight;
 
                     if (width > 0 && height > 0) {
-                        self.viewport.resize(width, height, true);
-                        self.forceRedraw();
-                        console.log("[OpenSeadragon] Auto-resized on visibility.");
+                        _this.forceResize();
                     }
                 }
             });
         }, { threshold: 0.1 });
 
-        observer.observe(this.container);
+        observer.observe(_this.container);
     }
     // END: Visibility Redraw Observer
 
@@ -878,14 +874,6 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         for (var i = 0; i < tileSources.length; i++) {
             doOne(tileSources[i]);
         }
-
-        setTimeout(() => {
-            if (this.container && this.container.clientWidth > 0 && this.container.clientHeight > 0) {
-                this.viewport.resize(this.container.clientWidth, this.container.clientHeight, true);
-                this.forceRedraw();
-                console.log("[fix-2660] Forced resize and redraw on open.");
-            }
-        }, 100);
 
         return this;
     },


### PR DESCRIPTION
Fix for hidden container rendering issue.
This pull request addresses a common issue where OpenSeadragon doesn't render images correctly if the viewer is placed inside a container that is hidden (for example, using display: none) when it's first created. When that container later becomes visible, the viewer doesn't automatically update or redraw, so the image remains blank or doesn't load properly.

What I did is as follows, 

1.Added a check that watches for when the viewer's container becomes visible.

2.When it does, the viewer is forced to resize and redraw itself based on the actual container size.

3.This makes sure the image appears correctly when toggling visibility, like when using tabs or collapsible panels.

These are needed because, many applications use hidden containers for things like tabs or popups. Without this fix, the viewer doesn’t display images properly unless the developer manually triggers a redraw. This change helps make OpenSeadragon work better out of the box in real-world interfaces.

I tested it by creating a simple HTML page where the viewer starts inside a hidden `<div>` that can be toggled visible. With the fix, the image now appears correctly every time the container is shown.

Let me know if you’d like any changes.