### PR TITLE
Adjustments for Viewport coordinate conversion functions.

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1575,7 +1575,7 @@ $.Viewport.prototype = {
         $.console.assert(this.viewer,
             "[Viewport.windowToImageCoordinates] the viewport must have a viewer.");
         const viewerCoordinates = pixel.minus(
-                $.getElementPosition(this.viewer.element));
+                $.getElementPosition(this.viewer.container));
         return this.viewerElementToImageCoordinates(viewerCoordinates);
     },
 
@@ -1590,7 +1590,7 @@ $.Viewport.prototype = {
             "[Viewport.imageToWindowCoordinates] the viewport must have a viewer.");
         const viewerCoordinates = this.imageToViewerElementCoordinates(pixel);
         return viewerCoordinates.plus(
-                $.getElementPosition(this.viewer.element));
+                $.getElementPosition(this.viewer.container));
     },
 
     /**
@@ -1650,7 +1650,7 @@ $.Viewport.prototype = {
         $.console.assert(this.viewer,
             "[Viewport.windowToViewportCoordinates] the viewport must have a viewer.");
         const viewerCoordinates = pixel.minus(
-                $.getElementPosition(this.viewer.element));
+                $.getElementPosition(this.viewer.container));
         return this.viewerElementToViewportCoordinates(viewerCoordinates);
     },
 
@@ -1664,7 +1664,7 @@ $.Viewport.prototype = {
             "[Viewport.viewportToWindowCoordinates] the viewport must have a viewer.");
         const viewerCoordinates = this.viewportToViewerElementCoordinates(point);
         return viewerCoordinates.plus(
-                $.getElementPosition(this.viewer.element));
+                $.getElementPosition(this.viewer.container));
     },
 
     /**

--- a/test/modules/viewport.js
+++ b/test/modules/viewport.js
@@ -1291,7 +1291,7 @@
                 return el.times(windowBoundary);
             },
             getExpected: function(orig, viewport) {
-                const posPoint = OpenSeadragon.getElementOffset(viewer.element);
+                const posPoint = OpenSeadragon.getElementOffset(viewer.container);
                 return orig.minus(posPoint).divide(viewport.getContainerSize().x * ZOOM_FACTOR).plus(VIEWER_PADDING);
             },
             method: 'windowToViewportCoordinates'
@@ -1305,7 +1305,7 @@
                 return el.times(viewer.source.dimensions.x);
             },
             getExpected: function(orig, viewport) {
-                const posPoint = OpenSeadragon.getElementOffset(viewer.element);
+                const posPoint = OpenSeadragon.getElementOffset(viewer.container);
                 return orig.plus(posPoint).minus(VIEWER_PADDING.times(viewport.getContainerSize().x * ZOOM_FACTOR));
             },
             method: 'imageToWindowCoordinates'
@@ -1320,7 +1320,7 @@
                 return el.times(windowBoundary);
             },
             getExpected: function(orig, viewport) {
-                const posPoint = OpenSeadragon.getElementOffset(viewer.element);
+                const posPoint = OpenSeadragon.getElementOffset(viewer.container);
                 return orig.minus(posPoint).divide(viewport.getContainerSize().x * ZOOM_FACTOR).plus(VIEWER_PADDING);
             },
             method: 'windowToViewportCoordinates'
@@ -1334,7 +1334,7 @@
                 return el.times(viewer.source.dimensions.x);
             },
             getExpected: function(orig, viewport) {
-                const posPoint = OpenSeadragon.getElementOffset(viewer.element);
+                const posPoint = OpenSeadragon.getElementOffset(viewer.container);
                 return orig.minus(VIEWER_PADDING).times(viewport.getContainerSize().x * ZOOM_FACTOR).plus(posPoint);
             },
             method: 'viewportToWindowCoordinates'


### PR DESCRIPTION
Coordinates are calculated relative to Viewer.container (instead of Viewer.element as before, see Issue #2828