### PR TITLE
Bugfix for 2904

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -378,7 +378,7 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
             }
             usedClip = true;
         }
-        tiledImage._hasOpaqueTile = false;
+
         if ( tiledImage.placeholderFillStyle && tiledImage._hasOpaqueTile === false ) {
             let placeholderRect = this.viewportToDrawerRectangle(tiledImage.getBoundsNoRotate(true));
             if (sketchScale) {


### PR DESCRIPTION
I think the bug in #2904 likely comes from this line:

https://github.com/openseadragon/openseadragon/blob/7e9335b3648f5566b1f55d2be43a8529868c9fb7/src/canvasdrawer.js#L381

Which looks like it was added while fixing an issue with placeholders but appears to be a leftover debugging artifact.

@bdrichards could you try building this branch and seeing if it fixes your issue?