### PR TITLE
fix: conditionally load grunt-istanbul to avoid circular dependency warning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,8 +16,12 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-eslint");
     grunt.loadNpmTasks("grunt-git-describe");
     grunt.loadNpmTasks('grunt-text-replace');
-    grunt.loadNpmTasks('grunt-istanbul');
     grunt.loadNpmTasks('grunt-shell');
+
+    // Only load grunt-istanbul when coverage task is run (avoids circular dependency warning)
+    if (grunt.cli.tasks.includes('coverage')) {
+        grunt.loadNpmTasks('grunt-istanbul');
+    }
 
     // ----------
     const packageJson = grunt.file.readJSON("package.json"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -870,9 +870,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001714",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz",
-            "integrity": "sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==",
+            "version": "1.0.30001762",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+            "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary

Fixes the Node.js circular dependency warning that appears during test runs:

```
Warning: Accessing non-existent property 'VERSION' of module exports inside circular dependency
```

## Problem

The `grunt-istanbul` package depends on the deprecated `istanbul` package, which has a circular dependency issue with newer versions of Node.js. This warning was displayed every time `npm run test` was executed, even though `grunt-istanbul` is only needed for the optional `coverage` task.

## Solution

Conditionally load `grunt-istanbul` only when the `coverage` task is explicitly being run:

```javascript
if (grunt.cli.tasks.includes('coverage')) {
    grunt.loadNpmTasks('grunt-istanbul');
}
```

This eliminates the warning during normal test runs while preserving full coverage functionality when needed.

## Testing

- ✅ `npm run test` - 311 tests pass, no circular dependency warning
- ✅ `grunt coverage` - Still works correctly when coverage is needed
