### PR TITLE
Overlay Rotation enable, Fix for non rotated viewport only

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -167,6 +167,7 @@
             if (this.location instanceof $.Rect) {
                 this.width = this.location.width;
                 this.height = this.location.height;
+                this.rotation = this.location.degrees * (Math.PI / 180.0);
                 this.location = this.location.getTopLeft();
                 this.placement = $.Placement.TOP_LEFT;
             }
@@ -174,7 +175,7 @@
             // Deprecated properties kept for backward compatibility.
             this.scales = this.width !== null && this.height !== null;
             this.bounds = new $.Rect(
-                this.location.x, this.location.y, this.width, this.height);
+            this.location.x, this.location.y, this.width, this.height, this.rotation * (180.0 / Math.PI));
             this.position = this.location;
         },
 
@@ -272,6 +273,8 @@
                 outerScale = viewport.flipped ? " scaleX(-1)" : " scaleX(1)";
             }
             const rotate = viewport.flipped ? -positionAndSize.rotate : positionAndSize.rotate;
+            const overlayRotationRadians = this.rotation;
+            //const overlayRotationDegrees =  overlayRotationRadians * (180.0 / Math.PI);
             const scale = viewport.flipped ? " scaleX(-1)" : "";
             // call the onDraw callback if it exists to allow one to overwrite
             // the drawing/positioning/sizing of the overlay
@@ -309,7 +312,7 @@
                     } else {
                         innerStyle[transformProp] = "";
                         style[transformOriginProp] = "";
-                        style[transformProp] = "";
+                        style[transformProp] = "rotate(" + overlayRotationRadians + "rad)";
                     }
                 }
                 style.display = 'flex';

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3103,6 +3103,7 @@ function getOverlayObject( viewer, overlay ) {
     let location = overlay.location;
     let width = overlay.width;
     let height = overlay.height;
+    let overlayRotation = overlay.rotation; // in radians
     if (!location) {
         let x = overlay.x;
         let y = overlay.y;
@@ -3133,6 +3134,7 @@ function getOverlayObject( viewer, overlay ) {
         checkResize: overlay.checkResize,
         width: width,
         height: height,
+        rotation: overlayRotation,
         rotationMode: overlay.rotationMode
     });
 }


### PR DESCRIPTION
Enables the preservation of an ovleray's rotation with minumal OSD changes.
Only tested on non-rotated viewports. For rotated and/or flipped, there is a section of logic under `drawHTML()` that is likley where overlay proper rotation in such circumstances can be implemented.
Mostly notable, as I understand things:
1. Ensuring rotation is honored for overlays involves using `imageToViewportRectangle(newrect)` without a `degrees` value in our callback code for a specific plugin. IF you make this call with individual parameters (x,y,width, height), there is currently no way to include a rotation in the function anyway. Also, if you pass a $Rect instance with a negative degrees value, the `$Rect function()`  (in `reactangle.js`) performs  normalization logic that is probably required for most cases/apps/plugins. However, in our use case, the plugin uses the rectangle center for rotation calculations etc., so the normalization mangles things. Rather than dive deep into changes in `rectangle.js`, we just add the rotation to the returned rectangle as in the following (`tmpRot` is the rotation degrees returned by the app/plugin overlay selection process):
`var newrect = new OpenSeadragon.Rect(rect.x, rect.y, rect.width, rect.height, 0);
 var newrect2 = viewer.viewport.imageToViewportRectangle(newrect);
 newrect2.degrees = tmpRot; // add this afterwards to retain proper x,y and rotation and avoid normalization logic in rectangle.js`

2. No testing has been performed with other applications/plugins that create Overlays and add to the html of the display.