### PR TITLE
Add tileQuality option to IIIFTileSource

### DIFF
--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -45,11 +45,12 @@
  * @param {String} [options.tileFormat='jpg']
  *      The extension that will be used when requiring tiles.
  * @param {String} [options.tileQuality]
- *      The IIIF quality to request for each tile. Must be a value the server
- *      lists as supported. The Image API spec defines 'native', 'color',
- *      'grey' and 'bitonal' for version 1.x, and 'default', 'color', 'gray'
- *      and 'bitonal' for versions 2.x and 3.x. Servers may also advertise
- *      additional qualities via the info.json profile or extraQualities.
+ *      The IIIF quality to request for each tile. The Image API spec defines
+ *      'native', 'color', 'grey' and 'bitonal' for version 1.x, and 'default',
+ *      'color', 'gray' and 'bitonal' for versions 2.x and 3.x. Servers may
+ *      advertise additional qualities via the info.json profile (v2) or
+ *      extraQualities (v3); these are accepted without warning. Unknown
+ *      values produce a console warning but are still sent to the server.
  *      Defaults to 'native' for 1.x and 'default' for 2.x and 3.x.
  *      @see https://iiif.io/api/image/3.0/#quality
  */
@@ -71,6 +72,10 @@ $.IIIFTileSource = function( options ){
     this.tileFormat = this.tileFormat || 'jpg';
 
     this.version = options.version;
+
+    if ( this.tileQuality ) {
+        warnIfUnknownQuality( this.tileQuality, this.version, options );
+    }
 
     this.isLevel0 = checkLevel0( options );
 
@@ -620,6 +625,52 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         });
     }
 
