### PR TITLE
Redesign of Authentication & Resource Access API

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,6 +64,7 @@ module.exports = function(grunt) {
             "src/referencestrip.js",
             "src/displayrectangle.js",
             "src/spring.js",
+            "src/httpclient.js",
             "src/imageloader.js",
             "src/tile.js",
             "src/overlay.js",

--- a/src/httpclient.js
+++ b/src/httpclient.js
@@ -1,0 +1,16 @@
+/**
+ * Generic HTTP Client Adapter for OpenSeadragon
+ */
+(function($) {
+    // todo for simplicity, still support headers from the old openseadragon configuration
+    // todo add support for crossOriginPolicy setup and ajaxHeaders
+    $.DefaultHttpClient = class DefaultHttpClient {
+        // todo async not supported yet, need to replace with $.Promise
+        async request(url, { method = "GET", headers = {}, body, signal } = {}) {
+            const response = await fetch(url, { method, headers, body, signal });
+            // todo somehow handle the payload, usually contains some info about the error
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return response;
+        }
+    };
+})(OpenSeadragon);

--- a/src/iiptilesource.js
+++ b/src/iiptilesource.js
@@ -170,6 +170,7 @@
 
       const _this = this;
 
+      // todo update this
       $.makeAjaxRequest( {
         url: url,
         type: "GET",

--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -45,7 +45,7 @@
  * @param {TileSource} [options.source] - Image loading strategy
  * @param {String} [options.loadWithAjax] - Whether to load this image with AJAX.
  * @param {String} [options.ajaxHeaders] - Headers to add to the image request if using AJAX.
- * @param {Boolean} [options.ajaxWithCredentials] - Whether to set withCredentials on AJAX requests.
+ * @param {Boolean} [options.ajaxWithCredentials] - deprecated
  * @param {String} [options.crossOriginPolicy] - CORS policy to use for downloads
  * @param {String} [options.postData] - HTTP POST data (usually but not necessarily in k=v&k2=v2... form,
  *      see TileSource::getTilePostData) or null
@@ -98,6 +98,7 @@ $.ImageJob = function(options) {
      * Whether to set withCredentials on AJAX requests.
      * @member {boolean} ajaxWithCredentials
      * @memberof OpenSeadragon.ImageJob#
+     * @deprecated
      */
 
     /**
@@ -211,23 +212,34 @@ $.ImageJob.prototype = {
      *   Usage: context.finish(data, request, dataType=undefined). Pass the downloaded data object
      *   add also reference to an ajax request if used. Optionally, specify what data type the data is.
      * @param {*} data data that has been downloaded
-     * @param {XMLHttpRequest} request reference to the request if used
-     * @param {string} dataType data type identifier
+     * @param {string} dataType data type identifier, used to be request argument (deprecated, yet still supported)
+     * @param {string} dataTypeOld data type identifier - old deprecated position
      *   fallback compatibility behavior: dataType treated as errorMessage if data is falsey value
      * @memberof OpenSeadragon.ImageJob#
      */
-    finish: function(data, request, dataType) {
+    finish: function(data, dataType, dataTypeOld) {
         if (!this.jobId) {
             return;
         }
         // old behavior, no deprecation due to possible finish calls with invalid data item (e.g. different error)
         if (isInvalidData(data)) {
-            this.fail(dataType || "[downloadTileStart->finish()] Retrieved data is invalid!", request);
+            this.fail(dataType || "[downloadTileStart->finish()] Retrieved data is invalid!");
             return;
         }
 
+        if (typeof dataTypeOld === "string") {
+            if (!dataType) {
+                dataType = dataTypeOld;
+            } else {
+                $.console.warn(
+                    'ImageJob.prototype.finish() called with both dataType and dataTypeOld. ' +
+                    'dataType is deprecated, dataTypeOld is still supported. ' +
+                    'dataType:', dataType, 'dataTypeOld:', dataTypeOld
+                );
+            }
+        }
+
         this.data = data;
-        this.request = request;
         this.errorMsg = null;
         this.dataType = dataType;
 
@@ -242,11 +254,10 @@ $.ImageJob.prototype = {
      *   Usage: context.fail(errMessage, request). Provide error message in case of failure,
      *   add also reference to an ajax request if used.
      * @param {string} errorMessage description upon failure
-     * @param {XMLHttpRequest} request reference to the request if used
+     * @param {XMLHttpRequest} request deprecated
      */
-    fail: function(errorMessage, request) {
+    fail: function(errorMessage, request = undefined) {
         this.data = null;
-        this.request = request;
         this.errorMsg = errorMessage;
         this.dataType = null;
 
@@ -350,7 +361,6 @@ $.BatchImageJob.prototype = {
      */
     fail: function(errorMessage, request) {
         this.data = null;
-        this.request = request;
         this.errorMsg = errorMessage;
         this.dataType = null;
 
@@ -410,8 +420,7 @@ $.ImageLoader.prototype = {
      * @param {String|Boolean} [options.crossOriginPolicy] - CORS policy to use for downloads
      * @param {String} [options.postData] - POST parameters (usually but not necessarily in k=v&k2=v2... form,
      *      see TileSource::getTilePostData) or null
-     * @param {Boolean} [options.ajaxWithCredentials] - Whether to set withCredentials on AJAX
-     *      requests.
+     * @param {Boolean} [options.ajaxWithCredentials] - deprecated
      * @param {Function} [options.callback] - Called once image has been downloaded.
      * @param {Function} [options.abort] - Called when this image job is aborted.
      * @returns {boolean} true if job was immediatelly started, false if queued

--- a/src/imagetilesource.js
+++ b/src/imagetilesource.js
@@ -40,7 +40,7 @@
  * 1. viewer.open({type: 'image', url: fooUrl});
  * 2. viewer.open(new OpenSeadragon.ImageTileSource({url: fooUrl}));
  *
- * With the first syntax, the crossOriginPolicy, ajaxWithCredentials and
+ * With the first syntax, the crossOriginPolicy and
  * useCanvas options are inherited from the viewer if they are not
  * specified directly in the options object.
  *
@@ -54,8 +54,7 @@
  * 'Anonymous', 'use-credentials', and false. If false, image requests will
  * not use CORS preventing internal pyramid building for images from other
  * domains.
- * @param {String|Boolean} [options.ajaxWithCredentials=false] Whether to set
- * the withCredentials XHR flag for AJAX requests (when loading tile sources).
+ * @param {String|Boolean} [options.ajaxWithCredentials=false] deprecated
  * @param {Boolean} [options.useCanvas=true] Set to false to prevent any use
  * of the canvas API.
  */
@@ -65,7 +64,6 @@ $.ImageTileSource = class extends $.TileSource {
         super($.extend({
             buildPyramid: true,
             crossOriginPolicy: false,
-            ajaxWithCredentials: false,
         }, props));
     }
 

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -708,20 +708,22 @@
   * @property {Number} [collectionTileMargin=80]
   *     If collectionMode is true, specifies the margin, in viewport coordinates, between each TiledImage.
   *
-  * @property {String|Boolean} [crossOriginPolicy=false]
+  * @property {String|Boolean} [crossOriginPolicy=false]   TODO: this needs to be updated and properly integrated with the default client
   *     Valid values are 'Anonymous', 'use-credentials', and false. If false, canvas requests will
   *     not use CORS, and the canvas will be tainted.
   *
   * @property {Boolean} [ajaxWithCredentials=false]
-  *     Whether to set the withCredentials XHR flag for AJAX requests.
-  *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
+  *     Deprecated.
   *
-  * @property {Boolean} [loadTilesWithAjax=false]
+  * @property {Boolean} [loadTilesWithAjax=false]   TODO: this needs to be updated and properly integrated with the default client, CONSIDER renaming
   *     Whether to load tile data using AJAX requests.
-  *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
+  *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level
   *
-  * @property {Object} [ajaxHeaders={}]
+  * @property {Object} [ajaxHeaders={}]  TODO: this needs to be updated and properly integrated with the default client, CONSIDER renaming
   *     A set of headers to include when making AJAX requests for tile sources or tiles.
+  *
+  * @property {DefaultHttpClient} [httpClient=undefined]
+  *     AuthClient providing access logics including authorization for resource access.
   *
   * @property {Boolean} [splitHashDataForPost=false]
   *     Allows to treat _first_ hash ('#') symbol as a separator for POST data:
@@ -1272,6 +1274,7 @@ function OpenSeadragon( options ){
             ajaxWithCredentials:    false,
             loadTilesWithAjax:      false,
             ajaxHeaders:            {},
+            httpClient:             undefined,
             splitHashDataForPost:   false,
             callTileLoadedWithCachedData: false,
 
@@ -2392,10 +2395,11 @@ function OpenSeadragon( options ){
         /**
          * Create an XHR object
          * @private
-         * @param {type} [local] Deprecated. Ignored (IE/ActiveXObject file protocol no longer supported).
          * @returns {XMLHttpRequest}
+         * @deprecated
          */
         createAjaxRequest: function() {
+            console.warn("This method is deprecated.");
             if ( window.XMLHttpRequest ) {
                 $.createAjaxRequest = function() {
                     return new XMLHttpRequest();
@@ -2424,11 +2428,13 @@ function OpenSeadragon( options ){
          * @param {String} options.responseType - the response type of the AJAX request
          * @param {String} options.postData - HTTP POST data (usually but not necessarily in k=v&k2=v2... form,
          *      see TileSource::getTilePostData), GET method used if null
-         * @param {Boolean} [options.withCredentials=false] - whether to set the XHR's withCredentials
+         * @param {Boolean} [options.withCredentials=false] - deprecated
          * @throws {Error}
          * @returns {XMLHttpRequest}
+         * @deprecated
          */
         makeAjaxRequest: function( url, onSuccess, onError ) {
+            console.warn("THis method is deprecated!");
             let withCredentials;
             let headers;
             let responseType;

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -93,7 +93,7 @@
  * @param {Boolean} [options.debugMode] - See {@link OpenSeadragon.Options}.
  * @param {String|CanvasGradient|CanvasPattern|Function} [options.placeholderFillStyle] - See {@link OpenSeadragon.Options}.
  * @param {String|Boolean} [options.crossOriginPolicy] - See {@link OpenSeadragon.Options}.
- * @param {Boolean} [options.ajaxWithCredentials] - See {@link OpenSeadragon.Options}.
+ * @param {Boolean} [options.ajaxWithCredentials] deprecated
  * @param {Boolean} [options.loadTilesWithAjax]
  *      Whether to load tile data using AJAX requests.
  *      Defaults to the setting in {@link OpenSeadragon.Options}.
@@ -2149,8 +2149,8 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             ajaxHeaders: tile.ajaxHeaders,
             crossOriginPolicy: this.crossOriginPolicy,
             ajaxWithCredentials: this.ajaxWithCredentials,
-            callback: function( data, errorMsg, tileRequest, dataType, tries ){
-                _this._onTileLoad( tile, time, data, errorMsg, tileRequest, dataType, tries );
+            callback: function( data, errorMsg, dataType, tries ){
+                _this._onTileLoad( tile, time, data, errorMsg, dataType, tries );
             },
             abort: function() {
                 tile.loading = false;
@@ -2181,11 +2181,10 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * @param {Number} time
      * @param {*} data image data
      * @param {String} errorMsg
-     * @param {XMLHttpRequest} tileRequest
      * @param {String} [dataType=undefined] data type, derived automatically if not set
      * @param {number} tries - The number of times the tile has been retried.
      */
-    _onTileLoad: function( tile, time, data, errorMsg, tileRequest, dataType, tries ) {
+    _onTileLoad: function( tile, time, data, errorMsg, dataType, tries ) {
         //data is set to null on error by image loader, allow custom falsey values (e.g. 0)
         if ( data === null || data === undefined ) {
             $.console.error( "Tile %s failed to load: %s - error: %s", tile, tile.getUrl(), errorMsg );
@@ -2201,14 +2200,14 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
              * @property {string} message - The error message.
              * @property {number} tries - The number of times the tile has been retried.
              * @property {boolean} maxReached - Whether the maximum number of retries has been reached.
-             * @property {XMLHttpRequest} tileRequest - The XMLHttpRequest used to load the tile if available.
+             * @property {XMLHttpRequest} tileRequest - deprecated
              */
             this.viewer.raiseEvent("tile-load-failed", {
                 tile: tile,
                 tiledImage: this,
                 time: time,
                 message: errorMsg,
-                tileRequest: tileRequest,
+                tileRequest: null,
                 tries: tries,
                 maxReached: this.viewer.tileRetryMax === 0 ? true : tries >= this.viewer.tileRetryMax
             });
@@ -2231,17 +2230,17 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             if (conversion) {
                 const desiredType = $.converter.getConversionPathFinalType(conversion);
                 $.converter.convert(tile, data, dataType, desiredType).then(newData => {
-                    this._setTileLoaded(tile, newData, null, tileRequest, desiredType);
+                    this._setTileLoaded(tile, newData, null, desiredType);
                 }).catch(e => {
                     $.console.warn("Failed to satisfy original type [%s] %s from %s: %s", desiredType, tile, dataType, e);
-                    this._setTileLoaded(tile, data, null, tileRequest, dataType);
+                    this._setTileLoaded(tile, data, null, dataType);
                 });
             } else {
                 $.console.warn( "Ignoring default base tile data type %s: no conversion possible from %s", this.originalDataType, dataType);
-                this._setTileLoaded(tile, data, null, tileRequest, dataType);
+                this._setTileLoaded(tile, data, null, dataType);
             }
         } else {
-            this._setTileLoaded(tile, data, null, tileRequest, dataType);
+            this._setTileLoaded(tile, data, null, dataType);
         }
     },
 
@@ -2251,10 +2250,9 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
      * @param {*} data image data, the data sent to ImageJob.prototype.finish(), by default an Image object,
      *   can be null: in that case, cache is assigned to a tile without further processing
      * @param {?Number} cutoff ignored, @deprecated
-     * @param {?XMLHttpRequest} tileRequest
      * @param {?String} [dataType=undefined] data type, derived automatically if not set
      */
-    _setTileLoaded: function(tile, data, cutoff, tileRequest, dataType) {
+    _setTileLoaded: function(tile, data, cutoff, dataType) {
         tile.tiledImage = this; //unloaded with tile.unload(), so we need to set it back
         // does nothing if tile.cacheKey already present
 
@@ -2314,7 +2312,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
              * @property {String} dataType type of the data
              * @property {OpenSeadragon.TiledImage} tiledImage - The tiled image of the loaded tile.
              * @property {OpenSeadragon.Tile} tile - The tile which has been loaded.
-             * @property {XMLHttpRequest} tileRequest - The AJAX request that loaded this tile (if applicable).
+             * @property {null} tileRequest - deprecated
              * @property {OpenSeadragon.Promise} - Promise resolved when the tile gets fully loaded.
              *   NOTE: DO NOT await the promise in the handler: you will create a deadlock!
              * @property {function} getCompletionCallback - deprecated
@@ -2322,7 +2320,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
             _this.viewer.raiseEventAwaiting("tile-loaded", {
                 tile: tile,
                 tiledImage: _this,
-                tileRequest: tileRequest,
+                tileRequest: null,
                 promise: new $.Promise(resolve => {
                     resolver = resolve;
                 }),

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -44,8 +44,7 @@
  * @property {Function} [options.success]
  *      A function to be called upon successful creation.
  * @property {Boolean} [options.ajaxWithCredentials]
- *      If this TileSource needs to make an AJAX call, this specifies whether to set
- *      the XHR's withCredentials (for accessing secure data).
+ *      Deprecated. Use crossOriginPolicy instead.
  * @property {Object} [options.ajaxHeaders]
  *      A set of headers to include in AJAX requests.
  * @property {Boolean} [options.splitHashDataForPost]
@@ -440,142 +439,53 @@ $.TileSource.prototype = {
      */
     getImageInfo: function( url ) {
         const _this = this;
-        let callbackName;
-        let callback;
-        let readySource;
-        let options;
-        let urlParts;
-        let filename;
-        let lastDot;
 
-
-        if( url ) {
-            urlParts = url.split( '/' );
-            filename = urlParts[ urlParts.length - 1 ];
-            lastDot  = filename.lastIndexOf( '.' );
-            if ( lastDot > -1 ) {
-                urlParts[ urlParts.length - 1 ] = filename.slice( 0, lastDot );
-            }
-        }
-
+        const client = this.viewer.httpClient;
+        // Handle POST data hidden in URL fragments if enabled
         let postData = null;
+        let requestUrl = url;
         if (this.splitHashDataForPost) {
             const hashIdx = url.indexOf("#");
             if (hashIdx !== -1) {
                 postData = url.substring(hashIdx + 1);
-                url = url.substr(0, hashIdx);
+                requestUrl = url.substring(0, hashIdx);
             }
         }
 
-        callback = function( data ){
-            if( typeof (data) === "string" ) {
-                data = $.parseXml( data );
-            }
-            const $TileSource = $.TileSource.determineType( _this, data, url );
-            if ( !$TileSource ) {
-                /**
-                 * Raised when an error occurs loading a TileSource.
-                 *
-                 * @event open-failed
-                 * @memberof OpenSeadragon.TileSource
-                 * @type {object}
-                 * @property {OpenSeadragon.TileSource} eventSource - A reference to the TileSource which raised the event.
-                 * @property {String} message
-                 * @property {String} source
-                 * @property {?Object} userData - Arbitrary subscriber-defined object.
-                 */
-                _this.raiseEvent( 'open-failed', { message: "Unable to load TileSource", source: url } );
-                return;
-            }
-
-            options = $TileSource.prototype.configure.apply( _this, [ data, url, postData ]);
-            if (options.ajaxWithCredentials === undefined) {
-                options.ajaxWithCredentials = _this.ajaxWithCredentials;
-            }
-
-            options.ready = true;  // force synchronous finish
-            readySource = new $TileSource( options );
-            _this.ready = true;
-            /**
-             * Raised when a TileSource is opened and initialized.
-             *
-             * @event ready
-             * @memberof OpenSeadragon.TileSource
-             * @type {object}
-             * @property {OpenSeadragon.TileSource} eventSource - A reference to the TileSource which raised the event.
-             * @property {Object} tileSource
-             * @property {?Object} userData - Arbitrary subscriber-defined object.
-             */
-            _this.raiseEvent( 'ready', { tileSource: readySource } );
-        };
-
-        if( url.match(/\.js$/) ){
-            //TODO: Its not very flexible to require tile sources to end jsonp
-            //      request for info  with a url that ends with '.js' but for
-            //      now it's the only way I see to distinguish uniformly.
-            callbackName = url.split('/').pop().replace('.js', '');
-            $.jsonp({
-                url: url,
-                async: false,
-                callbackName: callbackName,
-                callback: callback
-            });
-        } else {
-            // request info via xhr asynchronously.
-            $.makeAjaxRequest( {
-                url: url,
-                postData: postData,
-                withCredentials: this.ajaxWithCredentials,
-                headers: this.ajaxHeaders,
-                success: function( xhr ) {
-                    const data = processResponse( xhr );
-                    callback( data );
-                },
-                error: function ( xhr, exc ) {
-                    let msg;
-
-                    /*
-                        IE < 10 will block XHR requests to different origins. Any property access on the request
-                        object will raise an exception which we'll attempt to handle by formatting the original
-                        exception rather than the second one raised when we try to access xhr.status
-                     */
-                    try {
-                        msg = "HTTP " + xhr.status + " attempting to load TileSource: " + url;
-                    } catch ( e ) {
-                        let formattedExc;
-                        if ( typeof ( exc ) === "undefined" || !exc.toString ) {
-                            formattedExc = "Unknown error";
-                        } else {
-                            formattedExc = exc.toString();
-                        }
-
-                        msg = formattedExc + " attempting to load TileSource: " + url;
-                    }
-
-                    $.console.error(msg);
-
-                    /***
-                     * Raised when an error occurs loading a TileSource.
-                     *
-                     * @event open-failed
-                     * @memberof OpenSeadragon.TileSource
-                     * @type {object}
-                     * @property {OpenSeadragon.TileSource} eventSource - A reference to the TileSource which raised the event.
-                     * @property {String} message
-                     * @property {String} source
-                     * @property {String} postData - HTTP POST data (usually but not necessarily in k=v&k2=v2... form,
-                     *      see TileSource::getTilePostData) or null
-                     * @property {?Object} userData - Arbitrary subscriber-defined object.
-                     */
-                    _this.raiseEvent( 'open-failed', {
-                        message: msg,
-                        source: url,
-                        postData: postData
+        client.request(requestUrl, {
+            method: postData ? "POST" : "GET",
+            body: postData,
+            headers: this.ajaxHeaders || {},
+            expect: "auto" // Automatically parses JSON/XML based on response headers
+        })
+            .then(data => {
+                // Determine the specific TileSource type (DZI, IIIF, etc.)
+                const $TileSource = $.TileSource.determineType(_this, data, url);
+                if (!$TileSource) {
+                    _this.raiseEvent('open-failed', {
+                        message: "Unable to determine TileSource type from response",
+                        source: url
                     });
+                    return;
                 }
-            });
-        }
 
+                // Configure and initialize the source
+                const options = $TileSource.prototype.configure.apply(_this, [data, url, postData]);
+                options.ready = true;
+                const readySource = new $TileSource(options);
+
+                _this.ready = true;
+                _this.raiseEvent('ready', {tileSource: readySource});
+            })
+            .catch(err => {
+                // Use your HTTPError statusCode or default to OSD error format
+                const status = err.statusCode || "Error";
+                _this.raiseEvent('open-failed', {
+                    message: `HttpClient metadata fetch failed [${status}]: ${err.message}`,
+                    source: url,
+                    postData: postData
+                });
+            });
     },
 
     /**
@@ -817,63 +727,63 @@ $.TileSource.prototype = {
         // Load the tile with an AJAX request if the loadWithAjax option is
         // set. Otherwise load the image by setting the source property of the image object.
 
-        // TODO: the cors/creds is not optimal here:
-        //  - XMLHttpRequest can only setup credentials flag, so `ajaxWithCredentials` is a boolean
-        //  - <img> item can turn on/off cors, and include credentials if cors on, therefore `crossOriginPolicy` can have three values (one is null)
-        //  --> we should merge these flags to a single value to avoid confusion with usage, and use modern fetch that can setup also cors to have consistent behavior
+        // TODO: the cors/creds merge not completed, need to replace withCredentials with crossOriginPolicy
+
+        // instead of using some weird header options, just inject http client
+        //  somehow rename the property below...
         if (context.loadWithAjax) {
-            context.userData.request = $.makeAjaxRequest({
-                url: context.src,
-                withCredentials: context.ajaxWithCredentials,
-                headers: context.ajaxHeaders,
-                responseType: "arraybuffer",
-                postData: context.postData,
-                success: function(request) {
-                    let blb;
-                    // Make the raw data into a blob.
-                    // BlobBuilder fallback adapted from
-                    // http://stackoverflow.com/questions/15293694/blob-constructor-browser-compatibility
-                    try {
-                        blb = new window.Blob([request.response]);
-                    } catch (e) {
-                        const BlobBuilder = (
-                            window.BlobBuilder ||
-                            window.WebKitBlobBuilder ||
-                            window.MozBlobBuilder ||
-                            window.MSBlobBuilder
-                        );
-                        if (e.name === 'TypeError' && BlobBuilder) {
-                            const bb = new BlobBuilder();
-                            bb.append(request.response);
-                            blb = bb.getBlob();
-                        }
+            const client = this.viewer.httpClient;
+
+            // Setup AbortController for OSD's abort signal
+            const controller = new AbortController();
+            context.userData.abortController = controller;
+
+            const requestOptions = {
+                method: context.postData ? "POST" : "GET",
+                headers: context.ajaxHeaders || {},
+                body: context.postData,
+                signal: controller.signal,
+                expect: "auto" // Let your client handle smart parsing
+            };
+
+            // Use your client's .request() method
+            client.request(context.src, requestOptions)
+                // todo async not supported yet, need to replace with $.Promise
+                .then(async (data) => {
+                    // If the data isn't a Blob/Image yet (e.g. raw string/JSON),
+                    // we ensure it's in a format OSD TileCache can handle.
+                    if (data instanceof Response) {
+                        data = await data.blob();
                     }
-                    // If the blob is empty for some reason consider the image load a failure.
-                    if (blb.size === 0) {
-                        context.fail("[downloadTileStart] Empty image response.", request);
-                    } else {
-                        context.finish(blb, request, "rasterBlob");
+
+                    if (!data || (data instanceof Blob && data.size === 0)) {
+                        context.fail("Empty tile data received.");
+                        return;
                     }
-                },
-                error: function(request) {
-                    context.fail("[downloadTileStart] Image load aborted - XHR error", request);
-                }
-            });
+
+                    // 'rasterBlob' tells OSD to treat the result as binary image data
+                    context.finish(data, "rasterBlob");
+                })
+                .catch((err) => {
+                    // Handle your custom HTTPError class
+                    const status = err.statusCode || "Unknown";
+                    context.fail(`HttpClient Error [${status}]: ${err.message}`);
+                });
         } else {
             // While we could just do this one-liner, we found out that downloading the data _before_ a cache is initialized
             // works better in general cases. Network access is the most error-prone part, and this scenario better supports
             // all default use-cases, including the fact that retry logic works only at this stage, not on the cache level.
-            //  context.finish(context.src, null, "__private__imageUrl");
+            //  context.finish(context.src, "__private__imageUrl");
 
             const image = new Image();
             context.userData.imageRequest = image;
             image.onload = function () {
                 image.onload = image.onerror = image.onabort = null;
-                context.finish(image, null, "image");
+                context.finish(image, "image");
             };
             image.onabort = image.onerror = function() {
                 image.onload = image.onerror = image.onabort = null;
-                context.fail("[downloadTileStart] Image load aborted or errored out.", null);
+                context.fail("[downloadTileStart] Image load aborted or errored out.");
             };
             if (typeof context.crossOriginPolicy === "string") {
                 image.crossOrigin = context.crossOriginPolicy;
@@ -891,8 +801,8 @@ $.TileSource.prototype = {
      * @param {*} [context.userData] - Empty object to attach (and mainly read) your own data.
      */
     downloadTileAbort: function (context) {
-        if (context.userData.request) {
-            context.userData.request.abort();
+        if (context.userData.abortController) {
+            context.userData.abortController.abort();
         }
         if (context.userData.imageRequest) {
             const image = context.userData.imageRequest;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -302,6 +302,11 @@ $.Viewer = function( options ) {
         this.tileSources = [ this.xmlPath ];
     }
 
+    if (!this.httpClient) {
+        //todo pass it args like the headers etc
+        this.httpClient = new $.DefaultHttpClient();
+    }
+
     this.element              = this.element || document.getElementById( this.id );
     this.canvas               = $.makeNeutralElement( "div" );
     this.canvas.className = "openseadragon-canvas";
@@ -1784,7 +1789,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * @property {String} [options.compositeOperation] How the image is composited onto other images.
      * @property {String} [options.crossOriginPolicy] The crossOriginPolicy for this specific image,
      * overriding viewer.crossOriginPolicy.
-     * @property {Boolean} [options.ajaxWithCredentials] Whether to set withCredentials on tile AJAX
+     * @property {Boolean} [options.ajaxWithCredentials] deprecated
      * @property {Boolean} [options.loadTilesWithAjax]
      *      Whether to load tile data using AJAX requests.
      *      Defaults to the setting in {@link OpenSeadragon.Options}.


### PR DESCRIPTION
This is just a design idea, not a functional code. 

### The problem:
 - whole 'auth idea' based on options object
	 - we have `ajax*`, old names
	 - we have `ajaxWithCredentials` x `crossOriginPolicy` peroperty mismatch, we need just one option
	 - passing options object is not flexible, auth tokens tend to change, how do you update token after it expired? refresh the viewer? each 5 minutes in some cases?
	 - what about different use-cases - different auth technology, which needs custom approach?

### The solution
 - support a http client, api that you can configure and do YOUR way of fetching the resource
 - by default, redirect old options to the default client, which uses them
 - no longer pass this info to image job api, client takes care of everything

### Problems with current design proposal
 - `downloadTileStart` is meant to generically override the whole download/fetch process, how do we ensure people use the auth client when re-implementing downloadTileStart?
 - http-client flexibility doubles the `downloadTileStart` flexbility, we suddenly have two places where users can override how data is downloaded (http client controls also other parts like initial info fetching)
 - what about `jsonp`? deprecate? I don't know any usecases
 
 Related: https://github.com/openseadragon/openseadragon/issues/2870