### PR TITLE
DrawerBase isSupported options

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -87,9 +87,10 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
     }
 
     /**
+     * @param {Object} options - Options for this drawer.
      * @returns {Boolean} true if canvas is supported by the browser, otherwise false
      */
-    static isSupported(){
+    static isSupported(options){
         return $.supportsCanvas;
     }
 

--- a/src/drawerbase.js
+++ b/src/drawerbase.js
@@ -215,11 +215,12 @@ OpenSeadragon.DrawerBase = class DrawerBase {
 
     /**
      * @abstract
-     * @param {Object} options For details please see {@link OpenSeadragon.DrawerOptions}.
+     * @param {OpenSeadragon.BaseDrawerOptions} [options] Options, if available.
+     *   For details please see {@link OpenSeadragon.DrawerOptions}.
      * @returns {Boolean} Whether the drawer implementation is supported by the browser.
      *  Must be overridden by extending classes.
      */
-    static isSupported(options) {
+    static isSupported(options = undefined) {
         $.console.error('Drawer.isSupported must be implemented by child class');
         return false;
     }

--- a/src/drawerbase.js
+++ b/src/drawerbase.js
@@ -215,9 +215,11 @@ OpenSeadragon.DrawerBase = class DrawerBase {
 
     /**
      * @abstract
-     * @returns {Boolean} Whether the drawer implementation is supported by the browser. Must be overridden by extending classes.
+     * @param {Object} options For details please see {@link OpenSeadragon.DrawerOptions}.
+     * @returns {Boolean} Whether the drawer implementation is supported by the browser.
+     *  Must be overridden by extending classes.
      */
-    static isSupported() {
+    static isSupported(options) {
         $.console.error('Drawer.isSupported must be implemented by child class');
     }
 

--- a/src/drawerbase.js
+++ b/src/drawerbase.js
@@ -221,6 +221,7 @@ OpenSeadragon.DrawerBase = class DrawerBase {
      */
     static isSupported(options) {
         $.console.error('Drawer.isSupported must be implemented by child class');
+        return false;
     }
 
     /**

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -118,9 +118,10 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
     }
 
     /**
+     * @param {Object} options - Options for this drawer.
      * @returns {Boolean} always true
      */
-    static isSupported() {
+    static isSupported(options) {
         return true;
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1156,7 +1156,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         let supported = false;
         if (Drawer) {
             try {
-                supported = Drawer.isSupported();
+                supported = Drawer.isSupported(drawerOptions || this.drawerOptions[drawerCandidate]);
             } catch (e) {
                 $.console.warn('Error in %s isSupported(); treating this drawer as unsupported:', drawerCandidate, e && e.message ? e.message : e);
             }
@@ -1164,7 +1164,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
         if (supported) {
             // if the drawer is supported, create it and return it.
             // first destroy the previous drawer
-            if(oldDrawer && mainDrawer){
+            if (oldDrawer && mainDrawer){
                 oldDrawer.destroy();
             }
 

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -742,9 +742,10 @@
          * Functional test: true if WebGL is supported and the real first-pass shader pipeline
          * can render (same shaders/context path used at runtime). Uses a temp context and
          * WebglContextManager, draws known non-black pixels to an FBO, then readPixels.
+         * @param {Object} options - Options for this drawer.
          * @returns {Boolean} true if WebGL is supported and the pipeline renders successfully
          */
-        static isSupported(){
+        static isSupported(options){
             let contextManager = null;
             let testTexture = null;
             let gl = null;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -269,7 +269,7 @@ declare namespace OpenSeadragon {
     }
 
     type DrawerType = "auto" | "html" | "canvas" | "webgl";
-    type DrawerConstructor = new (options: TDrawerConstructorParameters) => DrawerBase;
+    type DrawerConstructor = new (options: DrawerConstructorParameters) => DrawerBase;
     type TypeConverter<TIn = any, TOut = any> = (
         tile: Tile,
         data: TIn,
@@ -752,7 +752,7 @@ declare namespace OpenSeadragon {
         viewportToDrawerRectangle(rectangle: Rect): Rect;
     }
 
-    interface TDrawerConstructorParameters {
+    interface DrawerConstructorParameters {
         viewer: Viewer;
         viewport: Viewport;
         element: HTMLElement;
@@ -763,7 +763,7 @@ declare namespace OpenSeadragon {
     class CanvasDrawer extends DrawerBase {
         container: HTMLElement;
 
-        constructor(options: TDrawerConstructorParameters);
+        constructor(options: DrawerConstructorParameters);
 
         get canvas(): HTMLCanvasElement;
         blendSketch(options: {
@@ -844,7 +844,7 @@ declare namespace OpenSeadragon {
 
     class HTMLDrawer extends DrawerBase {
         container: HTMLElement;
-        constructor(options: TDrawerConstructorParameters);
+        constructor(options: DrawerConstructorParameters);
         get canvas(): HTMLCanvasElement;
     }
 
@@ -2025,7 +2025,7 @@ declare namespace OpenSeadragon {
         container: HTMLElement;
         context: CanvasRenderingContext2D;
 
-        constructor(options: TDrawerConstructorParameters);
+        constructor(options: DrawerConstructorParameters);
 
         draw(tiledImages: any[]): void;
         setContextRecoveryEnabled(enabled: boolean): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -269,7 +269,7 @@ declare namespace OpenSeadragon {
     }
 
     type DrawerType = "auto" | "html" | "canvas" | "webgl";
-    type DrawerConstructor = new (options: TDrawerOptions) => DrawerBase;
+    type DrawerConstructor = new (options: TDrawerConstructorParameters) => DrawerBase;
     type TypeConverter<TIn = any, TOut = any> = (
         tile: Tile,
         data: TIn,
@@ -752,17 +752,18 @@ declare namespace OpenSeadragon {
         viewportToDrawerRectangle(rectangle: Rect): Rect;
     }
 
-    interface TDrawerOptions {
+    interface TDrawerConstructorParameters {
         viewer: Viewer;
         viewport: Viewport;
         element: HTMLElement;
         debugGridColor?: string | string[];
+        options: BaseDrawerOptions;
     }
 
     class CanvasDrawer extends DrawerBase {
         container: HTMLElement;
 
-        constructor(options: TDrawerOptions);
+        constructor(options: TDrawerConstructorParameters);
 
         get canvas(): HTMLCanvasElement;
         blendSketch(options: {
@@ -843,7 +844,7 @@ declare namespace OpenSeadragon {
 
     class HTMLDrawer extends DrawerBase {
         container: HTMLElement;
-        constructor(options: TDrawerOptions);
+        constructor(options: TDrawerConstructorParameters);
         get canvas(): HTMLCanvasElement;
     }
 
@@ -2024,7 +2025,7 @@ declare namespace OpenSeadragon {
         container: HTMLElement;
         context: CanvasRenderingContext2D;
 
-        constructor(options: TDrawerOptions);
+        constructor(options: TDrawerConstructorParameters);
 
         draw(tiledImages: any[]): void;
         setContextRecoveryEnabled(enabled: boolean): void;


### PR DESCRIPTION
Drawer might need the options passed to it to know if it is able to render. Flex-renderer was originally supporting both versions of webgl versions and the preferrence was passed to the options. We might not need it RN, but I still view this missing argument as a gap in the API that deserves fixing.