### PR TITLE
Add Iris Tilesource

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,7 @@ module.exports = function(grunt) {
             "src/dzitilesource.js",
             "src/iiiftilesource.js",
             "src/iiptilesource.js",
+            "src/iristilesource.js",
             "src/osmtilesource.js",
             "src/tmstilesource.js",
             "src/zoomifytilesource.js",

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -42,10 +42,12 @@
    * @memberof OpenSeadragon
    * @extends OpenSeadragon.TileSource
    *
+   * @param {String} type       - iris
    * @param {String} serverUrl  - Iris host server path (ex: "http://localhost:3000")
    * @param {String} slideId    - Image id (ex: "12345" for 12345.iris)
    *
    * Example: tileSources: {
+   *            type:         "iris",
    *            serverUrl:    "http://localhost:3000",
    *            slideId:      "12345"
    *          }
@@ -60,7 +62,6 @@
     this.tileOverlap = 0;
     this.minLevel = 0;
     this.maxLevel = 0;
-    this.maxZoomLevel = 0;
     this.ready = false;
 
     this.fetchMetadata = options.fetchMetadata || this.defaultFetchMetadata;
@@ -107,8 +108,6 @@
 
       this.levelScales = data.extent.layers.map(level => level.scale);
       this.maxLevel = data.extent.layers.length - 1;
-
-      this.maxZoomLevel = Math.max(...this.levelScales);
     },
 
     defaultFetchMetadata: function(url, context) {

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -164,7 +164,6 @@
         return;
       }
 
-      // Update internal properties with new options
       if (options.serverUrl) {
         this.serverUrl = options.serverUrl;
       }
@@ -172,7 +171,6 @@
         this.slideId = options.slideId;
       }
 
-      // Re-fetch metadata if configuration changes
       this.ready = false;
       const url = this.getMetadataUrl();
       this.fetchMetadata(url, this);

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -90,16 +90,16 @@
       const maxLayer = layers.length - 1;
       const maxScale = layers[maxLayer].scale;
 
-      this.width = parseInt(Math.ceil(data.extent.width * maxScale), 10);
-      this.height = parseInt(Math.ceil(data.extent.height * maxScale), 10);
+      this.width = Math.ceil(data.extent.width * maxScale);
+      this.height = Math.ceil(data.extent.height * maxScale);
 
       this.dimensions = new $.Point(this.width, this.height);
       this.aspectRatio = this.width / this.height;
       this.levelSizes = layers.map(level => ({
-        width: parseInt(Math.ceil(level.x_tiles * level.scale), 10),
-        height: parseInt(Math.ceil(level.y_tiles * level.scale), 10),
-        xTiles: parseInt(Math.ceil(level.x_tiles), 10),
-        yTiles: parseInt(Math.ceil(level.y_tiles), 10)
+        width: Math.ceil(level.x_tiles * level.scale),
+        height: Math.ceil(level.y_tiles * level.scale),
+        xTiles: Math.ceil(level.x_tiles),
+        yTiles: Math.ceil(level.y_tiles)
       }));
 
       this.levelScales = layers.map(level =>
@@ -107,7 +107,7 @@
       );
 
       this.minLevel = 0;
-      this.maxLevel = parseInt(Math.ceil(this.levelSizes.length - 1), 10);
+      this.maxLevel = Math.ceil(this.levelSizes.length - 1);
     },
 
     defaultFetchMetadata: function(url, context) {
@@ -141,8 +141,8 @@
         return new $.Point(0, 0);
       }
       return new $.Point(
-        parseInt(Math.ceil(this.levelSizes[level].xTiles), 10),
-        parseInt(Math.ceil(this.levelSizes[level].yTiles), 10)
+        Math.ceil(this.levelSizes[level].xTiles),
+        Math.ceil(this.levelSizes[level].yTiles)
       );
     },
 

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -87,27 +87,33 @@
       this._tileWidth = 256;
       this._tileHeight = 256;
 
-      this.width = data.extent.width;
-      this.height = data.extent.height;
+      this.tileSize = this._tileWidth;
+      this.tileOverlap = 0;
 
-      if (this.width <= 0 || this.height <= 0) {
-        const msg = "Invalid dimensions received from metadata.";
-        $.console.error(msg);
-        this.raiseEvent('open-failed', { message: msg });
-        return;
-      }
+      const layers = data.extent.layers;
+
+      const maxLayer = layers.length - 1;
+      const maxScale = layers[maxLayer].scale;
+      this.width = data.extent.width * maxScale;
+      this.height = data.extent.height * maxScale;
 
       this.dimensions = new $.Point(this.width, this.height);
       this.aspectRatio = this.width / this.height;
