### PR TITLE
Bumping up max bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,12 @@
     "bundlesize": [
         {
             "path": "build/openseadragon/openseadragon.min.js",
-            "maxSize": "90 kB",
+            "maxSize": "95 kB",
             "compression": "gzip"
         },
         {
             "path": "build/openseadragon/openseadragon.min.js",
-            "maxSize": "350 kB",
+            "maxSize": "375 kB",
             "compression": "none"
         }
     ],


### PR DESCRIPTION
I like that we're tracking the bundle size, but I think it's natural for it to grow over time. 