### PR TITLE
chore: fix jsdoc bugs

### DIFF
--- a/src/datatypeconverter.js
+++ b/src/datatypeconverter.js
@@ -470,7 +470,6 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
      * Note: although we try to implement the type guessing, do
      * not rely on this functionality! Prefer explicit type declaration.
      *
-     * @function guessType
      * @param x object to get unique identifier for
      *  - can be array, in that case, alphabetically-ordered list of inner unique types
      *    is returned (null, undefined are ignored)

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -74,7 +74,7 @@
     }
   };
 
-  $.extend($.IrisTileSource.prototype, $.TileSource.prototype, {
+  $.extend($.IrisTileSource.prototype, $.TileSource.prototype, /** @lends OpenSeadragon.IrisTileSource.prototype */{
     /**
      * Return URL string for image metadata
      * @function

--- a/src/priorityqueue.js
+++ b/src/priorityqueue.js
@@ -15,13 +15,11 @@ const OpenSeadragon = $; // alias for JSDoc
 /**
  * @class OpenSeadragon.PriorityQueue
  * @classdesc Fast priority queue. Implemented as a Heap.
+ * @param {?OpenSeadragon.PriorityQueue} optHeap Optional Heap or
+ *     Object to initialize heap with.
  */
 OpenSeadragon.PriorityQueue = class PriorityQueue {
 
-    /**
-     * @param {?OpenSeadragon.PriorityQueue} optHeap Optional Heap or
-     *     Object to initialize heap with.
-     */
     constructor(optHeap = undefined) {
         /**
          * The nodes of the heap.

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3301,10 +3301,10 @@ function getActiveActionFromKey(code, shift) {
 /**
  * Handles the keyup event on the viewer's canvas element.
  *
- * @private
  * For the released key, marks both the shifted and non-shifted navigation actions as inactive in the _activeActions object.
  * If either action is released before reaching the minimum frame threshold, sets that action as "virtually held" in _navActionVirtuallyHeld,
  * ensuring smooth completion of the minimum pan or zoom distance regardless of modifier key release order.
+ * @private
  */
 function onCanvasKeyUp(event) {
 


### PR DESCRIPTION
This should fix the API docs page.

<img width="293" height="360" alt="image" src="https://github.com/user-attachments/assets/5d581a1d-a1ce-47c0-a6a8-d780f0edd3dc" />

https://github.com/openseadragon/openseadragon/issues/2879