### PR TITLE
Fix missing image in navigator when using WebGL drawer with cross-origin tiles; add navigatorDrawer option

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -514,6 +514,14 @@
   * @property {String} [navigatorDisplayRegionColor='#900']
   *     Specifies the border color of the display region rectangle of the navigator minimap
   *
+  * @property {String|Array} [navigatorDrawer=null]
+  *     Specifies the drawer type to use for the navigator minimap, overriding the
+  *     parent viewer's drawer. Accepts the same values as the {@link OpenSeadragon.Options#drawer}
+  *     option (e.g. 'canvas', 'webgl', 'html'). When null (the default), the navigator
+  *     inherits the parent viewer's full drawer configuration, including any fallback candidates
+  *     (e.g. if the viewer uses ['webgl', 'canvas'], the navigator will also fall back from
+  *     WebGL to canvas on failure).
+  *
   * @property {Number} [controlsFadeDelay=2000]
   *     The number of milliseconds to wait once the user has stopped interacting
   *     with the interface before beginning to fade the controls. Assumes
@@ -711,6 +719,13 @@
   * @property {String|Boolean} [crossOriginPolicy=false]
   *     Valid values are 'Anonymous', 'use-credentials', and false. If false, canvas requests will
   *     not use CORS, and the canvas will be tainted.
+  *     <br><br>
+  *     When using the WebGL drawer (the default) with cross-origin tile sources, this option must
+  *     be set to 'Anonymous' (or 'use-credentials') and the tile server must respond with
+  *     appropriate CORS headers (e.g. Access-Control-Allow-Origin: *). Without this, WebGL cannot
+  *     upload tile images as textures due to browser security restrictions, and the drawer will
+  *     fall back to canvas rendering. This applies equally to the navigator minimap — see also
+  *     navigatorDrawer if you want to use canvas for the navigator explicitly.
   *
   * @property {Boolean} [ajaxWithCredentials=false]
   *     Whether to set the withCredentials XHR flag for AJAX requests.
@@ -1403,6 +1418,7 @@ function OpenSeadragon( options ){
             navigatorOpacity:           0.8,
             navigatorBorderColor:       '#555',
             navigatorDisplayRegionColor: '#900',
+            navigatorDrawer:            null,
 
             // INITIAL ROTATION
             degrees:                    0,

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -514,7 +514,7 @@
   * @property {String} [navigatorDisplayRegionColor='#900']
   *     Specifies the border color of the display region rectangle of the navigator minimap
   *
-  * @property {String|Array} [navigatorDrawer=null]
+  * @property {String|DrawerImplementation|Array|null} [navigatorDrawer=null]
   *     Specifies the drawer type to use for the navigator minimap, overriding the
   *     parent viewer's drawer. Accepts the same values as the {@link OpenSeadragon.Options#drawer}
   *     option (e.g. 'canvas', 'webgl', 'html'). When null (the default), the navigator
@@ -723,9 +723,11 @@
   *     When using the WebGL drawer (the default) with cross-origin tile sources, this option must
   *     be set to 'Anonymous' (or 'use-credentials') and the tile server must respond with
   *     appropriate CORS headers (e.g. Access-Control-Allow-Origin: *). Without this, WebGL cannot
-  *     upload tile images as textures due to browser security restrictions, and the drawer will
-  *     fall back to canvas rendering. This applies equally to the navigator minimap — see also
-  *     navigatorDrawer if you want to use canvas for the navigator explicitly.
+  *     upload tile images as textures due to browser security restrictions. The viewer can only
+  *     fall back to canvas rendering if 'canvas' is included in the configured drawer candidates
+  *     (see {@link OpenSeadragon.Options#drawer} and {@link OpenSeadragon.Options#navigatorDrawer}).
+  *     This applies equally to the navigator minimap — see also navigatorDrawer if you want to
+  *     use canvas for the navigator explicitly.
   *
   * @property {Boolean} [ajaxWithCredentials=false]
   *     Whether to set the withCredentials XHR flag for AJAX requests.

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -621,11 +621,20 @@ $.Viewer = function( options ) {
             displayRegionColor: this.navigatorDisplayRegionColor,
             crossOriginPolicy: this.crossOriginPolicy,
             animationTime:     this.animationTime,
-            drawer:            this.drawer.getType(),
+            drawer:            this.navigatorDrawer || this.drawerCandidates,
             drawerOptions:     this.drawerOptions,
             loadTilesWithAjax: this.loadTilesWithAjax,
             ajaxHeaders:       this.ajaxHeaders,
             ajaxWithCredentials: this.ajaxWithCredentials,
+        });
+
+        this.navigator.addOnceHandler('drawer-error', () => {
+            $.console.warn(
+                'OpenSeadragon: The navigator has fallen back to canvas rendering because WebGL ' +
+                'could not process the tile data. If tiles are cross-origin, set ' +
+                'crossOriginPolicy: "Anonymous" (requires CORS headers on the tile server), or ' +
+                'set navigatorDrawer: "canvas" to use canvas explicitly.'
+            );
         });
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -621,19 +621,19 @@ $.Viewer = function( options ) {
             displayRegionColor: this.navigatorDisplayRegionColor,
             crossOriginPolicy: this.crossOriginPolicy,
             animationTime:     this.animationTime,
-            drawer:            this.navigatorDrawer || this.drawerCandidates,
+            drawer:            this.navigatorDrawer || options.drawer,
             drawerOptions:     this.drawerOptions,
             loadTilesWithAjax: this.loadTilesWithAjax,
             ajaxHeaders:       this.ajaxHeaders,
             ajaxWithCredentials: this.ajaxWithCredentials,
         });
 
-        this.navigator.addOnceHandler('drawer-error', () => {
+        this.navigator.addOnceHandler('drawer-error', (event) => {
             $.console.warn(
-                'OpenSeadragon: The navigator has fallen back to canvas rendering because WebGL ' +
-                'could not process the tile data. If tiles are cross-origin, set ' +
-                'crossOriginPolicy: "Anonymous" (requires CORS headers on the tile server), or ' +
-                'set navigatorDrawer: "canvas" to use canvas explicitly.'
+                'OpenSeadragon navigator drawer error: ' + event.error +
+                ' If tiles are cross-origin, set crossOriginPolicy: "Anonymous" or ' +
+                '"use-credentials" (requires CORS headers on the tile server), or set ' +
+                'navigatorDrawer: "canvas" to use canvas explicitly.'
             );
         });
     }

--- a/test/modules/navigator.js
+++ b/test/modules/navigator.js
@@ -1132,4 +1132,45 @@
         });
     });
 