+
+    /**
+     * Collect IIIF qualities the server may accept for a given info.json.
+     * Combines the spec-defined set for the API version with any qualities
+     * advertised by the server (profile.qualities for v2, extraQualities for v3).
+     * @function
+     * @param {Number} version
+     * @param {Object} options - the info.json data
+     * @returns {String[]}
+     */
+    function getKnownQualities ( version, options ) {
+        const specQualities = version === 1 ?
+            [ 'native', 'color', 'grey', 'bitonal' ] :
+            [ 'default', 'color', 'gray', 'bitonal' ];
+        const advertised = [];
+        if ( version === 2 && Array.isArray(options.profile) ) {
+            for ( let i = 1; i < options.profile.length; i++ ) {
+                const entry = options.profile[i];
+                if ( entry && Array.isArray(entry.qualities) ) {
+                    advertised.push.apply(advertised, entry.qualities);
+                }
+            }
+        }
+        if ( version === 3 && Array.isArray(options.extraQualities) ) {
+            advertised.push.apply(advertised, options.extraQualities);
+        }
+        return specQualities.concat(advertised);
+    }
+
+    /**
+     * Emit a console warning if tileQuality is not in the set of known
+     * qualities for this server. Does not throw; the value is still used.
+     * @function
+     */
+    function warnIfUnknownQuality ( quality, version, options ) {
+        const known = getKnownQualities(version, options);
+        if ( known.indexOf(quality) === -1 ) {
+            $.console.warn(
+                "[IIIFTileSource] tileQuality '%s' is not in the set of " +
+                "qualities known for this image (%s). The request will still " +
+                "be sent; the server may reject it.",
+                quality,
+                known.join(', ')
+            );
+        }
+    }
 
     function configureFromXml10(xmlDoc) {
         //parse the xml

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -53,6 +53,14 @@
  *      values produce a console warning but are still sent to the server.
  *      Defaults to 'native' for 1.x and 'default' for 2.x and 3.x.
  *      @see https://iiif.io/api/image/3.0/#quality
+ * @param {String[]} [options.extraQualities]
+ *      Additional quality values the server supports beyond the IIIF Image
+ *      API 3.x spec defaults. Normally populated automatically from the
+ *      server's info.json `extraQualities` field, but may also be passed
+ *      explicitly. Values listed here are treated as known qualities and
+ *      will not trigger the unknown quality warning when used as
+ *      `tileQuality`.
+ *      @see https://iiif.io/api/image/3.0/#53-extra-functionality
  */
 $.IIIFTileSource = function( options ){
 

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -44,6 +44,14 @@
  * @see http://iiif.io/api/image/
  * @param {String} [options.tileFormat='jpg']
  *      The extension that will be used when requiring tiles.
+ * @param {String} [options.tileQuality]
+ *      The IIIF quality to request for each tile. Must be a value the server
+ *      lists as supported. The Image API spec defines 'native', 'color',
+ *      'grey' and 'bitonal' for version 1.x, and 'default', 'color', 'gray'
+ *      and 'bitonal' for versions 2.x and 3.x. Servers may also advertise
+ *      additional qualities via the info.json profile or extraQualities.
+ *      Defaults to 'native' for 1.x and 'default' for 2.x and 3.x.
+ *      @see https://iiif.io/api/image/3.0/#quality
  */
 $.IIIFTileSource = function( options ){
 
@@ -484,11 +492,15 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
         tileHeight = this.getTileHeight(level);
         iiifTileSizeWidth = Math.round( tileWidth / scale );
         iiifTileSizeHeight = Math.round( tileHeight / scale );
-        if (this.version === 1) {
-            iiifQuality = "native." + this.tileFormat;
+        let quality;
+        if ( this.tileQuality ) {
+            quality = this.tileQuality;
+        } else if ( this.version === 1 ) {
+            quality = "native";
         } else {
-            iiifQuality = "default." + this.tileFormat;
+            quality = "default";
         }
+        iiifQuality = quality + "." + this.tileFormat;
         if ( levelWidth < tileWidth && levelHeight < tileHeight ){
             if ( this.version === 2 && levelWidth === this.width ) {
                 iiifSize = "full";

--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -604,11 +604,13 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
      */
     function constructLevels(options) {
         const levels = [];
+        const quality = options.tileQuality ||
+            (options.version === 1 ? 'native' : 'default');
         for(let i = 0; i < options.sizes.length; i++) {
             levels.push({
                 url: options._id + '/full/' + options.sizes[i].width + ',' +
                     (options.version === 3 ? options.sizes[i].height : '') +
-                    '/0/default.' + options.tileFormat,
+                    '/0/' + quality + '.' + options.tileFormat,
                 width: options.sizes[i].width,
                 height: options.sizes[i].height
             });

--- a/test/modules/iiif.js
+++ b/test/modules/iiif.js
@@ -288,4 +288,22 @@
         assert.equal(source3DescendingSizeOrder.getTileUrl(2, 0, 0), "http://example.com/identifier/0,0,512,512/512,512/0/default.jpg");
     });
 
+    QUnit.test('IIIFTileSource.getTileUrl honours tileQuality option', function( assert ) {
+        const withQuality = function( info, quality ) {
+            return OpenSeadragon.extend({}, info, { tileQuality: quality });
+        };
+
+        const source11Grey = getSource(withQuality(infoJson11level1, "grey"));
+        assert.equal(source11Grey.getTileUrl(0, 0, 0), "http://example.com/identifier/full/8,/0/grey.jpg",
+            "Version 1 source uses supplied tileQuality instead of 'native'");
+
+        const source2Gray = getSource(withQuality(infoJson2level1, "gray"));
+        assert.equal(source2Gray.getTileUrl(0, 0, 0), "http://example.com/identifier/full/8,/0/gray.jpg",
+            "Version 2 source uses supplied tileQuality instead of 'default'");
+
+        const source3Bitonal = getSource(withQuality(infoJson3level1, "bitonal"));
+        assert.equal(source3Bitonal.getTileUrl(0, 0, 0), "http://example.com/identifier/full/8,4/0/bitonal.jpg",
+            "Version 3 source uses supplied tileQuality instead of 'default'");
+    });
+
 })();

--- a/test/modules/iiif.js
+++ b/test/modules/iiif.js
@@ -304,6 +304,14 @@
         const source3Bitonal = getSource(withQuality(infoJson3level1, "bitonal"));
         assert.equal(source3Bitonal.getTileUrl(0, 0, 0), "http://example.com/identifier/full/8,4/0/bitonal.jpg",
             "Version 3 source uses supplied tileQuality instead of 'default'");
+
+        const source2Level0Gray = getSource(withQuality(infoJson2level0, "gray"));
+        assert.equal(source2Level0Gray.getTileUrl(0, 0, 0), "http://example.com/identifier/full/1000,/0/gray.jpg",
+            "Version 2 legacy pyramid uses supplied tileQuality instead of 'default'");
+
+        const source3Level0Bitonal = getSource(withQuality(infoJson3level0, "bitonal"));
+        assert.equal(source3Level0Bitonal.getTileUrl(0, 0, 0), "http://example.com/identifier/full/1000,500/0/bitonal.jpg",
+            "Version 3 legacy pyramid uses supplied tileQuality instead of 'default'");
     });
 
 })();

--- a/test/modules/iiif.js
+++ b/test/modules/iiif.js
@@ -314,4 +314,67 @@
             "Version 3 legacy pyramid uses supplied tileQuality instead of 'default'");
     });
 
