### PR TITLE
Revert back default downloadTileStart logics.

### DIFF
--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -225,7 +225,7 @@ $.TileSource = function( options ) {
         //implements and 'configure'
         setTimeout(() => this.getImageInfo(this.url)); //needs async in case someone exits immediately
     } else {
-        this._uniqueIdentifier = Math.floor(Math.random()*1e10).toString(36);
+        this._uniqueIdentifier = Math.floor(Math.random() * 1e10).toString(36);
         // by default it used to fire immediately, so make the ready default
         if (this.ready || this.ready === undefined) {
             this.raiseEvent('ready', { tileSource: this });


### PR DESCRIPTION
While we could just do this one-liner, we found out that downloading the data _before_ a cache is initialized works better in general cases. Network access is the most error-prone part, and this scenario better supports all default use-cases, including the fact that retry logics works only at this stage, not on the cache level.

I did not rever everything; the download ajax route still returns a blob instead of image. This gives the users freedom to not forcing image creation, sometimes images are not really needed (e.g. canvas renderer). So this way we have somethiing better:
 - simple scenario - image download, implemented by a browser
 - advanced scenario vs ajax - more user control, blob output - further optimization-anle
 
 The crucial part is that the fetching happens at the downloadTileStart level. We should document this.