### PR TITLE
Fix openseadragon#2756: Improve Ajax headers propagation

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2889,8 +2889,7 @@ function getTileSourceImplementation( viewer, tileSource, imgOptions, successCal
                 crossOriginPolicy: imgOptions.crossOriginPolicy !== undefined ?
                     imgOptions.crossOriginPolicy : viewer.crossOriginPolicy,
                 ajaxWithCredentials: viewer.ajaxWithCredentials,
-                ajaxHeaders: imgOptions.ajaxHeaders ?
-                    imgOptions.ajaxHeaders : viewer.ajaxHeaders,
+                ajaxHeaders: $.extend({}, viewer.ajaxHeaders, imgOptions.ajaxHeaders),
                 splitHashDataForPost: viewer.splitHashDataForPost,
                 success: function( event ) {
                     successCallback( event.tileSource );


### PR DESCRIPTION
This change should fix openseadragon#2756, ajax headers propagation from viewer down to tile sources.