### PR TITLE
chore: add bundle size analysis tools

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -7,6 +7,7 @@ on:
       - 'src/**'
       - 'Gruntfile.js'
       - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/bundle-size.yml'
 
 jobs:
@@ -29,9 +30,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies (PR branch)
-        run: |
-          npm install -g grunt-cli
-          npm ci
+        run: npm ci
 
       - name: Build PR branch
         run: npm run build
@@ -55,7 +54,7 @@ jobs:
       - name: Check bundle size limits
         run: |
           set -o pipefail
-          npm run bundlesize 2>&1 | tee bundlesize-output.txt
+          npm run bundlesize 2>&1 | tee "$RUNNER_TEMP/bundlesize-output.txt"
 
       - name: Checkout base branch
         run: |
@@ -84,74 +83,98 @@ jobs:
 
       - name: Calculate size differences and post results
         uses: actions/github-script@v7
+        env:
+          PR_MIN_SIZE: ${{ steps.pr_size.outputs.pr_min_size }}
+          PR_FULL_SIZE: ${{ steps.pr_size.outputs.pr_full_size }}
+          PR_MIN_GZIP: ${{ steps.pr_size.outputs.pr_min_gzip }}
+          PR_FULL_GZIP: ${{ steps.pr_size.outputs.pr_full_gzip }}
+          BASE_MIN_SIZE: ${{ steps.base_size.outputs.base_min_size }}
+          BASE_FULL_SIZE: ${{ steps.base_size.outputs.base_full_size }}
+          BASE_MIN_GZIP: ${{ steps.base_size.outputs.base_min_gzip }}
+          BASE_FULL_GZIP: ${{ steps.base_size.outputs.base_full_gzip }}
+          BUNDLESIZE_OUTPUT_PATH: ${{ runner.temp }}/bundlesize-output.txt
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
+            const parseBytes = (value, label) => {
+              const parsed = Number.parseInt(value, 10);
+              if (!Number.isFinite(parsed)) {
+                throw new Error(`Expected numeric ${label}, received: ${value}`);
+              }
+              return parsed;
+            };
 
-            const prMinSize = parseInt('${{ steps.pr_size.outputs.pr_min_size }}');
-            const prFullSize = parseInt('${{ steps.pr_size.outputs.pr_full_size }}');
-            const prMinGzip = parseInt('${{ steps.pr_size.outputs.pr_min_gzip }}');
-            const prFullGzip = parseInt('${{ steps.pr_size.outputs.pr_full_gzip }}');
+            const prMinSize = parseBytes(process.env.PR_MIN_SIZE, 'PR_MIN_SIZE');
+            const prFullSize = parseBytes(process.env.PR_FULL_SIZE, 'PR_FULL_SIZE');
+            const prMinGzip = parseBytes(process.env.PR_MIN_GZIP, 'PR_MIN_GZIP');
+            const prFullGzip = parseBytes(process.env.PR_FULL_GZIP, 'PR_FULL_GZIP');
 
-            const baseMinSize = parseInt('${{ steps.base_size.outputs.base_min_size }}');
-            const baseFullSize = parseInt('${{ steps.base_size.outputs.base_full_size }}');
-            const baseMinGzip = parseInt('${{ steps.base_size.outputs.base_min_gzip }}');
-            const baseFullGzip = parseInt('${{ steps.base_size.outputs.base_full_gzip }}');
+            const baseMinSize = parseBytes(process.env.BASE_MIN_SIZE, 'BASE_MIN_SIZE');
+            const baseFullSize = parseBytes(process.env.BASE_FULL_SIZE, 'BASE_FULL_SIZE');
+            const baseMinGzip = parseBytes(process.env.BASE_MIN_GZIP, 'BASE_MIN_GZIP');
+            const baseFullGzip = parseBytes(process.env.BASE_FULL_GZIP, 'BASE_FULL_GZIP');
 