-
-      this.levelSizes = data.extent.layers.map(level => ({
+      this.levelSizes = layers.map(level => ({
         width: level.x_tiles * this._tileWidth,
         height: level.y_tiles * this._tileHeight,
-        xTiles: level.x_tiles
+        xTiles: level.x_tiles,
+        yTiles: level.y_tiles
       }));
 
-      this.levelScales = data.extent.layers.map(level => level.scale);
-      this.maxLevel = data.extent.layers.length - 1;
+      const fullResWidth = this.levelSizes[this.levelSizes.length - 1].width;
+
+      this.levelScales = this.levelSizes.map(level =>
+        level.width / fullResWidth
+      );
+
+      this.minLevel = 0;
+      this.maxLevel = this.levelSizes.length - 1;
     },
 
     defaultFetchMetadata: function(url, context) {
@@ -137,18 +143,15 @@
     },
 
     getNumTiles: function(level) {
-      var levelSize = this.levelSizes[level];
-      var x = Math.ceil(levelSize.width / this._tileWidth);
-      var y = Math.ceil(levelSize.height / this._tileHeight);
-
-      return new $.Point(x, y);
+      if (level < this.minLevel || level > this.maxLevel || !this.levelSizes[level]) {
+        return new $.Point(0, 0);
+      }
+      return new $.Point(this.levelSizes[level].xTiles, this.levelSizes[level].yTiles);
     },
 
     getTileUrl: function(level, x, y) {
       const pos = y * this.levelSizes[level].xTiles + x;
-      const url = `${this.serverUrl}/slides/${this.slideId}/layers/${level}/tiles/${pos}`;
-
-      return url;
+      return `${this.serverUrl}/slides/${this.slideId}/layers/${level}/tiles/${pos}`;
     },
 
     getLevelScale: function(level) {

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -1,0 +1,176 @@
+/**
+ * OpenSeadragon - IrisTileSource
+ *
+ * Copyright (C) 2009 CodePlex Foundation
+ * Copyright (C) 2010-2025 OpenSeadragon contributors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * - Neither the name of CodePlex Foundation nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. *
+ *
+ */
+
+(function($) {
+
+  /**
+   * @class IrisTileSource
+   * @classdesc A tilesource implementation for use with Iris images.
+   *
+   * @memberof OpenSeadragon
+   * @extends OpenSeadragon.TileSource
+   *
+   * @param {String} serverUrl  - Iris host server path (ex: "http://localhost:3000")
+   * @param {String} slideId    - Image id (ex: "12345" for 12345.iris)
+   *
+   * Example: tileSources: {
+   *            serverUrl:    "http://localhost:3000",
+   *            slideId:      "12345"
+   *          }
+   */
+
+  $.IrisTileSource = function(options) {
+    $.EventSource.call(this);
+
+    if (options && options.serverUrl && options.slideId) {
+      $.extend(this, options);
+
+      this.aspectRatio = 1;
+      this.dimensions  = new $.Point(0, 0);
+      this._tileWidth  = 0;
+      this._tileHeight = 0;
+      this.tileOverlap = 0;
+      this.minLevel    = 0;
+      this.maxLevel    = 0;
+      this.ready       = false;
+
+      this.fetchMetadata = options.fetchMetadata || this.defaultFetchMetadata;
+
+      var url = this.getMetadataUrl();
+      this.fetchMetadata(url, this);
+    }
+  };
+
+  $.extend($.IrisTileSource.prototype, $.TileSource.prototype, {
+    getMetadataUrl: function() {
+      return this.serverUrl + '/slides/' + this.slideId + '/metadata';
+    },
+
+    supports: function(data) {
+      return (data && ("serverUrl" in data) && ("slideId" in data));
+    },
+
+    parseMetadata: function(data) {
+      this._tileWidth = 256;
+      this._tileHeight = 256;
+
+      this.width = data.extent.width;
+      this.height = data.extent.height;
+
+      if (this.width <= 0 || this.height <= 0) {
+        console.error("Invalid dimensions received from metadata.");
+      }
+
+      this.dimensions = new $.Point(this.width, this.height);
+      this.aspectRatio = this.width / this.height;
+
+      this.levelSizes = data.extent.layers.map(level => ({
+        width: level.x_tiles * this._tileWidth,
+        height: level.y_tiles * this._tileHeight,
+        xTiles: level.x_tiles
+      }));
+
+      this.levelScales = data.extent.layers.map(level => level.scale);
+      this.maxLevel = data.extent.layers.length - 1;
+    },
+
+    defaultFetchMetadata: function(url, context) {
+      $.makeAjaxRequest({
+        url: url,
+        type: "GET",
+        async: true,
+        success: function(xhr) {
+          try {
+            const data = JSON.parse(xhr.responseText);
+            context.parseMetadata(data);
+            context.ready = true;
+            context.raiseEvent('ready', { tileSource: context });
+          }
+          catch (e) {
+            var msg = "IrisTileSource: Error parsing metadata: " + e.message;
+            console.error(msg);
+            context.raiseEvent('open-failed', { message: msg, source: url });
+          }
+        },
+        error: function(xhr, exc) {
+          var msg = "IrisTileSource: Unable to get metadata from " + url;
+          console.error(msg);
+          context.raiseEvent('open-failed', { message: msg, source: url });
+        }
+      });
+    },
+
+    getNumTiles: function(level) {
+      var levelSize = this.levelSizes[level];
+      var x = Math.ceil(levelSize.width / this._tileWidth);
+      var y = Math.ceil(levelSize.height / this._tileHeight);
+
+      return new $.Point(x, y);
+    },
+
+    getTileUrl: function(level, x, y) {
+      const pos = y * this.levelSizes[level].xTiles + x;
+      const url = `${this.serverUrl}/slides/${this.slideId}/layers/${level}/tiles/${pos}`;
+
+      return url;
+    },
+
+    getLevelScale: function(level) {
+      return this.levelScales[level];
+    },
+
+    configure: function(options) {
+      if (!options) {
+        console.error('No options provided to configure.');
+        return;
+      }
+
+      if (options.serverUrl) {
+        this.serverUrl = options.serverUrl;
+      }
+      if (options.slideId) {
+        this.slideId = options.slideId;
+      }
+
+      this.ready = false;
+      const url = this.getMetadataUrl();
+      this.fetchMetadata(url, this);
+    }
+
+  });
+
+  $.extend(true, $.IrisTileSource.prototype, $.EventSource.prototype);
+
+}(OpenSeadragon));

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -68,14 +68,30 @@
   };
 
   $.extend($.IrisTileSource.prototype, $.TileSource.prototype, {
+    /**
+     * Return URL string for image metadata
+     * @function
+     * @returns {String} url - The Iris metadata URL
+     */
     getMetadataUrl: function() {
       return this.serverUrl + '/slides/' + this.slideId + '/metadata';
     },
 
+    /**
+     * Determine if the data implies the image service is supported by this tile source.
+     * @function
+     * @param {Object} data - The raw metadata object to check
+     * @returns {Boolean} - True if supported, false otherwise
+     */
     supports: function(data) {
       return (data && data.type === "iris" && data.serverUrl && data.slideId);
     },
 
+    /**
+     * Parse Iris protocol metadata response
+     * @function
+     * @param {Object} data - Raw metadata from an Iris server
+     */
     parseMetadata: function(data) {
       this._tileWidth = 256;
       this._tileHeight = 256;
@@ -106,6 +122,12 @@
       this.maxLevel = Math.ceil(this.levelSizes.length - 1);
     },
 
+    /**
+     * Default method to retrieve image metadata from an Iris-compatible server
+     * @function
+     * @param {String} url - The metadata URL
+     * @param {Object} context - The context (the tile source instance)
+     */
     defaultFetchMetadata: function(url, context) {
       $.makeAjaxRequest({
         url: url,
@@ -132,6 +154,12 @@
       });
     },
 
+    /**
+     * Get the number of tiles at a given level
+     * @function
+     * @param {Number} level - The image depth level
+     * @returns {OpenSeadragon.Point} - Number of tiles in x and y directions
+     */
     getNumTiles: function(level) {
       if (level < this.minLevel || level > this.maxLevel || !this.levelSizes[level]) {
         return new $.Point(0, 0);
@@ -142,15 +170,35 @@
       );
     },
 
+    /**
+     * Determine the URL which will return an image for the region specified by the given x, y, and level components.
+     * @function
+     * @param {Number} level - The zoom level
+     * @param {Number} x - The x tile index
+     * @param {Number} y - The y tile index
+     * @returns {String} - The tile URL
+     */
     getTileUrl: function(level, x, y) {
       const pos = y * this.levelSizes[level].xTiles + x;
       return `${this.serverUrl}/slides/${this.slideId}/layers/${level}/tiles/${pos}`;
     },
 
+    /**
+     * Get the scale for a given level
+     * @function
+     * @param {Number} level - The image depth level
+     * @returns {Number} - The scale for the level
+     */
     getLevelScale: function(level) {
       return this.levelScales[level];
     },
 
+    /**
+     * Retrieve and immediately return the options object
+     * @function
+     * @param {Object} options - Options object
+     * @returns {Object} - The options object
+     */
     configure: function (options) {
       return options;
     }

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -59,7 +59,6 @@
     this.dimensions = new $.Point(0, 0);
     this._tileWidth = 0;
     this._tileHeight = 0;
-    this.tileOverlap = 0;
     this.minLevel = 0;
     this.maxLevel = 0;
     this.ready = false;
@@ -67,7 +66,6 @@
     this.fetchMetadata = options.fetchMetadata || this.defaultFetchMetadata;
 
     $.TileSource.apply(this, [options]);
-
     if (options && options.serverUrl && options.slideId) {
       var url = this.getMetadataUrl();
       this.fetchMetadata(url, this);
@@ -87,33 +85,29 @@
       this._tileWidth = 256;
       this._tileHeight = 256;
 
-      this.tileSize = this._tileWidth;
-      this.tileOverlap = 0;
-
       const layers = data.extent.layers;
 
       const maxLayer = layers.length - 1;
       const maxScale = layers[maxLayer].scale;
-      this.width = data.extent.width * maxScale;
-      this.height = data.extent.height * maxScale;
+
+      this.width = parseInt(Math.ceil(data.extent.width * maxScale), 10);
+      this.height = parseInt(Math.ceil(data.extent.height * maxScale), 10);
 
       this.dimensions = new $.Point(this.width, this.height);
       this.aspectRatio = this.width / this.height;
       this.levelSizes = layers.map(level => ({
-        width: level.x_tiles * this._tileWidth,
-        height: level.y_tiles * this._tileHeight,
-        xTiles: level.x_tiles,
-        yTiles: level.y_tiles
+        width: parseInt(Math.ceil(level.x_tiles * level.scale), 10),
+        height: parseInt(Math.ceil(level.y_tiles * level.scale), 10),
+        xTiles: parseInt(Math.ceil(level.x_tiles), 10),
+        yTiles: parseInt(Math.ceil(level.y_tiles), 10)
       }));
 
-      const fullResWidth = this.levelSizes[this.levelSizes.length - 1].width;
-
-      this.levelScales = this.levelSizes.map(level =>
-        level.width / fullResWidth
+      this.levelScales = layers.map(level =>
+        level.scale / maxScale
       );
 
       this.minLevel = 0;
-      this.maxLevel = this.levelSizes.length - 1;
+      this.maxLevel = parseInt(Math.ceil(this.levelSizes.length - 1), 10);
     },
 
     defaultFetchMetadata: function(url, context) {
@@ -146,7 +140,10 @@
       if (level < this.minLevel || level > this.maxLevel || !this.levelSizes[level]) {
         return new $.Point(0, 0);
       }
-      return new $.Point(this.levelSizes[level].xTiles, this.levelSizes[level].yTiles);
+      return new $.Point(
+        parseInt(Math.ceil(this.levelSizes[level].xTiles), 10),
+        parseInt(Math.ceil(this.levelSizes[level].yTiles), 10)
+      );
     },
 
     getTileUrl: function(level, x, y) {

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -60,6 +60,7 @@
     this.tileOverlap = 0;
     this.minLevel = 0;
     this.maxLevel = 0;
+    this.maxZoomLevel = 0;
     this.ready = false;
 
     this.fetchMetadata = options.fetchMetadata || this.defaultFetchMetadata;
@@ -106,6 +107,8 @@
 
       this.levelScales = data.extent.layers.map(level => level.scale);
       this.maxLevel = data.extent.layers.length - 1;
+
+      this.maxZoomLevel = Math.max(...this.levelScales);
     },
 
     defaultFetchMetadata: function(url, context) {

--- a/test/coverage.html
+++ b/test/coverage.html
@@ -92,6 +92,7 @@
     <script src="/test/modules/imageloader.js"></script>
     <script src="/test/modules/iiif.js"></script>
     <script src="/test/modules/iip.js"></script>
+    <script src="/test/modules/iris.js"></script>
     <!-- The navigator tests are the slowest (for now; hopefully they can be sped up)
     so we put them last. -->
     <script src="/test/modules/navigator.js"></script>

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -28,7 +28,12 @@
         });
 
         assert.ok(test.ready, "IrisTileSource should be ready after mock metadata");
-        assert.equal(test.width, mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale, "Width should be correctly parsed from mock metadata");
+
+        const expectedWidth = parseInt(Math.ceil(
+            mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
+        ), 10);
+
+        assert.equal(test.width, expectedWidth, "Width should be correctly parsed from mock metadata");
 
         const expectedUrl = "http://localhost/slides/12345/metadata";
         assert.equal(test.getMetadataUrl(), expectedUrl, "Metadata URL should match expected format");
@@ -44,9 +49,16 @@
         test.parseMetadata(mockMetadata);
 
         // Check dimensions
+        const expectedWidth = parseInt(Math.ceil(
+            mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
+        ), 10);
+        const expectedHeight = parseInt(Math.ceil(
+            mockMetadata.extent.height * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
+        ), 10);
+
         assert.ok(test.width, "Width exists");
-        assert.equal(test.width, mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale, "Parsing width correctly");
-        assert.equal(test.height, mockMetadata.extent.height * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale, "Parsing height correctly");
+        assert.equal(test.width, expectedWidth, "Parsing width correctly");
+        assert.equal(test.height, expectedHeight, "Parsing height correctly");
 
         // Check level sizes and scales
         assert.ok(test.levelSizes, "Level sizes exist");
@@ -59,10 +71,10 @@
         assert.deepEqual(
             test.levelScales,
             [
-                mockMetadata.extent.layers[0].x_tiles / (mockMetadata.extent.layers[3].x_tiles),
-                mockMetadata.extent.layers[1].x_tiles / (mockMetadata.extent.layers[3].x_tiles),
-                mockMetadata.extent.layers[2].x_tiles / (mockMetadata.extent.layers[3].x_tiles),
-                mockMetadata.extent.layers[3].x_tiles / (mockMetadata.extent.layers[3].x_tiles)
+                (mockMetadata.extent.layers[0].scale / mockMetadata.extent.layers[3].scale),
+                (mockMetadata.extent.layers[1].scale / mockMetadata.extent.layers[3].scale),
+                (mockMetadata.extent.layers[2].scale / mockMetadata.extent.layers[3].scale),
+                (mockMetadata.extent.layers[3].scale / mockMetadata.extent.layers[3].scale)
             ],
             "Parsing scales correctly"
         );
@@ -75,7 +87,6 @@
             fetchMetadata: mockFetchMetadata
         });
 
-        // Test tile URL generation
         assert.equal(
             test.getTileUrl(0, 0, 0),
             "http://localhost/slides/12345/layers/0/tiles/0",

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -62,7 +62,7 @@
 
         // Check level sizes and scales
         assert.ok(test.levelSizes, "Level sizes exist");
-        assert.equal(typeof test.levelSizes, "object", "Level sizes is an array");
+        assert.ok(Array.isArray(test.levelSizes), "Level sizes is an array");
         assert.equal(test.levelSizes.length, 4, "Number of levels is correct");
         assert.equal(test.maxLevel, 3, "Max level is correctly set");
 

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -48,7 +48,7 @@
 
         test.parseMetadata(mockMetadata);
 
-        // Check the dimensions
+        // Check dimensions
         const expectedWidth = parseInt(Math.ceil(
             mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
         ), 10);

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -65,7 +65,6 @@
         assert.ok(Array.isArray(test.levelSizes), "Level sizes is an array");
         assert.equal(test.levelSizes.length, 4, "Number of levels is correct");
         assert.equal(test.maxLevel, 3, "Max level is correctly set");
-        assert.equal(test.maxZoomLevel, 64.0141, "Max zoom level is correctly set");
 
         assert.ok(test.levelScales, "Level scales exist");
         assert.equal(test.levelScales.length, 4, "Number of scales matches number of levels");

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -48,7 +48,7 @@
 
         test.parseMetadata(mockMetadata);
 
-        // Check dimensions
+        // Check the dimensions
         const expectedWidth = parseInt(Math.ceil(
             mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
         ), 10);

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -1,20 +1,21 @@
 (function() {
     QUnit.module('Iris');
 
+    const mockMetadata = {
+        extent: {
+            width: 1983,
+            height: 1381,
+            layers: [
+                { x_tiles: 8, y_tiles: 6, scale: 1 },
+                { x_tiles: 31, y_tiles: 22, scale: 4.0005 },
+                { x_tiles: 124, y_tiles: 87, scale: 16.0035 },
+                { x_tiles: 496, y_tiles: 346, scale: 64.0141 }
+            ]
+        }
+    };
+
     const mockFetchMetadata = function(url, context) {
-        const metadata = {
-            extent: {
-                width: 1983,
-                height: 1381,
-                layers: [
-                    { x_tiles: 8, y_tiles: 6, scale: 1 },
-                    { x_tiles: 31, y_tiles: 22, scale: 4.0005 },
-                    { x_tiles: 124, y_tiles: 87, scale: 16.0035 },
-                    { x_tiles: 496, y_tiles: 346, scale: 64.0141 }
-                ]
-            }
-        };
-        context.parseMetadata(metadata);
+        context.parseMetadata(mockMetadata);
         context.ready = true;
         context.raiseEvent('ready', { tileSource: context });
     };
@@ -27,7 +28,7 @@
         });
 
         assert.ok(test.ready, "IrisTileSource should be ready after mock metadata");
-        assert.equal(test.width, 1983, "Width should be correctly parsed from mock metadata");
+        assert.equal(test.width, mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale, "Width should be correctly parsed from mock metadata");
 
         const expectedUrl = "http://localhost/slides/12345/metadata";
         assert.equal(test.getMetadataUrl(), expectedUrl, "Metadata URL should match expected format");
@@ -40,35 +41,31 @@
             fetchMetadata: () => {}
         });
 
-        const metadata = {
-            extent: {
-                width: 1983,
-                height: 1381,
-                layers: [
-                    { x_tiles: 8, y_tiles: 6, scale: 1 },
-                    { x_tiles: 31, y_tiles: 22, scale: 4.0005 },
-                    { x_tiles: 124, y_tiles: 87, scale: 16.0035 },
-                    { x_tiles: 496, y_tiles: 346, scale: 64.0141 }
-                ]
-            }
-        };
-
-        test.parseMetadata(metadata);
+        test.parseMetadata(mockMetadata);
 
         // Check dimensions
         assert.ok(test.width, "Width exists");
-        assert.equal(test.width, 1983, "Parsing width correctly");
-        assert.equal(test.height, 1381, "Parsing height correctly");
+        assert.equal(test.width, mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale, "Parsing width correctly");
+        assert.equal(test.height, mockMetadata.extent.height * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale, "Parsing height correctly");
 
         // Check level sizes and scales
         assert.ok(test.levelSizes, "Level sizes exist");
         assert.ok(Array.isArray(test.levelSizes), "Level sizes is an array");
-        assert.equal(test.levelSizes.length, 4, "Number of levels is correct");
-        assert.equal(test.maxLevel, 3, "Max level is correctly set");
+        assert.equal(test.levelSizes.length, mockMetadata.extent.layers.length, "Number of levels is correct");
+        assert.equal(test.maxLevel, mockMetadata.extent.layers.length - 1, "Max level is correctly set");
 
         assert.ok(test.levelScales, "Level scales exist");
         assert.equal(test.levelScales.length, 4, "Number of scales matches number of levels");
-        assert.deepEqual(test.levelScales, [1, 4.0005, 16.0035, 64.0141], "Parsing scales correctly");
+        assert.deepEqual(
+            test.levelScales,
+            [
+                mockMetadata.extent.layers[0].x_tiles / (mockMetadata.extent.layers[3].x_tiles),
+                mockMetadata.extent.layers[1].x_tiles / (mockMetadata.extent.layers[3].x_tiles),
+                mockMetadata.extent.layers[2].x_tiles / (mockMetadata.extent.layers[3].x_tiles),
+                mockMetadata.extent.layers[3].x_tiles / (mockMetadata.extent.layers[3].x_tiles)
+            ],
+            "Parsing scales correctly"
+        );
     });
 
     QUnit.test('IrisTileSource getTileUrl', function(assert) {

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -65,6 +65,7 @@
         assert.ok(Array.isArray(test.levelSizes), "Level sizes is an array");
         assert.equal(test.levelSizes.length, 4, "Number of levels is correct");
         assert.equal(test.maxLevel, 3, "Max level is correctly set");
+        assert.equal(test.maxZoomLevel, 64.0141, "Max zoom level is correctly set");
 
         assert.ok(test.levelScales, "Level scales exist");
         assert.equal(test.levelScales.length, 4, "Number of scales matches number of levels");

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -14,26 +14,20 @@
         }
     };
 