+    QUnit.test('Navigator inherits parent drawerCandidates by default', function(assert) {
+        const done = assert.async();
+        viewer = OpenSeadragon({
+            id:            'example',
+            prefixUrl:     '/build/openseadragon/images/',
+            tileSources:   '/test/data/tall.dzi',
+            springStiffness: 100,
+            showNavigator:  true,
+            drawer:        ['webgl', 'canvas']
+        });
+        viewer.addOnceHandler('open', function() {
+            assert.deepEqual(
+                viewer.navigator.drawerCandidates,
+                viewer.drawerCandidates,
+                'Navigator drawerCandidates should match parent viewer drawerCandidates when navigatorDrawer is not set.'
+            );
+            done();
+        });
+    });
+
+    QUnit.test('navigatorDrawer overrides parent drawer for navigator', function(assert) {
+        const done = assert.async();
+        viewer = OpenSeadragon({
+            id:            'example',
+            prefixUrl:     '/build/openseadragon/images/',
+            tileSources:   '/test/data/tall.dzi',
+            springStiffness: 100,
+            showNavigator:  true,
+            drawer:        'webgl',
+            navigatorDrawer: 'canvas'
+        });
+        viewer.addOnceHandler('open', function() {
+            assert.equal(
+                viewer.navigator.drawer.getType(),
+                'canvas',
+                'Navigator should use the drawer type specified by navigatorDrawer.'
+            );
+            done();
+        });
+    });
+
 })();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -420,6 +420,7 @@ declare namespace OpenSeadragon {
         navigatorOpacity?: number;
         navigatorBorderColor?: string;
         navigatorDisplayRegionColor?: string;
+        navigatorDrawer?: string | string[];
         controlsFadeDelay?: number;
         controlsFadeLength?: number;
         maxImageCacheCount?: number;


### PR DESCRIPTION
### Problem

When `showNavigator: true` and the viewer uses a WebGL drawer (the default), the navigator minimap renders as gray, without image, if tile sources are cross-origin and `crossOriginPolicy` is not set.

Root cause: The Navigator was created with `drawer: this.drawer.getType()`, which returns the string `'webgl'`. This discards the parent viewer's full drawer candidate list (e.g. `['webgl', 'canvas', 'html']`), leaving the navigator with `drawerCandidates = ['webgl']` and no canvas fallback. When WebGL fails to upload cross-origin tiles as textures (a browser security restriction), the main viewer silently recovers by compositing through a backup canvas drawer — but the navigator, lacking canvas in its candidates, hads no recovery path and stays gray.

The main viewer reports `drawer.getType() === 'webgl'` throughout because the fallback operates internally per-TiledImage, not at the viewer/drawer level.

### Changes

**src/viewer.js**
- Pass `this.drawerCandidates` to the Navigator instead of this.drawer.getType(), so the navigator inherits the parent viewer's full drawer configuration including fallback candidates. This makes the navigator's failure behavior consistent with the main viewer.
- Add a `addOnceHandler('drawer-error', ...)` on the navigator that emits an actionable console.warn if WebGL falls back, pointing to crossOriginPolicy and navigatorDrawer as solutions.

**src/openseadragon.js / types/index.d.ts**
- Add navigatorDrawer option (null by default) allowing explicit override of the navigator's drawer, independent of the parent viewer. Useful when the tile server does not support CORS and you want the navigator to use canvas unconditionally while the main viewer uses WebGL.
- Expand `crossOriginPolicy` JSDoc to explain its importance for WebGL and the navigator.

### Workarounds available to users

**Option 1:** Fix WebGL for both viewer and navigator (requires CORS headers on tile server)
`OpenSeadragon({ tileSources: '...', showNavigator: true, crossOriginPolicy: 'Anonymous' })`

**Option 2:** Use canvas only for the navigator, WebGL for main viewer (no CORS required)
`OpenSeadragon({ tileSources: '...', showNavigator: true, navigatorDrawer: 'canvas' })`

### Tests

Two new tests in **test/modules/navigator.js**:
- Navigator inherits parent drawerCandidates by default
- navigatorDrawer option overrides the navigator's drawer independently