-            const bundlesizeOutput = fs.existsSync('bundlesize-output.txt')
-              ? fs.readFileSync('bundlesize-output.txt', 'utf8').trim()
+            const bundlesizeOutput = fs.existsSync(process.env.BUNDLESIZE_OUTPUT_PATH)
+              ? fs.readFileSync(process.env.BUNDLESIZE_OUTPUT_PATH, 'utf8').trim()
               : 'Bundle size command output was unavailable.';
 
             const formatBytes = (bytes) => {
-              if (bytes === 0) {
+              const absoluteBytes = Math.abs(bytes);
+              if (absoluteBytes === 0) {
                 return '0 B';
               }
 
-              const k = 1024;
-              const sizes = ['B', 'KB', 'MB'];
-              const i = Math.floor(Math.log(bytes) / Math.log(k));
-              return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+              const k = 1000;
+              const sizes = ['B', 'kB', 'MB'];
+              const i = Math.floor(Math.log(absoluteBytes) / Math.log(k));
+              const value = parseFloat((absoluteBytes / Math.pow(k, i)).toFixed(2));
+              return `${value} ${sizes[i]}`;
             };
 
             const formatDiff = (current, base) => {
               const diff = current - base;
-              const diffPercent = ((diff / base) * 100).toFixed(2);
-              const sign = diff > 0 ? '+' : '';
+              const sign = diff > 0 ? '+' : diff < 0 ? '-' : '';
+              const diffPercent = base === 0
+                ? 'n/a'
+                : `${sign}${Math.abs((diff / base) * 100).toFixed(2)}%`;
               const direction = diff > 0 ? 'increased' : diff < 0 ? 'decreased' : 'unchanged';
-              return `${direction}: ${sign}${formatBytes(diff)} (${sign}${diffPercent}%)`;
+              return `${direction}: ${sign}${formatBytes(diff)} (${diffPercent})`;
             };
 
             const minGzipDiff = prMinGzip - baseMinGzip;
             const minStatus = minGzipDiff > 0 ? 'increased' : minGzipDiff < 0 ? 'decreased' : 'unchanged';
 
-            const comment = `## Bundle Size Report
-
-            ### Minified Bundle
-            | Metric | Base | PR | Change |
-            |--------|------|-----|--------|
-            | **Size** | ${formatBytes(baseMinSize)} | ${formatBytes(prMinSize)} | ${formatDiff(prMinSize, baseMinSize)} |
-            | **Gzipped** | ${formatBytes(baseMinGzip)} | ${formatBytes(prMinGzip)} | ${formatDiff(prMinGzip, baseMinGzip)} |
-
-            ### Full Bundle (unminified)
-            | Metric | Base | PR | Change |
-            |--------|------|-----|--------|
-            | **Size** | ${formatBytes(baseFullSize)} | ${formatBytes(prFullSize)} | ${formatDiff(prFullSize, baseFullSize)} |
-            | **Gzipped** | ${formatBytes(baseFullGzip)} | ${formatBytes(prFullGzip)} | ${formatDiff(prFullGzip, baseFullGzip)} |
-
-            ### Bundle Size Check
-            \`\`\`text
-            ${bundlesizeOutput}
-            \`\`\`
-
-            ### Status
-            **Minified gzipped size**: ${formatBytes(prMinGzip)} (${minStatus} compared with base)
-
-            ${minGzipDiff > 0 ? '**Warning**: Bundle size increased.' : minGzipDiff < 0 ? '**Good**: Bundle size decreased.' : '**Good**: No change in bundle size.'}
-
-            ---
-            <sub>Measured on ${new Date().toLocaleString()}</sub>
-            `;
+            const marker = '<!-- bundle-size-report -->';
+            const comment = [
+              marker,
+              '## Bundle Size Report',
+              '',
+              '### Minified Bundle',
+              '| Metric | Base | PR | Change |',
+              '|--------|------|-----|--------|',
+              `| **Size** | ${formatBytes(baseMinSize)} | ${formatBytes(prMinSize)} | ${formatDiff(prMinSize, baseMinSize)} |`,
+              `| **Gzipped** | ${formatBytes(baseMinGzip)} | ${formatBytes(prMinGzip)} | ${formatDiff(prMinGzip, baseMinGzip)} |`,
+              '',
+              '### Full Bundle (unminified)',
+              '| Metric | Base | PR | Change |',
+              '|--------|------|-----|--------|',
+              `| **Size** | ${formatBytes(baseFullSize)} | ${formatBytes(prFullSize)} | ${formatDiff(prFullSize, baseFullSize)} |`,
+              `| **Gzipped** | ${formatBytes(baseFullGzip)} | ${formatBytes(prFullGzip)} | ${formatDiff(prFullGzip, baseFullGzip)} |`,
+              '',
+              '### Bundle Size Check',
+              '```text',
+              bundlesizeOutput,
+              '```',
+              '',
+              '### Status',
+              `**Minified gzipped size**: ${formatBytes(prMinGzip)} (${minStatus} compared with base)`,
+              '',
+              minGzipDiff > 0 ? '**Warning**: Bundle size increased.' : minGzipDiff < 0 ? '**Good**: Bundle size decreased.' : '**Good**: No change in bundle size.',
+              '',
+              '---',
+              `<sub>Measured on ${new Date().toISOString()}</sub>`
+            ].join('\n');
 
             try {
               // Find existing comment
@@ -162,7 +185,7 @@ jobs:
               });
 
               const botComment = comments.find(comment =>
-                comment.user.type === 'Bot' && comment.body.includes('Bundle Size Report')
+                comment.user.type === 'Bot' && comment.body.includes(marker)
               );
 
               if (botComment) {
@@ -185,8 +208,8 @@ jobs:
                 console.log('Created new comment');
               }
             } catch (error) {
-              // If we can't post a comment (e.g., insufficient permissions), log the report instead
-              console.log('Unable to post comment (likely insufficient permissions)');
+              // Fork PRs run under pull_request with a read-only token, so comment writes can fail by design.
+              console.log('Unable to post comment (likely insufficient permissions for a fork PR)');
               console.log('Bundle Size Report:');
               console.log(comment);
               // Don't fail the workflow

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Get PR branch bundle sizes
         id: pr_size
         run: |
+          set -o pipefail
           # Get file sizes
           PR_MIN_SIZE=$(stat -f%z "build/openseadragon/openseadragon.min.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.min.js")
           PR_FULL_SIZE=$(stat -f%z "build/openseadragon/openseadragon.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.js")
@@ -68,6 +69,7 @@ jobs:
       - name: Get base branch bundle sizes
         id: base_size
         run: |
+          set -o pipefail
           # Get file sizes
           BASE_MIN_SIZE=$(stat -f%z "build/openseadragon/openseadragon.min.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.min.js")
           BASE_FULL_SIZE=$(stat -f%z "build/openseadragon/openseadragon.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.js")
@@ -127,7 +129,10 @@ jobs:
 
               const k = 1000;
               const sizes = ['B', 'kB', 'MB'];
-              const i = Math.floor(Math.log(absoluteBytes) / Math.log(k));
+              const i = Math.min(
+                Math.floor(Math.log(absoluteBytes) / Math.log(k)),
+                sizes.length - 1
+              );
               const value = parseFloat((absoluteBytes / Math.pow(k, i)).toFixed(2));
               return `${value} ${sizes[i]}`;
             };

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,198 @@
+name: 'Bundle Size Check'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'Gruntfile.js'
+      - 'package.json'
+      - '.github/workflows/bundle-size.yml'
+
+jobs:
+  check_bundle_size:
+    name: Check Bundle Size
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: lts/*
+
+      - name: Install dependencies (PR branch)
+        run: |
+          npm install -g grunt-cli
+          npm ci
+
+      - name: Build PR branch
+        run: npm run build
+
+      - name: Get PR branch bundle sizes
+        id: pr_size
+        run: |
+          # Get file sizes
+          PR_MIN_SIZE=$(stat -f%z "build/openseadragon/openseadragon.min.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.min.js")
+          PR_FULL_SIZE=$(stat -f%z "build/openseadragon/openseadragon.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.js")
+
+          # Get gzipped sizes
+          PR_MIN_GZIP=$(gzip -c "build/openseadragon/openseadragon.min.js" | wc -c | tr -d ' ')
+          PR_FULL_GZIP=$(gzip -c "build/openseadragon/openseadragon.js" | wc -c | tr -d ' ')
+
+          echo "pr_min_size=$PR_MIN_SIZE" >> $GITHUB_OUTPUT
+          echo "pr_full_size=$PR_FULL_SIZE" >> $GITHUB_OUTPUT
+          echo "pr_min_gzip=$PR_MIN_GZIP" >> $GITHUB_OUTPUT
+          echo "pr_full_gzip=$PR_FULL_GZIP" >> $GITHUB_OUTPUT
+
+      - name: Check bundle size limits
+        run: |
+          set -o pipefail
+          npm run bundlesize 2>&1 | tee bundlesize-output.txt
+
+      - name: Checkout base branch
+        run: |
+          git checkout ${{ github.base_ref }}
+
+      - name: Clean and rebuild base branch
+        run: |
+          npm ci
+          npm run build
+
+      - name: Get base branch bundle sizes
+        id: base_size
+        run: |
+          # Get file sizes
+          BASE_MIN_SIZE=$(stat -f%z "build/openseadragon/openseadragon.min.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.min.js")
+          BASE_FULL_SIZE=$(stat -f%z "build/openseadragon/openseadragon.js" 2>/dev/null || stat -c%s "build/openseadragon/openseadragon.js")
+
+          # Get gzipped sizes
+          BASE_MIN_GZIP=$(gzip -c "build/openseadragon/openseadragon.min.js" | wc -c | tr -d ' ')
+          BASE_FULL_GZIP=$(gzip -c "build/openseadragon/openseadragon.js" | wc -c | tr -d ' ')
+
+          echo "base_min_size=$BASE_MIN_SIZE" >> $GITHUB_OUTPUT
+          echo "base_full_size=$BASE_FULL_SIZE" >> $GITHUB_OUTPUT
+          echo "base_min_gzip=$BASE_MIN_GZIP" >> $GITHUB_OUTPUT
+          echo "base_full_gzip=$BASE_FULL_GZIP" >> $GITHUB_OUTPUT
+
+      - name: Calculate size differences and post results
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const prMinSize = parseInt('${{ steps.pr_size.outputs.pr_min_size }}');
+            const prFullSize = parseInt('${{ steps.pr_size.outputs.pr_full_size }}');
+            const prMinGzip = parseInt('${{ steps.pr_size.outputs.pr_min_gzip }}');
+            const prFullGzip = parseInt('${{ steps.pr_size.outputs.pr_full_gzip }}');
+
+            const baseMinSize = parseInt('${{ steps.base_size.outputs.base_min_size }}');
+            const baseFullSize = parseInt('${{ steps.base_size.outputs.base_full_size }}');
+            const baseMinGzip = parseInt('${{ steps.base_size.outputs.base_min_gzip }}');
+            const baseFullGzip = parseInt('${{ steps.base_size.outputs.base_full_gzip }}');
+
+            const bundlesizeOutput = fs.existsSync('bundlesize-output.txt')
+              ? fs.readFileSync('bundlesize-output.txt', 'utf8').trim()
+              : 'Bundle size command output was unavailable.';
+
+            const formatBytes = (bytes) => {
+              if (bytes === 0) {
+                return '0 B';
+              }
+
+              const k = 1024;
+              const sizes = ['B', 'KB', 'MB'];
+              const i = Math.floor(Math.log(bytes) / Math.log(k));
+              return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+            };
+
+            const formatDiff = (current, base) => {
+              const diff = current - base;
+              const diffPercent = ((diff / base) * 100).toFixed(2);
+              const sign = diff > 0 ? '+' : '';
+              const direction = diff > 0 ? 'increased' : diff < 0 ? 'decreased' : 'unchanged';
+              return `${direction}: ${sign}${formatBytes(diff)} (${sign}${diffPercent}%)`;
+            };
+
+            const minGzipDiff = prMinGzip - baseMinGzip;
+            const minStatus = minGzipDiff > 0 ? 'increased' : minGzipDiff < 0 ? 'decreased' : 'unchanged';
+
+            const comment = `## Bundle Size Report
+
+            ### Minified Bundle
+            | Metric | Base | PR | Change |
+            |--------|------|-----|--------|
+            | **Size** | ${formatBytes(baseMinSize)} | ${formatBytes(prMinSize)} | ${formatDiff(prMinSize, baseMinSize)} |
+            | **Gzipped** | ${formatBytes(baseMinGzip)} | ${formatBytes(prMinGzip)} | ${formatDiff(prMinGzip, baseMinGzip)} |
+
+            ### Full Bundle (unminified)
+            | Metric | Base | PR | Change |
+            |--------|------|-----|--------|
+            | **Size** | ${formatBytes(baseFullSize)} | ${formatBytes(prFullSize)} | ${formatDiff(prFullSize, baseFullSize)} |
+            | **Gzipped** | ${formatBytes(baseFullGzip)} | ${formatBytes(prFullGzip)} | ${formatDiff(prFullGzip, baseFullGzip)} |
+
+            ### Bundle Size Check
+            \`\`\`text
+            ${bundlesizeOutput}
+            \`\`\`
+
+            ### Status
+            **Minified gzipped size**: ${formatBytes(prMinGzip)} (${minStatus} compared with base)
+
+            ${minGzipDiff > 0 ? '**Warning**: Bundle size increased.' : minGzipDiff < 0 ? '**Good**: Bundle size decreased.' : '**Good**: No change in bundle size.'}
+
+            ---
+            <sub>Measured on ${new Date().toLocaleString()}</sub>
+            `;
+
+            try {
+              // Find existing comment
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+
+              const botComment = comments.find(comment =>
+                comment.user.type === 'Bot' && comment.body.includes('Bundle Size Report')
+              );
+
+              if (botComment) {
+                // Update existing comment
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: comment
+                });
+                console.log('Updated existing comment');
+              } else {
+                // Create new comment
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: comment
+                });
+                console.log('Created new comment');
+              }
+            } catch (error) {
+              // If we can't post a comment (e.g., insufficient permissions), log the report instead
+              console.log('Unable to post comment (likely insufficient permissions)');
+              console.log('Bundle Size Report:');
+              console.log(comment);
+              // Don't fail the workflow
+            }
+
+            // Always write to job summary (visible in Actions UI)
+            await core.summary
+              .addRaw(comment)
+              .write();

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ instrumented/
 .directory
 local-test
 .DS_Store
+bundle-analysis.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,21 @@ You can also publish the built version to the site-build repository. This assume
 
 ... which will delete the existing openseadragon folder, along with the .zip and .tar.gz files, out of the site-build folder and replace them with newly built ones from the source in this repository; you'll then need to commit the changes to site-build.
 
+### Bundle Size Analysis
+
+To ensure OpenSeadragon stays lean and fast, we track bundle sizes and enforce limits. To check bundle size:
+
+    npm run bundlesize
+
+This will show you the current bundle sizes and whether they're within the limits configured in `package.json`.
+
+**Automated PR Comments**: When you open a PR, a bot will automatically comment with bundle size comparisons showing how your changes affect the bundle size compared to the base branch.
+
+The bundle size check runs automatically in CI/CD, and PRs will fail if bundle sizes exceed these limits. If your changes cause the bundle to grow significantly, consider:
+- Removing unused code
+- Optimizing imports
+- Refactoring large features
+
 ### Testing
 
 Our tests are based on [QUnit](https://qunitjs.com/) and [Puppeteer](https://github.com/GoogleChrome/puppeteer); they're both installed when you run `npm install`. To run on the command line:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "grunt-shell": "^4.0.0",
                 "grunt-text-replace": "^0.4.0",
                 "qunit": "^2.24.1",
+                "source-map-explorer": "^2.5.3",
                 "tsd": "^0.33.0",
                 "typescript": "^5.9.3"
             },
@@ -932,6 +933,19 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/btoa": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+            "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+            "dev": true,
+            "license": "(MIT OR Apache-2.0)",
+            "bin": {
+                "btoa": "bin/btoa.js"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "dev": true,
@@ -1226,6 +1240,13 @@
         "node_modules/continuable-cache": {
             "version": "0.3.1",
             "dev": true
+        },
+        "node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/core-util-is": {
             "version": "1.0.2",
@@ -1566,6 +1587,22 @@
             "version": "1.1.1",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/ejs": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "jake": "^10.8.5"
+            },
+            "bin": {
+                "ejs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.138",
@@ -2424,6 +2461,39 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/filelist": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+            "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "minimatch": "^5.0.1"
+            }
+        },
+        "node_modules/filelist/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/filelist/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/fill-range": {
@@ -4323,17 +4393,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/istanbul/node_modules/mkdirp": {
-            "version": "0.5.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
         "node_modules/istanbul/node_modules/resolve": {
             "version": "1.1.7",
             "dev": true,
@@ -4349,6 +4408,31 @@
             "engines": {
                 "node": ">=0.8.0"
             }
+        },
+        "node_modules/jake": {
+            "version": "10.9.4",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+            "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "async": "^3.2.6",
+                "filelist": "^1.0.4",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "jake": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jake/node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/jest-diff": {
             "version": "29.7.0",
@@ -4986,6 +5070,19 @@
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
         },
         "node_modules/morgan": {
             "version": "1.10.1",
@@ -6492,6 +6589,217 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-explorer": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.5.3.tgz",
+            "integrity": "sha512-qfUGs7UHsOBE5p/lGfQdaAj/5U/GWYBw2imEpD6UQNkqElYonkow8t+HBL1qqIl3CuGZx7n8/CQo4x1HwSHhsg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "btoa": "^1.2.1",
+                "chalk": "^4.1.0",
+                "convert-source-map": "^1.7.0",
+                "ejs": "^3.1.5",
+                "escape-html": "^1.0.3",
+                "glob": "^7.1.6",
+                "gzip-size": "^6.0.0",
+                "lodash": "^4.17.20",
+                "open": "^7.3.1",
+                "source-map": "^0.7.4",
+                "temp": "^0.9.4",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "sme": "bin/cli.js",
+                "source-map-explorer": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/source-map-explorer/node_modules/gzip-size": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+            "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -6764,6 +7072,20 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/temp": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+            "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mkdirp": "^0.5.1",
+                "rimraf": "~2.6.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/text-decoder": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "grunt-shell": "^4.0.0",
         "grunt-text-replace": "^0.4.0",
         "qunit": "^2.24.1",
+        "source-map-explorer": "^2.5.3",
         "tsd": "^0.33.0",
         "typescript": "^5.9.3"
     },
@@ -53,8 +54,23 @@
         "test": "grunt test",
         "prepare": "grunt build",
         "build": "grunt build",
-        "dev": "grunt dev"
+        "dev": "grunt dev",
+        "bundlesize": "node scripts/check-bundle-size.js",
+        "bundlesize:visualize": "source-map-explorer build/openseadragon/openseadragon.min.js --no-border-checks",
+        "package": "grunt package"
     },
+    "bundlesize": [
+        {
+            "path": "build/openseadragon/openseadragon.min.js",
+            "maxSize": "90 kB",
+            "compression": "gzip"
+        },
+        {
+            "path": "build/openseadragon/openseadragon.min.js",
+            "maxSize": "350 kB",
+            "compression": "none"
+        }
+    ],
     "types": "types/index.d.ts",
     "tsd": {
         "directory": "test-dts"

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -9,13 +9,17 @@ const packageJson = require(path.join(root, 'package.json'));
 const checks = packageJson.bundlesize || [];
 
 function parseMaxSize(size) {
-    const match = /^([\d.]+)\s*(b|kb|mb)$/i.exec(size);
+    const match = /^(\d+(?:\.\d+)?)\s*(b|kb|mb)$/i.exec(size);
 
     if (!match) {
         throw new Error(`Unsupported maxSize value: ${size}`);
     }
 
     const amount = Number(match[1]);
+    if (!Number.isFinite(amount)) {
+        throw new Error(`Unsupported maxSize value: ${size}`);
+    }
+
     const unit = match[2].toLowerCase();
     const multipliers = {
         b: 1,
@@ -31,7 +35,7 @@ function formatSize(bytes) {
         return `${bytes}B`;
     }
 
-    return `${(bytes / 1000).toFixed(2)}KB`;
+    return `${(bytes / 1000).toFixed(2)}kB`;
 }
 
 function getSize(filePath, compression) {

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,0 +1,76 @@
+/* eslint-env node */
+
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+const root = path.resolve(__dirname, '..');
+const packageJson = require(path.join(root, 'package.json'));
+const checks = packageJson.bundlesize || [];
+
+function parseMaxSize(size) {
+    const match = /^([\d.]+)\s*(b|kb|mb)$/i.exec(size);
+
+    if (!match) {
+        throw new Error(`Unsupported maxSize value: ${size}`);
+    }
+
+    const amount = Number(match[1]);
+    const unit = match[2].toLowerCase();
+    const multipliers = {
+        b: 1,
+        kb: 1000,
+        mb: 1000 * 1000
+    };
+
+    return amount * multipliers[unit];
+}
+
+function formatSize(bytes) {
+    if (bytes < 1000) {
+        return `${bytes}B`;
+    }
+
+    return `${(bytes / 1000).toFixed(2)}KB`;
+}
+
+function getSize(filePath, compression) {
+    const file = fs.readFileSync(filePath);
+
+    if (compression === 'gzip') {
+        return zlib.gzipSync(file).length;
+    }
+
+    if (compression === 'none') {
+        return file.length;
+    }
+
+    throw new Error(`Unsupported compression value: ${compression}`);
+}
+
+let failed = false;
+
+for (const check of checks) {
+    const filePath = path.join(root, check.path);
+    const maxSize = parseMaxSize(check.maxSize);
+    const compression = check.compression || 'gzip';
+
+    if (!fs.existsSync(filePath)) {
+        console.error(`FAIL ${check.path}: file does not exist`);
+        failed = true;
+        continue;
+    }
+
+    const size = getSize(filePath, compression);
+    const passed = size <= maxSize;
+    const status = passed ? 'PASS' : 'FAIL';
+    const comparator = passed ? '<' : '>';
+
+    console.log(
+        `${status} ${check.path}: ${formatSize(size)} ${comparator} maxSize ${check.maxSize.replace(/\s+/g, '')} (${compression})`
+    );
+
+    failed = failed || !passed;
+}
+
+process.exitCode = failed ? 1 : 0;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -837,7 +837,7 @@ declare namespace OpenSeadragon {
         raiseEventAwaiting<K extends keyof EventMap>(
             eventName: K,
             eventArgs?: object,
-            bindTarget?: any = null,
+            bindTarget?: any,
         ): Promise<any>;
         removeAllHandlers<K extends keyof EventMap>(eventName: K): void;
         removeHandler<K extends keyof EventMap>(


### PR DESCRIPTION
## Summary

This PR adds bundle-size monitoring and visualization for OpenSeadragon.

- Adds `npm run bundlesize`, backed by `scripts/check-bundle-size.js`, to check the minified bundle against the limits configured in `package.json`.
- Adds `npm run bundlesize:visualize` using `source-map-explorer` to inspect what contributes to the generated bundle.
- Adds a `Bundle Size Check` GitHub Actions workflow that builds the PR branch, runs the bundle-size check, compares against the base branch, and posts or updates a PR comment with the raw check output plus size deltas.
- Updates `CONTRIBUTING.md` to point contributors at `npm run bundlesize` without duplicating limit values that can drift from `package.json`.

## Usage

```bash
npm run build
npm run bundlesize
npm run bundlesize:visualize
```

## Verification

Local checks:

```bash
npm run build
npm run bundlesize
npx tsc --noEmit -p tsconfig.dts.json
node --check scripts/check-bundle-size.js
node node_modules/source-map-explorer/bin/cli.js --version
```

GitHub Actions:

- `Bundle Size Check / Check Bundle Size` passed.
- `Pull Request Checks / Run test tasks` passed.
