### PR TITLE
docs: add tile-drawing customization tip under Development section by ROHIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ https://www.newline.co/courses/openseadragon-deep-dive
 
 If you want to use OpenSeadragon in your own projects, you can find the latest stable build, API documentation, and example code at [https://openseadragon.github.io/][openseadragon]. If you want to modify OpenSeadragon and/or contribute to its development, read the [contributing guide][github-contributing] for instructions.
 
+> 💡 Tip: Developers can enhance user experience by customizing tiles during rendering using the `tile-drawing` hook. This is especially useful for applying overlays, annotations, or debugging individual tiles in advanced image viewers.
+
 ## License
 
 OpenSeadragon is released under the New BSD license. For details, see the [LICENSE.txt file][github-license].


### PR DESCRIPTION
This pull request adds a helpful developer tip under the **Development** section in the `README.md` file.

The added note introduces the `tile-drawing` hook, which allows developers to customize how tiles are rendered during runtime. This can be especially useful in scenarios like:

- Adding overlays or annotations on top of individual tiles.
- Debugging tile positions or sources.
- Creating enhanced viewing experiences for advanced image applications.

The goal is to improve the documentation for first-time developers and power users by surfacing useful customization capabilities of OpenSeadragon.

This change does not affect any functionality or logic and is strictly a documentation enhancement.
