### PR TITLE
Viewport update docs on resize(), Improve resize() logic,

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,2 @@
 defaults
+not op_mini all

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,1 @@
 defaults
-not op_mini all

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -403,11 +403,16 @@ $.Viewer = function( options ) {
 
     THIS[ this.hash ].prevContainerSize = _getSafeElemSize( this.container );
 
-    this._resizeObserver = new ResizeObserver(function(){
-        THIS[_this.hash].needsResize = true;
-    });
+    if (window.ResizeObserver) {
+        this._autoResizePolling = false;
+        this._resizeObserver = new ResizeObserver(function() {
+            THIS[_this.hash].needsResize = true;
+        });
 
-    this._resizeObserver.observe(this.container, {});
+        this._resizeObserver.observe(this.container, {});
+    } else {
+        this._autoResizePolling = true;
+    }
 
     // Create the world
     this.world = new $.World({
@@ -4225,9 +4230,19 @@ function updateOnce( viewer ) {
     }
 
     let viewerWasResized = false;
-    if (THIS[viewer.hash].needsResize && (viewer.autoResize || THIS[viewer.hash].forceResize)) {
-        doViewerResize(viewer);
-        viewerWasResized = true;
+    if (viewer.autoResize || THIS[viewer.hash].forceResize) {
+        let containerSize = undefined;
+        if (viewer._autoResizePolling) {
+            containerSize = _getSafeElemSize(viewer.container);
+            const prevContainerSize = THIS[viewer.hash].prevContainerSize;
+            if (!containerSize.equals(prevContainerSize)) {
+                THIS[viewer.hash].needsResize = true;
+            }
+        }
+        if (THIS[viewer.hash].needsResize) {
+            doViewerResize(viewer, containerSize);
+            viewerWasResized = true;
+        }
     }
 
     const viewportChange = viewer.viewport.update() || viewerWasResized;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -395,8 +395,7 @@ $.Viewer = function( options ) {
         leaveHandler:          $.delegate( this, onContainerLeave )
     });
 
-    if( this.toolbar ){
-        this.toolbar = new $.ControlDock({ element: this.toolbar });
+    if ( this.toolbar ){
         this.toolbar = new $.ControlDock({ element: this.toolbar });
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -397,22 +397,18 @@ $.Viewer = function( options ) {
 
     if( this.toolbar ){
         this.toolbar = new $.ControlDock({ element: this.toolbar });
+        this.toolbar = new $.ControlDock({ element: this.toolbar });
     }
 
     this.bindStandardControls();
 
     THIS[ this.hash ].prevContainerSize = _getSafeElemSize( this.container );
 
-    if(window.ResizeObserver){
-        this._autoResizePolling = false;
-        this._resizeObserver = new ResizeObserver(function(){
-            THIS[_this.hash].needsResize = true;
-        });
+    this._resizeObserver = new ResizeObserver(function(){
+        THIS[_this.hash].needsResize = true;
+    });
 
-        this._resizeObserver.observe(this.container, {});
-    } else {
-        this._autoResizePolling = true;
-    }
+    this._resizeObserver.observe(this.container, {});
 
     // Create the world
     this.world = new $.World({
@@ -4137,7 +4133,7 @@ function updateMulti( viewer ) {
     }
 }
 
-function doViewerResize(viewer, containerSize){
+function doViewerResize(viewer, containerSize = undefined){
     const viewport = viewer.viewport;
     const zoom = viewport.getZoom();
     const center = viewport.getCenter();
@@ -4230,23 +4226,10 @@ function updateOnce( viewer ) {
     }
 
     let viewerWasResized = false;
-    if (viewer.autoResize || THIS[viewer.hash].forceResize){
-        let containerSize;
-        if(viewer._autoResizePolling){
-            containerSize = _getSafeElemSize(viewer.container);
-            const prevContainerSize = THIS[viewer.hash].prevContainerSize;
-            if (!containerSize.equals(prevContainerSize)) {
-                THIS[viewer.hash].needsResize = true;
-            }
-        }
-        if(THIS[viewer.hash].needsResize){
-            doViewerResize(viewer, containerSize || _getSafeElemSize(viewer.container));
-            viewerWasResized = true;
-        }
-
+    if (THIS[viewer.hash].needsResize && (viewer.autoResize || THIS[viewer.hash].forceResize)) {
+        doViewerResize(viewer);
+        viewerWasResized = true;
     }
-
-
 
     const viewportChange = viewer.viewport.update() || viewerWasResized;
     let animated = viewer.world.update(viewportChange) || viewportChange;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4137,7 +4137,7 @@ function updateMulti( viewer ) {
     }
 }
 
-function doViewerResize(viewer, containerSize = undefined){
+function doViewerResize(viewer, containerSize) {
     const viewport = viewer.viewport;
     const zoom = viewport.getZoom();
     const center = viewport.getCenter();
@@ -4240,7 +4240,7 @@ function updateOnce( viewer ) {
             }
         }
         if (THIS[viewer.hash].needsResize) {
-            doViewerResize(viewer, containerSize);
+            doViewerResize(viewer, containerSize || _getSafeElemSize(viewer.container));
             viewerWasResized = true;
         }
     }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4231,7 +4231,7 @@ function updateOnce( viewer ) {
 
     let viewerWasResized = false;
     if (viewer.autoResize || THIS[viewer.hash].forceResize) {
-        let containerSize = undefined;
+        let containerSize;
         if (viewer._autoResizePolling) {
             containerSize = _getSafeElemSize(viewer.container);
             const prevContainerSize = THIS[viewer.hash].prevContainerSize;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1056,12 +1056,12 @@ $.Viewport.prototype = {
      */
     resize: function( newContainerSize = undefined, maintain = false ) {
         if (!newContainerSize) {
-            if (this.viewer) {
-               const el = $.getElement(this.viewer.container);
-                newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1);
-            } else {
+            if (!this.viewer) {
                 $.console.warn('[Viewport::resize] needs newContainerSize argument when the viewport.viewer reference is not defined!');
+                return;
             }
+            const el = $.getElement(this.viewer.container);
+            newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1);
         }
         const oldBounds = this.getBoundsNoRotate(false);
         const newBounds = oldBounds;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1058,7 +1058,7 @@ $.Viewport.prototype = {
         if (!newContainerSize) {
             if (this.viewer) {
                const el = $.getElement(this.viewer.container);
-                newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1); 
+                newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1);
             } else {
                 $.console.warn('[Viewport::resize] needs newContainerSize argument when the viewport.viewer reference is not defined!');
             }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1058,7 +1058,7 @@ $.Viewport.prototype = {
         if (!newContainerSize) {
             if (!this.viewer) {
                 $.console.warn('[Viewport::resize] needs newContainerSize argument when the viewport.viewer reference is not defined!');
-                return;
+                return this;
             }
             const el = $.getElement(this.viewer.container);
             newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1);

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1041,8 +1041,6 @@ $.Viewport.prototype = {
      * @param {OpenSeadragon.Point} [pivot] (Optional) point in viewport coordinates
      * @param {Boolean} [immediately=false] Whether to animate to the new angle
      * around which the rotation should be performed. Defaults to the center of the viewport.
-     * * @param {Boolean} [immediately=false] Whether to animate to the new angle
-     * or rotate immediately.
      * @returns {OpenSeadragon.Viewport} Chainable.
      */
     rotateBy: function(degrees, pivot, immediately){
@@ -1058,8 +1056,12 @@ $.Viewport.prototype = {
      */
     resize: function( newContainerSize = undefined, maintain = false ) {
         if (!newContainerSize) {
-            const el = $.getElement(this.viewer.container);
-            newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1);
+            if (this.viewer) {
+               const el = $.getElement(this.viewer.container);
+                newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1); 
+            } else {
+                $.console.warn('[Viewport::resize] needs newContainerSize argument when the viewport.viewer reference is not defined!');
+            }
         }
         const oldBounds = this.getBoundsNoRotate(false);
         const newBounds = oldBounds;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1051,8 +1051,8 @@ $.Viewport.prototype = {
 
     /**
      * @function
-     * @param {OpenSeadragon.Point} [newContainerSize=undefined] - current size if not defined
-     * @param {boolean} [maintain=false] - if true, bounds are adjusted to maintain the current zoom level
+     * @param {OpenSeadragon.Point} [newContainerSize] - current size if not defined
+     * @param {Boolean} [maintain=false] - if true, bounds are adjusted to maintain the current zoom level
      * @returns {OpenSeadragon.Viewport} Chainable.
      * @fires OpenSeadragon.Viewer.event:resize
      */

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1039,6 +1039,7 @@ $.Viewport.prototype = {
      * @function
      * @param {Number} degrees The degrees by which to rotate the viewport.
      * @param {OpenSeadragon.Point} [pivot] (Optional) point in viewport coordinates
+     * @param {Boolean} [immediately=false] Whether to animate to the new angle
      * around which the rotation should be performed. Defaults to the center of the viewport.
      * * @param {Boolean} [immediately=false] Whether to animate to the new angle
      * or rotate immediately.
@@ -1050,12 +1051,16 @@ $.Viewport.prototype = {
 
     /**
      * @function
-     * @param {OpenSeadragon.Point} newContainerSize
-     * @param {boolean} maintain - if true, bounds are adjusted to maintain the current zoom level
+     * @param {OpenSeadragon.Point} [newContainerSize=undefined] - current size if not defined
+     * @param {boolean} [maintain=false] - if true, bounds are adjusted to maintain the current zoom level
      * @returns {OpenSeadragon.Viewport} Chainable.
      * @fires OpenSeadragon.Viewer.event:resize
      */
-    resize: function( newContainerSize, maintain ) {
+    resize: function( newContainerSize = undefined, maintain = false ) {
+        if (!newContainerSize) {
+            const el = $.getElement(this.viewer.container);
+            newContainerSize = new $.Point(el.clientWidth || 1, el.clientHeight || 1);
+        }
         const oldBounds = this.getBoundsNoRotate(false);
         const newBounds = oldBounds;
         let widthDeltaFactor;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1050,11 +1050,13 @@ $.Viewport.prototype = {
 
     /**
      * @function
+     * @param {OpenSeadragon.Point} newContainerSize
+     * @param {boolean} maintain - if true, bounds are adjusted to maintain the current zoom level
      * @returns {OpenSeadragon.Viewport} Chainable.
      * @fires OpenSeadragon.Viewer.event:resize
      */
     resize: function( newContainerSize, maintain ) {
-        const oldBounds = this.getBoundsNoRotate();
+        const oldBounds = this.getBoundsNoRotate(false);
         const newBounds = oldBounds;
         let widthDeltaFactor;
         this._sizeChanged = !this.containerSize.equals(newContainerSize);


### PR DESCRIPTION
Small patch, I had bugs in my code because docs said it takes no args. IMHO a sensible default would be the parent container so people can call `resize()` to trigger update.