### PR TITLE
test: add positiveModulo unit tests (addresses #306)

### DIFF
--- a/test/positive-modulo.test.js
+++ b/test/positive-modulo.test.js
@@ -1,0 +1,19 @@
+
+// test/positive-modulo.test.js
+// A small unit test for OpenSeadragon.positiveModulo()
+// Uses QUnit syntax which is used by OSD test harness
+
+QUnit.module('Utils: positiveModulo');
+
+QUnit.test('positiveModulo returns positive remainder for negative numbers', function (assert) {
+  assert.expect(2);
+
+  // Example: -1 mod 5 = 4
+  const result1 = OpenSeadragon.positiveModulo(-1, 5);
+  assert.strictEqual(result1, 4, 'positiveModulo(-1, 5) === 4');
+
+  // Example: -8 mod 7 = 6
+  const result2 = OpenSeadragon.positiveModulo(-8, 7);
+  assert.strictEqual(result2, 6, 'positiveModulo(-8, 7) === 6');
+});
+


### PR DESCRIPTION
Fixes: #306

### Summary
Adds a QUnit test to verify OpenSeadragon.positiveModulo returns positive remainders for negative inputs.

### Changes
- Added test/positive-modulo.test.js with two assertions for negative inputs
- Added test/positive-modulo-runner.html to run test in browser

### How to run locally
1. python3 -m http.server 8000
2. Open http://localhost:8000/test/positive-modulo-runner.html in a browser
