### PR TITLE
Fix TypeScript type definition for module augmentation

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -248,7 +248,7 @@ declare namespace OpenSeadragon {
 
     type DrawerType = "auto" | "html" | "canvas" | "webgl";
     type DrawerConstructor = new(options: TDrawerOptions) => DrawerBase;
-    type TypeConverter<TIn = any, TOut = any> = (tile: OpenSeadragon.Tile, data: TIn) => TOut | Promise<TOut>;
+    type TypeConverter<TIn = any, TOut = any> = (tile: Tile, data: TIn) => TOut | Promise<TOut>;
     type TypeDestructor<TIn = any, TOut = any> = (data: TIn) => TOut | Promise<TOut>;
 
     interface Options {
@@ -2383,4 +2383,4 @@ export as namespace OpenSeadragon;
 
 declare function OpenSeadragon(options: OpenSeadragon.Options): OpenSeadragon.Viewer;
 
-export default OpenSeadragon;
+export = OpenSeadragon;


### PR DESCRIPTION
Fixes #2881

### Changes

**types/index.d.ts:**
- Changed `export default OpenSeadragon` to `export = OpenSeadragon` for proper CommonJS/UMD compatibility
- Fixed `TypeConverter` type to use `Tile` instead of `OpenSeadragon.Tile` for consistency

### Problem
The previous `export default` syntax caused issues when trying to import OpenSeadragon in TypeScript projects, particularly with module augmentation.

When using `export default`, TypeScript treats the module as an ES module, which breaks:
1. **Module augmentation** - `declare module 'openseadragon'` augmentation doesn't work properly with default exports
2. **Type consistency** - The library uses UMD pattern (`module.exports = $`) but TypeScript types declared it as ES module, causing type/runtime mismatch

### Solution
Using `export =` syntax provides proper TypeScript support for UMD modules, allowing both:
```typescript
// ES module import
import OpenSeadragon from 'openseadragon';

// CommonJS require
const OpenSeadragon = require('openseadragon');
```

**Module augmentation now works:**
```typescript
//osd-augmentation.d.ts
import "openseadragon";
declare module "openseadragon" {
    interface Viewer {
        svgOverlay(): SvgOverlay;
    }
    interface SvgOverlay {
        resize(): void;
    }
}

//plugin.ts
OpenSeadragon.Viewer.prototype.svgOverlay = function () {
    console.log("Plugin method executed");
    return {
        resize: () => {
            console.log("hello from plugin");
        }
    };
};

//viewer.ts
const viewer: OpenSeadragon.Viewer = OpenSeadragon({
    id: "viewer",
    prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
    tileSources: "https://openseadragon.github.io/example-images/highsmith/highsmith.dzi",
    drawer: "canvas"
});

const plugin = viewer.svgOverlay();
plugin.resize();
```
