### PR TITLE
Feat: add tries and maxReached properties to tile-load-failed event

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -296,7 +296,7 @@ function completeJob(loader, job, callback) {
         }
     }
 
-    callback(job.data, job.errorMsg, job.request, job.dataType);
+    callback(job.data, job.errorMsg, job.request, job.dataType, job.tries);
 }
 
 }(OpenSeadragon));

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2188,6 +2188,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
              * @property {OpenSeadragon.TiledImage} tiledImage - The tiled image the tile belongs to.
              * @property {number} time - The time in milliseconds when the tile load began.
              * @property {string} message - The error message.
+             * @property {number} tries - The number of times the tile has been retried.
+             * @property {boolean} maxReached - Whether the maximum number of retries has been reached.
              * @property {XMLHttpRequest} tileRequest - The XMLHttpRequest used to load the tile if available.
              */
             this.viewer.raiseEvent("tile-load-failed", {

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -2139,8 +2139,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             ajaxHeaders: tile.ajaxHeaders,
             crossOriginPolicy: this.crossOriginPolicy,
             ajaxWithCredentials: this.ajaxWithCredentials,
-            callback: function( data, errorMsg, tileRequest, dataType ){
-                _this._onTileLoad( tile, time, data, errorMsg, tileRequest, dataType );
+            callback: function( data, errorMsg, tileRequest, dataType, tries ){
+                _this._onTileLoad( tile, time, data, errorMsg, tileRequest, dataType, tries );
             },
             abort: function() {
                 tile.loading = false;
@@ -2173,8 +2173,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * @param {String} errorMsg
      * @param {XMLHttpRequest} tileRequest
      * @param {String} [dataType=undefined] data type, derived automatically if not set
+     * @param {number} tries - The number of times the tile has been retried.
      */
-    _onTileLoad: function( tile, time, data, errorMsg, tileRequest, dataType ) {
+    _onTileLoad: function( tile, time, data, errorMsg, tileRequest, dataType, tries ) {
         //data is set to null on error by image loader, allow custom falsey values (e.g. 0)
         if ( data === null || data === undefined ) {
             $.console.error( "Tile %s failed to load: %s - error: %s", tile, tile.getUrl(), errorMsg );
@@ -2197,7 +2198,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                 tiledImage: this,
                 time: time,
                 message: errorMsg,
-                tileRequest: tileRequest
+                tileRequest: tileRequest,
+                tries: tries,
+                maxReached: this.viewer.tileRetryMax === 0 ? true : tries >= this.viewer.tileRetryMax
             });
             tile.loading = false;
             tile.exists = false;


### PR DESCRIPTION
Added `tries` and `maxReached` properties to the tile-load-failed event.

I made it so that `maxReached` is true if the default retry value 0 is set, since the property pretty much means "won't retry this tile".

Let me know if you want any other changes!