+    QUnit.test('IIIFTileSource warns on unknown tileQuality but still uses it', function( assert ) {
+        const originalWarn = OpenSeadragon.console.warn;
+        const calls = [];
+        OpenSeadragon.console.warn = function() {
+            calls.push(Array.prototype.slice.call(arguments));
+        };
+        try {
+            const data = OpenSeadragon.extend({}, infoJson3level1, { tileQuality: "sepia" });
+            const source = getSource(data);
+            assert.equal(calls.length, 1, "Unknown quality triggers exactly one warning");
+            assert.ok(calls[0][0].indexOf("[IIIFTileSource]") === 0, "Warning is namespaced");
+            assert.equal(source.getTileUrl(0, 0, 0),
+                "http://example.com/identifier/full/8,4/0/sepia.jpg",
+                "Unknown quality is still used in tile URL");
+        } finally {
+            OpenSeadragon.console.warn = originalWarn;
+        }
+    });
+
+    QUnit.test('IIIFTileSource accepts extraQualities (v3) without warning', function( assert ) {
+        const originalWarn = OpenSeadragon.console.warn;
+        const calls = [];
+        OpenSeadragon.console.warn = function() {
+            calls.push(Array.prototype.slice.call(arguments));
+        };
+        try {
+            const data = OpenSeadragon.extend({}, infoJson3level1, {
+                extraQualities: [ "sepia", "infrared" ],
+                tileQuality: "sepia"
+            });
+            const source = getSource(data);
+            assert.equal(calls.length, 0, "Quality listed in extraQualities does not warn");
+            assert.equal(source.getTileUrl(0, 0, 0),
+                "http://example.com/identifier/full/8,4/0/sepia.jpg",
+                "extraQualities value is used in tile URL");
+        } finally {
+            OpenSeadragon.console.warn = originalWarn;
+        }
+    });
+
+    QUnit.test('IIIFTileSource accepts profile.qualities (v2) without warning', function( assert ) {
+        const originalWarn = OpenSeadragon.console.warn;
+        const calls = [];
+        OpenSeadragon.console.warn = function() {
+            calls.push(Array.prototype.slice.call(arguments));
+        };
+        try {
+            const base = OpenSeadragon.extend(true, {}, infoJson2level1);
+            base.profile = [
+                "http://iiif.io/api/image/2/level1.json",
+                { qualities: [ "sepia" ] }
+            ];
+            base.tileQuality = "sepia";
+            const source = getSource(base);
+            assert.equal(calls.length, 0, "Quality listed in profile.qualities does not warn");
+            assert.equal(source.getTileUrl(0, 0, 0),
+                "http://example.com/identifier/full/8,/0/sepia.jpg",
+                "profile.qualities value is used in tile URL");
+        } finally {
+            OpenSeadragon.console.warn = originalWarn;
+        }
+    });
+
 })();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -853,6 +853,7 @@ declare namespace OpenSeadragon {
         levelSizes?: Array<{ width: number; height: number }>;
         scale_factors?: number[];
         tileFormat: string;
+        tileQuality?: string;
         tiles?: Array<{
             width: number;
             height?: number;
@@ -860,7 +861,7 @@ declare namespace OpenSeadragon {
         }>;
         version: number;
 
-        constructor(options: TileSourceOptions & { tileFormat?: string });
+        constructor(options: TileSourceOptions & { tileFormat?: string; tileQuality?: string });
     }
 
     interface IrisTileSourceOptions extends TileSourceOptions {


### PR DESCRIPTION
Picks up #1838 (up for grabs since 2021). Opening as a draft to get guidance before polishing.

## What this does

Adds an opt-in `tileQuality` option to `IIIFTileSource`. When set, it is used in the IIIF tile URL in place of the default. Defaults are unchanged:

- `native` for IIIF Image API 1.x
- `default` for 2.x and 3.x

Scoped to `IIIFTileSource` only, per @iangilman's 2020 review feedback on #1838 ("It's an IIIF-only feature, though, so it should just be in the IIIFTileSource"). Mirrors the existing `tileFormat` plumbing.

- `src/iiiftilesource.js` - option, JSDoc, applied in `getTileUrl`
- `test/modules/iiif.js` - URL composition tests for v1/v2/v3
- `types/index.d.ts` - TS definition

All 328 tests pass; lint clean.

## Open question - URL-string `tileSources`

This narrow scope only covers the **inline info.json** case (user passes the parsed info object with `tileQuality` set on it). It does not cover the more common **URL-string** case (`tileSources: "https://server/info.json"`), because at `viewer.js:2121` the temporary `TileSource` is constructed with only a fixed set of fields (`url`, `crossOriginPolicy`, `ajaxWithCredentials`, `ajaxHeaders`, `splitHashDataForPost`). Anything else on the outer `addTiledImage` options is dropped before reaching the IIIF source.

The original PR #1838 worked around this by adding `tileQuality` to the base `TileSource` and `TiledImage` - which was the part you asked to remove.

Three possible directions, happy to take whichever you prefer:

1. **Land this as-is** - narrow, IIIF-only, inline info.json only. Documents the limitation. Common URL-string users would need to pre-fetch info.json.
2. **Add `tileQuality` field to the temporary `TileSource` constructor in `viewer.js`** - minimal extra plumbing, but puts an IIIF-specific field name on the base class.
3. **Generic forwarding mechanism in `viewer.js`** - pass through arbitrary outer-options to the temporary `TileSource` so future per-source options don't need viewer-level edits. Larger design change.

Which would you like? I will tidy up and mark ready for review once direction is clear.