### PR TITLE
Add tiledImageCreated method for DrawerBase.

### DIFF
--- a/src/drawerbase.js
+++ b/src/drawerbase.js
@@ -283,6 +283,15 @@ OpenSeadragon.DrawerBase = class DrawerBase{
         this._dataNeedsRefresh = $.now();
     }
 
+    /**
+     * When a Tiled Image is initialized and ready, this method is called.
+     * Unlike with events, here it is guaranteed that all external code has finished
+     * processing (under normal circumstances) and the tiled image should not change.
+     */
+    tiledImageCreated() {
+        // pass
+    }
+
     // Private functions
 
     /**

--- a/src/drawerbase.js
+++ b/src/drawerbase.js
@@ -287,8 +287,9 @@ OpenSeadragon.DrawerBase = class DrawerBase{
      * When a Tiled Image is initialized and ready, this method is called.
      * Unlike with events, here it is guaranteed that all external code has finished
      * processing (under normal circumstances) and the tiled image should not change.
+     * @param {OpenSeadragon.TiledImage} tiledImage target image that has been created
      */
-    tiledImageCreated() {
+    tiledImageCreated(tiledImage) {
         // pass
     }
 

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -85,6 +85,10 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
             };
         }
 
+        // In theory, HTML drawer should cope well with canvas node type too,
+        // but tests fail - if this conversion is used, it outputs uninitialized zeroed data
+        // (data manipulation test module).
+
         // The actual placing logics will not happen at draw event, but when the cache is created:
         // $.converter.learn("context2d", HTMLDrawer.canvasCacheType, (t, d) => _prepareTile(t, d.canvas), 1, 1);
         $.converter.learn("image", HTMLDrawer.imageCacheType, _prepareTile, 1, 1);

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -86,10 +86,10 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
         }
 
         // The actual placing logics will not happen at draw event, but when the cache is created:
-        $.converter.learn("context2d", HTMLDrawer.canvasCacheType, (t, d) => _prepareTile(t, d.canvas), 1, 1);
+        // $.converter.learn("context2d", HTMLDrawer.canvasCacheType, (t, d) => _prepareTile(t, d.canvas), 1, 1);
         $.converter.learn("image", HTMLDrawer.imageCacheType, _prepareTile, 1, 1);
         // Also learn how to move back, since these elements can be just used as-is
-        $.converter.learn(HTMLDrawer.canvasCacheType, "context2d", (t, d) => d.data.getContext('2d'), 1, 3);
+        // $.converter.learn(HTMLDrawer.canvasCacheType, "context2d", (t, d) => d.data.getContext('2d'), 1, 3);
         $.converter.learn(HTMLDrawer.imageCacheType, "image", (t, d) => d.data, 1, 3);
 
         function _freeTile(data) {
@@ -101,7 +101,7 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
             }
         }
 
-        $.converter.learnDestroy(HTMLDrawer.canvasCacheType, _freeTile);
+        // $.converter.learnDestroy(HTMLDrawer.canvasCacheType, _freeTile);
         $.converter.learnDestroy(HTMLDrawer.imageCacheType, _freeTile);
     }
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -89,7 +89,7 @@ $.Tile = function(level, x, y, bounds, exists, url, context2D, loadWithAjax, aja
     this.positionedBounds  = new OpenSeadragon.Rect(bounds.x, bounds.y, bounds.width, bounds.height);
     /**
      * The portion of the tile to use as the source of the drawing operation, in pixels. Note that
-     * this only works when drawing with canvas; when drawing with HTML the entire tile is always used.
+     * this property is ignored with HTML drawer where the whole tile is always drawn.
      * @member {OpenSeadragon.Rect} sourceBounds
      * @memberof OpenSeadragon.Tile#
      */

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1922,9 +1922,12 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     });
                 }
 
-                // This is necessary since drawer might react upon finalized tiled image, after
-                // all events have been processed.
-                _this.drawer.tiledImageCreated(tiledImage);
+                // It might happen processReadyItems() is called after viewer.destroy()
+                if (_this.drawer) {
+                    // This is necessary since drawer might react upon finalized tiled image, after
+                    // all events have been processed.
+                    _this.drawer.tiledImageCreated(tiledImage);
+                }
             }
         }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -582,6 +582,7 @@ $.Viewer = function( options ) {
             crossOriginPolicy: this.crossOriginPolicy,
             animationTime:     this.animationTime,
             drawer:            this.drawer.getType(),
+            drawerOptions:     this.drawerOptions,
             loadTilesWithAjax: this.loadTilesWithAjax,
             ajaxHeaders:       this.ajaxHeaders,
             ajaxWithCredentials: this.ajaxWithCredentials,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1110,8 +1110,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             Drawer = $.determineDrawer(drawerCandidate);
         }
 
-        if(!Drawer){
-            $.console.warn('Unsupported drawer! Drawer must be an existing string type, or a class that extends OpenSeadragon.DrawerBase.');
+        if (!Drawer) {
+            $.console.warn('Unsupported drawer %s! Drawer must be an existing string type, or a class that extends OpenSeadragon.DrawerBase.', drawerCandidate);
         }
 
         // if the drawer is supported, create it and return true
@@ -1921,6 +1921,10 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                         item: tiledImage
                     });
                 }
+
+                // This is necessary since drawer might react upon finalized tiled image, after
+                // all events have been processed.
+                _this.drawer.tiledImageCreated(tiledImage);
             }
         }
 

--- a/test/modules/data-manipulation.js
+++ b/test/modules/data-manipulation.js
@@ -1,4 +1,4 @@
-/* global QUnit, testLog */
++/* global QUnit, testLog */
 
 (function() {
 
@@ -94,8 +94,6 @@
             // make sure at least one tile loaded
             const tile = tileRef || viewer.world.getItemAt(0).getTilesToDraw()[0];
             await tile[PROMISE_REF_KEY];
-            // Get some time for viewer to load data
-            await sleep(50);
 
             if (type === "canvas") {
                 //test with the underlying canvas instead

--- a/test/modules/data-manipulation.js
+++ b/test/modules/data-manipulation.js
@@ -1,4 +1,4 @@
-+/* global QUnit, testLog */
+/* global QUnit, testLog */
 
 (function() {
 


### PR DESCRIPTION
The renderer I develop needs to react upon tiled image creation. However, events are not sufficient as users might modify something even _after the event has finished_, since `addTiledImage(...)` fires a callback after the event. I need to have users to apply all modifications before we process the tiled image. 

This PR also adds some minor fixes.