### PR TITLE
chore: update some optional JSDoc blocks parameters

### DIFF
--- a/src/dzitilesource.js
+++ b/src/dzitilesource.js
@@ -99,7 +99,7 @@ $.extend( $.DziTileSource.prototype, $.TileSource.prototype, /** @lends OpenSead
      * this tile source.
      * @function
      * @param {Object|Array} data
-     * @param {String} optional - url
+     * @param {String} [url]
      */
     supports: function( data, url ){
         let ns;

--- a/src/eventsource.js
+++ b/src/eventsource.js
@@ -174,7 +174,7 @@ $.EventSource.prototype = {
      * Remove all event handlers for a given event type. If no type is given all
      * event handlers for every event type are removed.
      * @function
-     * @param {String} eventName - Name of event for which all handlers are to be removed.
+     * @param {String} [eventName] - Name of event for which all handlers are to be removed.
      */
     removeAllHandlers: function( eventName ) {
         if ( eventName ){

--- a/src/iiptilesource.js
+++ b/src/iiptilesource.js
@@ -44,10 +44,10 @@
    * @extends OpenSeadragon.TileSource
    * @see https://iipimage.sourceforge.io
    *
-   * @param {String} iipsrv               - IIPImage host server path (ex: "https://host/fcgi-bin/iipsrv.fcgi" or "/fcgi-bin/iipsrv.fcgi")
-   * @param {String} image                - Image path and name on server (ex: "image.tif")
-   * @param {String} format    (optional) - Tile output format (default: "jpg")
-   * @param {Object} transform (optional) - Object containing image processing transforms
+   * @param {String} iipsrv      - IIPImage host server path (ex: "https://host/fcgi-bin/iipsrv.fcgi" or "/fcgi-bin/iipsrv.fcgi")
+   * @param {String} image       - Image path and name on server (ex: "image.tif")
+   * @param {String} [format]    - Tile output format (default: "jpg")
+   * @param {Object} [transform] - Object containing image processing transforms
    *                                        (supported transform: "stack","quality","contrast","color","invert",
    *                                                              "colormap," "gamma","minmax","twist","hillshade".
    *                                        See https://iipimage.sourceforge.io/documentation/protocol for how to use)
@@ -101,7 +101,7 @@
      * this tile source.
      * @function
      * @param {Object|Array} data
-     * @param {String} optional - url
+     * @param {String} [url]
      */
     supports: function(data, url) {
       // Configuration must supply the IIP server endpoint and the image name

--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -74,7 +74,7 @@ $.ImageTileSource = class extends $.TileSource {
      * this tile source.
      * @function
      * @param {Object|Array} data
-     * @param {String} url - optional
+     * @param {String} [url]
      */
     supports(data, url) {
         return data.type && data.type === "image";

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -45,7 +45,7 @@
    * @param {String} type       - iris
    * @param {String} serverUrl  - Iris host server path (ex: "http://localhost:3000")
    * @param {String} slideId    - Image id (ex: "12345" for 12345.iris)
-   * @param {Object} metadata   - Optional metadata object to use instead of fetching
+   * @param {Object} [metadata] - Optional metadata object to use instead of fetching
    *
    * Example: tileSources: {
    *            type:         "iris",

--- a/src/legacytilesource.js
+++ b/src/legacytilesource.js
@@ -104,7 +104,7 @@ $.extend( $.LegacyTileSource.prototype, $.TileSource.prototype, /** @lends OpenS
      * this tile source.
      * @function
      * @param {Object|Array} data
-     * @param {String} optional - url
+     * @param {String} [url]
      */
     supports: function( data, url ){
         return (

--- a/src/osmtilesource.js
+++ b/src/osmtilesource.js
@@ -108,7 +108,7 @@ $.extend( $.OsmTileSource.prototype, $.TileSource.prototype, /** @lends OpenSead
      * this tile source.
      * @function
      * @param {Object|Array} data
-     * @param {String} optional - url
+     * @param {String} [url]
      */
     supports: function( data, url ){
         return (

--- a/src/tmstilesource.js
+++ b/src/tmstilesource.js
@@ -100,7 +100,7 @@ $.extend( $.TmsTileSource.prototype, $.TileSource.prototype, /** @lends OpenSead
      * this tile source.
      * @function
      * @param {Object|Array} data
-     * @param {String} optional - url
+     * @param {String} [url]
      */
     supports: function( data, url ){
         return ( data.type && "tiledmapservice" === data.type );

--- a/src/zoomifytilesource.js
+++ b/src/zoomifytilesource.js
@@ -111,7 +111,7 @@
          * this tile source.
          * @function
          * @param {Object|Array} data
-         * @param {String} optional - url
+         * @param {String} [url]
          */
         supports: function(data, url) {
             return (data.type && "zoomifytileservice" === data.type);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -618,7 +618,7 @@ declare namespace OpenSeadragon {
         getHandler<K extends keyof EventMap>(eventName: K): void;
         numberOfHandlers<K extends keyof EventMap>(eventName: K): number;
         raiseEvent<K extends keyof EventMap>(eventName: K, eventArgs: object): boolean;
-        removeAllHandlers<K extends keyof EventMap>(eventName: K): boolean;
+        removeAllHandlers<K extends keyof EventMap>(eventName?: K): boolean;
         removeHandler<K extends keyof EventMap>(eventName: K, handler: EventHandler<EventMap[K]>): boolean;
     }
 


### PR DESCRIPTION
I noticed that `EventSource.removeAllHandlers()`'s `eventName` parameter is not marked as optional in the JSDoc block or the type definitions. Cleaned up a few more optional JSDoc block parameters while I was at it :)