### PR TITLE
Fix OSM tile source default dimensions

### DIFF
--- a/src/osmtilesource.js
+++ b/src/osmtilesource.js
@@ -53,9 +53,11 @@
  *
  * Note 2. Image dimension. According to the OSM Wiki
  * (http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Zoom_levels)
- * the highest Mapnik zoom level has 256.144x256.144 tiles, with a 256x256
- * pixel size. I.e. the Deep Zoom image dimension is 65.572.864x65.572.864
+ * the highest Mapnik zoom level has 262.144x262.144 tiles, with a 256x256
+ * pixel size. I.e. the Deep Zoom image dimension is 67.108.864x67.108.864
  * pixels.
+ * OSM now supports higher max zoom (e.g. 19), but this default is
+ * based on zoom level 18: 2^18 tiles * 256px.
  *
  * @memberof OpenSeadragon
  * @extends OpenSeadragon.TileSource
@@ -84,8 +86,8 @@ $.OsmTileSource = function( width, height, tileSize, tileOverlap, tilesUrl ) {
     //but allow them to be specified so fliks can host there own instance
     //or apply against other services supportting the same standard
     if( !options.width || !options.height ){
-        options.width = 65572864;
-        options.height = 65572864;
+        options.width = 67108864;
+        options.height = 67108864;
     }
     if( !options.tileSize ){
         options.tileSize = 256;


### PR DESCRIPTION
Fixes #2850.

  - Corrected OSM tile count to 262.144x262.144 and image size to
  67.108.864.
  - Updated default width/height to 67,108,864.
  - Added note about max zoom 19 vs default based on zoom 18.

 Thanks @dao251 for the report and details on the OSM wiki typo. This is my first PR in a public repo, I hope this is the right approach! 