### PR TITLE
Add red tile overlay example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ https://www.newline.co/courses/openseadragon-deep-dive
 
 If you want to use OpenSeadragon in your own projects, you can find the latest stable build, API documentation, and example code at [https://openseadragon.github.io/][openseadragon]. If you want to modify OpenSeadragon and/or contribute to its development, read the [contributing guide][github-contributing] for instructions.
 
+## Custom Tile Rendering Example
+
+OpenSeadragon allows you to customize how each tile is rendered by listening to the `tile-drawing` event.
+
+Here’s an example that overlays a red transparent color on each tile as it loads:
+
+```html
+<script src="https://unpkg.com/openseadragon@4.1.0/build/openseadragon/openseadragon.min.js"></script>
+<div id="openseadragon" style="width: 100%; height: 500px;"></div>
+<script>
+  const viewer = OpenSeadragon({
+    id: "openseadragon",
+    prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
+    tileSources: "https://openseadragon.github.io/example-images/highsmith/highsmith.dzi"
+  });
+
+  viewer.addHandler('tile-drawing', function(event) {
+    const ctx = event.rendered;
+    if (ctx) {
+      ctx.fillStyle = 'rgba(255, 0, 0, 0.2)';
+      ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    }
+  });
+</script>
+```
+
 ## License
 
 OpenSeadragon is released under the New BSD license. For details, see the [LICENSE.txt file][github-license].


### PR DESCRIPTION
### 📝 Pull Request Title  
**Add Custom Tile Rendering Example in README**

---

### 📄 Description  
This pull request adds a new example under the **Custom Tile Rendering Example** section in the `README.md`.  
It demonstrates how to use OpenSeadragon's `tile-drawing` event to overlay a semi-transparent red color on each tile as it loads.

---

### 🔍 Why This Is Useful  
This example is helpful for developers who want to:
- Customize tile rendering behavior
- Leverage the `tile-drawing` event for overlays or analytics
- Understand how to manipulate the canvas context for tiles

---

### ✅ Code Snippet Preview  
```js
viewer.addHandler('tile-drawing', function(event) {
  const ctx = event.rendered;
  if (ctx) {
    ctx.fillStyle = 'rgba(255, 0, 0, 0.2)';
    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
  }
});
