### PR TITLE
fix: setCoverage missing reset call

### DIFF
--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1774,9 +1774,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
         const numberOfTiles = this.source.getNumTiles(level);
         const viewportCenter = this.viewport.pixelFromPoint(this.viewport.getCenter());
         this._resetCoverage(this.coverage, level);
-        if (loadArea) {
-            this._resetCoverage(this.loadingCoverage, level);
-        }
+        this._resetCoverage(this.loadingCoverage, level);
 
         let tilesToDraw = null;
         let tileIndex = 0;


### PR DESCRIPTION
Fixes https://github.com/openseadragon/openseadragon/issues/2932. The idea was likely 'if loadArea not set then do not reset loadingCoverage as it does not get updated', but we update loadingCoverage for all tiles, including loaded ones. So cleaning always seems like correct approach, unless we wanted to keep the coverage populated when rendering 2+ world items in collection mode. Not sure. Also weird that this warning does not appear when stacking TIs atop each other.