### PR TITLE
fix: make body children invisible instead of removing them

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -148,7 +148,14 @@ $.Viewer = function( options ) {
         overlaysContainer:  null,
 
         //private state properties
-        previousBody:   [],
+
+        // When we go full-screen we insert ourselves into the body and make
+        // everything else hidden. This is basically the same as
+        // `requestFullScreen` but works in all browsers: iPhone is known to not
+        // allow full-screen with the requestFullScreen API.  This holds the
+        // children of the body and their display values, so we can undo our
+        // changes when we go out of full-screen
+        previousDisplayValuesOfBodyChildren:   [],
 
         //This was originally initialized in the constructor and so could never
         //have anything in it.  now it can because we allow it to be specified
@@ -1406,20 +1413,29 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             this.bodyDisplay = bodyStyle.display;
             bodyStyle.display = "block";
 
-            //when entering full screen on the ipad it wasn't sufficient to leave
-            //the body intact as only only the top half of the screen would
-            //respond to touch events on the canvas, while the bottom half treated
-            //them as touch events on the document body.  Thus we remove and store
-            //the bodies elements and replace them when we leave full screen.
-            this.previousBody = [];
+            //when entering full screen on the ipad it wasn't sufficient to
+            //leave the body intact as only only the top half of the screen
+            //would respond to touch events on the canvas, while the bottom half
+            //treated them as touch events on the document body.  Thus we make
+            //them invisible (display: none) and apply the older values when we
+            //go out of full screen.
+            this.previousDisplayValuesOfBodyChildren = [];
             THIS[ this.hash ].prevElementParent = this.element.parentNode;
             THIS[ this.hash ].prevNextSibling = this.element.nextSibling;
             THIS[ this.hash ].prevElementWidth = this.element.style.width;
             THIS[ this.hash ].prevElementHeight = this.element.style.height;
-            nodes = body.childNodes.length;
+            nodes = body.children.length;
             for ( let i = 0; i < nodes; i++ ) {
-                this.previousBody.push( body.childNodes[ 0 ] );
-                body.removeChild( body.childNodes[ 0 ] );
+                const element = body.children[i];
+                if (element === this.element) {
+                    // Do not hide ourselves...
+                    continue;
+                }
+                this.previousDisplayValuesOfBodyChildren.push({
+                    element,
+                    display: element.style.display
+                });
+                element.style.display = 'none';
             }
 
             //If we've got a toolbar, we need to enable the user to use css to
@@ -1473,9 +1489,10 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
             bodyStyle.display = this.bodyDisplay;
 
             body.removeChild( this.element );
-            nodes = this.previousBody.length;
+            nodes = this.previousDisplayValuesOfBodyChildren.length;
             for ( let i = 0; i < nodes; i++ ) {
-                body.appendChild( this.previousBody.shift() );
+                const { element, display } = this.previousDisplayValuesOfBodyChildren[i];
+                element.style.display = display;
             }
 
             $.removeClass( this.element, 'fullpage' );


### PR DESCRIPTION
This prevents iframes, webcomponents, elements with events etcetera from getting detached, which may be destructive for them.

This would fix a number of bugs:

* Fixes #1677, where webcomponents were being destructed
* An issue on our side where webcomponents are also destructed: https://github.com/eeditiones/tei-publisher-app/issues/67
* Fixes #1127, where iframes are unloaded when we go full-screen
* Fixes #2391 where an SVG filter element is also removed
* Possibly even more.

One thing though, I do not have access to an iPad, so I cannot verify this does not re-introduce the bug this code tries to fix. I am hoping someone can verify this for me! Still opening this PR to hopefully address the issues linked.

I already manually tested this in:

* Chrome on Desktop
* Firefox on Desktop
* Chrome on android
* Firefox on Android