-    const mockFetchMetadata = function(url, context) {
-        context.parseMetadata(mockMetadata);
-        context.ready = true;
-        context.raiseEvent('ready', { tileSource: context });
-    };
-
     QUnit.test('IrisTileSource getMetadataUrl', function(assert) {
         const test = new OpenSeadragon.IrisTileSource({
             serverUrl: "http://localhost",
             slideId: "12345",
-            fetchMetadata: mockFetchMetadata
+            metadata: mockMetadata
         });
 
-        assert.ok(test.ready, "IrisTileSource should be ready after mock metadata");
+        assert.ok(test.ready, "IrisTileSource should be ready after metadata");
 
         const expectedWidth = Math.ceil(
             mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
         );
 
-        assert.equal(test.width, expectedWidth, "Width should be correctly parsed from mock metadata");
+        assert.equal(test.width, expectedWidth, "Width should be correctly parsed from metadata");
 
         const expectedUrl = "http://localhost/slides/12345/metadata";
         assert.equal(test.getMetadataUrl(), expectedUrl, "Metadata URL should match expected format");
@@ -43,10 +37,8 @@
         const test = new OpenSeadragon.IrisTileSource({
             serverUrl: "http://localhost",
             slideId: "12345",
-            fetchMetadata: () => {}
+            metadata: mockMetadata
         });
-
-        test.parseMetadata(mockMetadata);
 
         // Check dimensions
         const expectedWidth = Math.ceil(
@@ -84,7 +76,7 @@
         const test = new OpenSeadragon.IrisTileSource({
             serverUrl: "http://localhost",
             slideId: "12345",
-            fetchMetadata: mockFetchMetadata
+            metadata: mockMetadata
         });
 
         assert.equal(

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -1,0 +1,108 @@
+(function() {
+    QUnit.module('Iris');
+
+    const mockFetchMetadata = function(url, context) {
+        const metadata = {
+            extent: {
+                width: 1983,
+                height: 1381,
+                layers: [
+                    { x_tiles: 8, y_tiles: 6, scale: 1 },
+                    { x_tiles: 31, y_tiles: 22, scale: 4.0005 },
+                    { x_tiles: 124, y_tiles: 87, scale: 16.0035 },
+                    { x_tiles: 496, y_tiles: 346, scale: 64.0141 }
+                ]
+            }
+        };
+        context.parseMetadata(metadata);
+        context.ready = true;
+        context.raiseEvent('ready', { tileSource: context });
+    };
+
+    QUnit.test('IrisTileSource getMetadataUrl', function(assert) {
+        const test = new OpenSeadragon.IrisTileSource({
+            serverUrl: "http://localhost",
+            slideId: "12345",
+            fetchMetadata: mockFetchMetadata
+        });
+
+        assert.ok(test.ready, "IrisTileSource should be ready after mock metadata");
+        assert.equal(test.width, 1983, "Width should be correctly parsed from mock metadata");
+
+        const expectedUrl = "http://localhost/slides/12345/metadata";
+        assert.equal(test.getMetadataUrl(), expectedUrl, "Metadata URL should match expected format");
+    });
+
+    QUnit.test('IrisTileSource metadata parsing', function(assert) {
+        const test = new OpenSeadragon.IrisTileSource({
+            serverUrl: "http://localhost",
+            slideId: "12345",
+            fetchMetadata: () => {}
+        });
+
+        const metadata = {
+            extent: {
+                width: 1983,
+                height: 1381,
+                layers: [
+                    { x_tiles: 8, y_tiles: 6, scale: 1 },
+                    { x_tiles: 31, y_tiles: 22, scale: 4.0005 },
+                    { x_tiles: 124, y_tiles: 87, scale: 16.0035 },
+                    { x_tiles: 496, y_tiles: 346, scale: 64.0141 }
+                ]
+            }
+        };
+
+        test.parseMetadata(metadata);
+
+        // Check dimensions
+        assert.ok(test.width, "Width exists");
+        assert.equal(test.width, 1983, "Parsing width correctly");
+        assert.equal(test.height, 1381, "Parsing height correctly");
+
+        // Check level sizes and scales
+        assert.ok(test.levelSizes, "Level sizes exist");
+        assert.equal(typeof test.levelSizes, "object", "Level sizes is an array");
+        assert.equal(test.levelSizes.length, 4, "Number of levels is correct");
+        assert.equal(test.maxLevel, 3, "Max level is correctly set");
+
+        assert.ok(test.levelScales, "Level scales exist");
+        assert.equal(test.levelScales.length, 4, "Number of scales matches number of levels");
+        assert.deepEqual(test.levelScales, [1, 4.0005, 16.0035, 64.0141], "Parsing scales correctly");
+    });
+
+    QUnit.test('IrisTileSource getTileUrl', function(assert) {
+        const test = new OpenSeadragon.IrisTileSource({
+            serverUrl: "http://localhost",
+            slideId: "12345",
+            fetchMetadata: mockFetchMetadata
+        });
+
+        // Test tile URL generation
+        assert.equal(
+            test.getTileUrl(0, 0, 0),
+            "http://localhost/slides/12345/layers/0/tiles/0",
+            "Tile URL for level 0, x=0, y=0 should match expected format"
+        );
+        assert.equal(
+            test.getTileUrl(1, 1, 0),
+            "http://localhost/slides/12345/layers/1/tiles/1",
+            "Tile URL for level 1, x=1, y=0 should match expected format"
+        );
+        assert.equal(
+            test.getTileUrl(2, 1, 1),
+            "http://localhost/slides/12345/layers/2/tiles/125",
+            "Tile URL for level 2, x=1, y=1 should match expected format"
+        );
+        assert.equal(
+            test.getTileUrl(3, 2, 2),
+            "http://localhost/slides/12345/layers/3/tiles/994",
+            "Tile URL for level 3, x=2, y=2 should match expected format"
+        );
+        assert.equal(
+            test.getTileUrl(3, 3, 2),
+            "http://localhost/slides/12345/layers/3/tiles/995",
+            "Tile URL for level 3, x=3, y=2 should match expected format"
+        );
+    });
+})();

--- a/test/modules/iris.js
+++ b/test/modules/iris.js
@@ -29,9 +29,9 @@
 
         assert.ok(test.ready, "IrisTileSource should be ready after mock metadata");
 
-        const expectedWidth = parseInt(Math.ceil(
+        const expectedWidth = Math.ceil(
             mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
-        ), 10);
+        );
 
         assert.equal(test.width, expectedWidth, "Width should be correctly parsed from mock metadata");
 
@@ -49,12 +49,12 @@
         test.parseMetadata(mockMetadata);
 
         // Check dimensions
-        const expectedWidth = parseInt(Math.ceil(
+        const expectedWidth = Math.ceil(
             mockMetadata.extent.width * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
-        ), 10);
-        const expectedHeight = parseInt(Math.ceil(
+        );
+        const expectedHeight = Math.ceil(
             mockMetadata.extent.height * mockMetadata.extent.layers[mockMetadata.extent.layers.length - 1].scale
-        ), 10);
+        );
 
         assert.ok(test.width, "Width exists");
         assert.equal(test.width, expectedWidth, "Parsing width correctly");

--- a/test/test.html
+++ b/test/test.html
@@ -46,6 +46,7 @@
     <script src="/test/modules/formats.js"></script>
     <script src="/test/modules/iiif.js"></script>
     <script src="/test/modules/iip.js"></script>
+    <script src="/test/modules/iris.js"></script>
     <script src="/test/modules/utils.js"></script>
     <script src="/test/modules/events.js"></script>
     <script src="/test/modules/units.js"></script>


### PR DESCRIPTION
Adding new tilesource to support Iris image formats. It leverages an API which issues tile data. The API is queried to get the tile metadata, and the individual tiles are pulled in at each layer and location as you zoom in and pan around.

### metadata API
- `/slides/{slideId}/metadata`
- which returns data of the format:
```
{
    "type": "slide_metadata",
    "format": "FORMAT_B8G8R8A8",
    "encoding": "image/jpeg",
    "extent": {
        "width": 1983,
        "height": 1381,
        "layers": [
            {
                "x_tiles": 8,
                "y_tiles": 6,
                "scale": 1
            },
            {
                "x_tiles": 31,
                "y_tiles": 22,
                "scale": 4.0005
            },
            {
                "x_tiles": 124,
                "y_tiles": 87,
                "scale": 16.0035
            },
            {
                "x_tiles": 496,
                "y_tiles": 346,
                "scale": 64.0141
            }
        ]
    }
}
```

### tile API
- `/slides/{slideId}/layers/{layerId}/tiles/{layerPosition}`
- where layerPosition is `y_coord * x_tiles_in_layer + x_coord`
- which returns the tile image