### PR TITLE
Fix jsdocs for tilecache.js

### DIFF
--- a/src/tilecache.js
+++ b/src/tilecache.js
@@ -34,10 +34,12 @@
 
 (function( $ ){
 
+    const OpenSeadragon = $; // alias for JSDoc
+
     const DRAWER_INTERNAL_CACHE = Symbol("DRAWER_INTERNAL_CACHE");
 
     /**
-     * @class CacheRecord
+     * @class OpenSeadragon.CacheRecord
      * @memberof OpenSeadragon
      * @classdesc Cached Data Record, the cache object. Keeps only latest object type required.
      *
@@ -48,7 +50,7 @@
      * Furthermore, it has a 'getData' function that returns a promise resolving
      * with the value on the desired type passed to the function.
      */
-    $.CacheRecord = class {
+    OpenSeadragon.CacheRecord = class CacheRecord {
         constructor() {
             this.revive();
         }
@@ -718,7 +720,7 @@
     };
 
     /**
-     * @class InternalCacheRecord
+     * @class OpenSeadragon.InternalCacheRecord
      * @memberof OpenSeadragon
      * @classdesc Simple cache record without robust support for async access. Meant for internal use only.
      *
@@ -730,7 +732,7 @@
      * It also does not record tiles nor allows cache/tile sharing.
      * @private
      */
-    $.InternalCacheRecord = class {
+    OpenSeadragon.InternalCacheRecord = class InternalCacheRecord {
         constructor(data, type, onDestroy) {
             this.tstamp = $.now();
             this._ondestroy = onDestroy;
@@ -801,8 +803,9 @@
         }
     };
 
+
     /**
-     * @class TileCache
+     * @class OpenSeadragon.TileCache
      * @memberof OpenSeadragon
      * @classdesc Stores all the tiles displayed in a {@link OpenSeadragon.Viewer}.
      * You generally won't have to interact with the TileCache directly.
@@ -810,7 +813,7 @@
      * @param {Number} [options.maxImageCacheCount] - See maxImageCacheCount in
      * {@link OpenSeadragon.Options} for details.
      */
-    $.TileCache = class {
+    OpenSeadragon.TileCache = class TileCache {
         constructor( options ) {
             options = options || {};
 


### PR DESCRIPTION
Updated the classes in tilecache.js to follow the pattern used in our other ES6 class definitions (i.e. the drawers) which worked correctly. Refers to discussion in https://github.com/openseadragon/openseadragon/issues/2848. The docs build correctly for me now:
<img width="627" height="871" alt="image" src="https://github.com/user-attachments/assets/8782085b-978a-4b34-b0e1-fc9c00b16e90" />
