### PR TITLE
fix: null/undefined data handling in cache

### DIFF
--- a/src/tilecache.js
+++ b/src/tilecache.js
@@ -316,11 +316,7 @@
 
             // always destroy the outdated record so we do not leak its resources
             if (internalCache) {
-                if (internalCache.loaded) {
-                    internalCache.destroy();
-                } else {
-                    internalCache.await().then(() => internalCache.destroy());
-                }
+                this._safeDestroyInternal(internalCache);
                 delete this[DRAWER_INTERNAL_CACHE][drawerID];
             }
 
@@ -328,8 +324,8 @@
             const transformedData = drawer.internalCacheCreate(this, this._tRef);
             $.console.assert(transformedData !== undefined, "[DrawerBase.internalCacheCreate] must return a value if usePrivateCache is enabled!");
             if (transformedData === undefined || transformedData === null) {
-                // do not store a null which would later hand null to the drawer destructor
-                return $.Promise.resolve(null);
+                // do not store in the internal cache which would later hand undefined/null to the drawer destructor
+                return $.Promise.resolve(undefined);
             }
             internalCache = this[DRAWER_INTERNAL_CACHE][drawerID] = new $.InternalCacheRecord(transformedData,
                 drawerID, (data) => drawer.internalCacheFree(data));
@@ -353,9 +349,8 @@
 
             const drawerID = drawer.getId();
 
-            // Force reset
             if (internalCache) {
-                internalCache.destroy();
+                this._safeDestroyInternal(internalCache);
                 delete this[DRAWER_INTERNAL_CACHE][drawerID];
             }
 
@@ -363,8 +358,8 @@
             const transformedData = drawer.internalCacheCreate(this, this._tRef);
             $.console.assert(transformedData !== undefined, "[DrawerBase.internalCacheCreate] must return a value if usePrivateCache is enabled!");
             if (transformedData === undefined || transformedData === null) {
-                // prevent storing falsey data
-                return null;
+                // do not store in the internal cache which would later hand undefined/null to the drawer destructor
+                return undefined;
             }
 
             internalCache = this[DRAWER_INTERNAL_CACHE][drawerID] = new $.InternalCacheRecord(transformedData,
@@ -525,6 +520,8 @@
             if (!internal || !drawer || !this._tRef) {
                 if (old) {
                     this._safeDestroyInternal(old);
+                }
+                if (internal) {
                     delete internal[drawerID];
                 }
                 return;

--- a/src/tilecache.js
+++ b/src/tilecache.js
@@ -312,15 +312,25 @@
                 return internalCache.await();
             }
 
-            // Force reset
-            if (internalCache && !internalCache.loaded) {
-                internalCache.await().then(() => internalCache.destroy());
+            const drawerID = drawer.getId();
+
+            // always destroy the outdated record so we do not leak its resources
+            if (internalCache) {
+                if (internalCache.loaded) {
+                    internalCache.destroy();
+                } else {
+                    internalCache.await().then(() => internalCache.destroy());
+                }
+                delete this[DRAWER_INTERNAL_CACHE][drawerID];
             }
 
             $.console.assert(this._tRef, "Data Create called from invalidation routine needs tile reference!");
             const transformedData = drawer.internalCacheCreate(this, this._tRef);
             $.console.assert(transformedData !== undefined, "[DrawerBase.internalCacheCreate] must return a value if usePrivateCache is enabled!");
-            const drawerID = drawer.getId();
+            if (transformedData === undefined || transformedData === null) {
+                // do not store a null which would later hand null to the drawer destructor
+                return $.Promise.resolve(null);
+            }
             internalCache = this[DRAWER_INTERNAL_CACHE][drawerID] = new $.InternalCacheRecord(transformedData,
                 drawerID, (data) => drawer.internalCacheFree(data));
             return internalCache.await();
@@ -340,16 +350,22 @@
                 return internalCache;
             }
 
+            const drawerID = drawer.getId();
+
             // Force reset
             if (internalCache) {
                 internalCache.destroy();
+                delete this[DRAWER_INTERNAL_CACHE][drawerID];
             }
 
             $.console.assert(this._tRef, "Data Create called from drawing loop needs tile reference!");
             const transformedData = drawer.internalCacheCreate(this, this._tRef);
             $.console.assert(transformedData !== undefined, "[DrawerBase.internalCacheCreate] must return a value if usePrivateCache is enabled!");
+            if (transformedData === undefined || transformedData === null) {
+                // prevent storing falsey data
+                return null;
+            }
 
-            const drawerID = drawer.getId();
             internalCache = this[DRAWER_INTERNAL_CACHE][drawerID] = new $.InternalCacheRecord(transformedData,
                 drawerID, (data) => drawer.internalCacheFree(data));
             return internalCache;
@@ -445,15 +461,29 @@
                 if (drawerId) {
                     const cache = internal[drawerId];
                     if (cache) {
-                        cache.destroy();
+                        this._safeDestroyInternal(cache);
                         delete internal[drawerId];
                     }
                 } else {
                     for (const iCache in internal) {
-                        internal[iCache].destroy();
+                        this._safeDestroyInternal(internal[iCache]);
                     }
                     delete this[DRAWER_INTERNAL_CACHE];
                 }
+            }
+        }
+
+        /**
+         * Destroy a single internal cache record without letting a faulty drawer
+         * destructor abort the surrounding cleanup loop.
+         * @param {OpenSeadragon.InternalCacheRecord} cache
+         * @private
+         */
+        _safeDestroyInternal(cache) {
+            try {
+                cache.destroy();
+            } catch (e) {
+                $.console.error("[CacheRecord.destroyInternalCache] internal cache destroy threw:", e);
             }
         }
 
@@ -517,8 +547,13 @@
         }
 
         _destroySelfUnsafe(data, type) {
-            // ensure old data destroyed
-            $.converter.destroy(data, type);
+            // ensure old data destroyed - never let a data/internal destructor throw abort the
+            // bookkeeping reset below, or the cache system is left in an inconsistent state.
+            try {
+                $.converter.destroy(data, type);
+            } catch (e) {
+                $.console.error("[CacheRecord._destroySelfUnsafe] data destroy threw:", e);
+            }
             this.destroyInternalCache();
             // might've got revived in meanwhile if async ...
             if (!this._destroyed) {
@@ -614,8 +649,9 @@
                 if (this._tiles[i] === tile) {
                     this._tiles.splice(i, 1);
                     if (this._tRef === tile) {
-                        // keep fresh ref
-                        this._tRef = this._tiles[i - 1];
+                        // keep a valid fresh ref: pick any remaining tile (splice already shifted
+                        // later tiles down into index i), or null when none remain
+                        this._tRef = this._tiles.length ? this._tiles[Math.min(i, this._tiles.length - 1)] : null;
                     }
                     return true;
                 }
@@ -683,9 +719,12 @@
                 this._promise = $.Promise.resolve(data);
                 const internal = this[DRAWER_INTERNAL_CACHE];
                 if (internal) {
+                    // main data changed: internal (drawer) caches are now stale - destroy them so
+                    // they regenerate lazily on next render
                     for (const iCache in internal) {
-                        internal[iCache].setDataAs(data, type);
+                        this._safeDestroyInternal(internal[iCache]);
                     }
+                    delete this[DRAWER_INTERNAL_CACHE];
                 }
                 this._triggerNeedsDraw();
                 return this._promise;
@@ -701,9 +740,11 @@
                 this._promise = $.Promise.resolve(data);
                 const internal = this[DRAWER_INTERNAL_CACHE];
                 if (internal) {
+                    // same as above - force regenerate
                     for (const iCache in internal) {
-                        internal[iCache].setDataAs(data, type);
+                        this._safeDestroyInternal(internal[iCache]);
                     }
+                    delete this[DRAWER_INTERNAL_CACHE];
                 }
                 this._triggerNeedsDraw();
                 return this._data;
@@ -866,8 +907,13 @@
          */
         destroy() {
             if (this.loaded) {
-                if (this._ondestroy) {
-                    this._ondestroy(this._data);
+                // only invoke destroy on real data, otherwise skip
+                if (this._ondestroy && this._data !== null && this._data !== undefined) {
+                    try {
+                        this._ondestroy(this._data);
+                    } catch (e) {
+                        $.console.error("[InternalCacheRecord.destroy] drawer internal cache free threw:", e);
+                    }
                 }
                 this._data = null;
                 this.loaded = false;

--- a/src/tilecache.js
+++ b/src/tilecache.js
@@ -333,6 +333,7 @@
             }
             internalCache = this[DRAWER_INTERNAL_CACHE][drawerID] = new $.InternalCacheRecord(transformedData,
                 drawerID, (data) => drawer.internalCacheFree(data));
+            internalCache._drawer = drawer; // kept so in-place data overwrite can rebuild via same drawer
             return internalCache.await();
         }
 
@@ -368,6 +369,7 @@
 
             internalCache = this[DRAWER_INTERNAL_CACHE][drawerID] = new $.InternalCacheRecord(transformedData,
                 drawerID, (data) => drawer.internalCacheFree(data));
+            internalCache._drawer = drawer; // kept so in-place data overwrite can rebuild via same drawer
             return internalCache;
         }
 
@@ -475,15 +477,94 @@
 
         /**
          * Destroy a single internal cache record without letting a faulty drawer
-         * destructor abort the surrounding cleanup loop.
+         * destructor abort the surrounding cleanup loop. If the record is still loading
+         * (async/preload build in flight), defer the destroy until it resolves, otherwise
+         * InternalCacheRecord.destroy() is a no-op (guarded by 'loaded') and the resource
+         * would leak once the pending build completes on an already-orphaned record.
          * @param {OpenSeadragon.InternalCacheRecord} cache
          * @private
          */
         _safeDestroyInternal(cache) {
+            if (cache.loaded) {
+                try {
+                    cache.destroy();
+                } catch (e) {
+                    $.console.error("[CacheRecord] internal cache destroy threw:", e);
+                }
+            } else {
+                cache.await().then(() => cache.destroy())
+                    .catch((e) => $.console.error("[CacheRecord] internal cache destroy threw:", e));
+            }
+        }
+
+        /**
+         * Rebuild every drawer's internal (derived) cache from the current main data after an
+         * in-place overwrite. Double-buffered. Preload/async drawers therefore keep
+         * drawing the previous texture until the replacement is loaded (no blink).
+         * @private
+         */
+        _refreshInternalCaches() {
+            const internal = this[DRAWER_INTERNAL_CACHE];
+            if (!internal) {
+                return;
+            }
+            for (const drawerID in internal) {
+                this._rebuildInternalCache(drawerID, internal[drawerID]);
+            }
+        }
+
+        /**
+         * @param {string} drawerID
+         * @param {OpenSeadragon.InternalCacheRecord} old the record being replaced
+         * @private
+         */
+        _rebuildInternalCache(drawerID, old) {
+            const internal = this[DRAWER_INTERNAL_CACHE];
+            const drawer = old && old._drawer;
+
+            if (!internal || !drawer || !this._tRef) {
+                if (old) {
+                    this._safeDestroyInternal(old);
+                    delete internal[drawerID];
+                }
+                return;
+            }
+
+            let transformedData;
             try {
-                cache.destroy();
+                transformedData = drawer.internalCacheCreate(this, this._tRef);
             } catch (e) {
-                $.console.error("[CacheRecord.destroyInternalCache] internal cache destroy threw:", e);
+                $.console.error("[CacheRecord._rebuildInternalCache] internalCacheCreate threw:", e);
+                transformedData = undefined;
+            }
+            if (transformedData === undefined || transformedData === null) {
+                this._safeDestroyInternal(old);
+                delete internal[drawerID];
+                return;
+            }
+
+            const fresh = new $.InternalCacheRecord(transformedData, drawerID,
+                (data) => drawer.internalCacheFree(data));
+            fresh._drawer = drawer;
+
+            const swap = () => {
+                const currentMap = this[DRAWER_INTERNAL_CACHE];
+                if (this._destroyed || !currentMap || currentMap[drawerID] !== old) {
+                    this._safeDestroyInternal(fresh);
+                    return;
+                }
+                currentMap[drawerID] = fresh;
+                this._safeDestroyInternal(old);
+                this._triggerNeedsDraw();
+            };
+
+            if (fresh.loaded) {
+                swap(); // sync (non-preload) drawer: replace immediately, no blink
+            } else {
+                fresh.await().then(swap).catch(e => {
+                    $.console.error("[CacheRecord._rebuildInternalCache] internal cache refresh failed:", e);
+                    this._safeDestroyInternal(fresh);
+                });
             }
         }
 
@@ -513,7 +594,7 @@
          * Must not be called on active cache, e.g. first call destroy().
          */
         revive() {
-            $.console.assert(!this.loaded && !this._type, "[CacheRecord::revive] must not be called when loaded!");
+            $.console.assert(!this.loaded && !this._type, "[CacheRecord.revive] must not be called when loaded!");
             this._tiles = [];
             this._data = null;
             this._type = null;
@@ -540,7 +621,8 @@
                     this._destroySelfUnsafe(this._data, this._type);
                 } else if (this._promise) {
                     const oldType = this._type;
-                    this._promise.then(x => this._destroySelfUnsafe(x, oldType)).catch($.console.error);
+                    this._promise.then(x => this._destroySelfUnsafe(x, oldType))
+                        .catch((e) => $.console.error("[CacheRecord.destroy] async threw:", e));
                 }
             }
 
@@ -717,15 +799,10 @@
                 this._type = type;
                 this._data = data;
                 this._promise = $.Promise.resolve(data);
-                const internal = this[DRAWER_INTERNAL_CACHE];
-                if (internal) {
-                    // main data changed: internal (drawer) caches are now stale - destroy them so
-                    // they regenerate lazily on next render
-                    for (const iCache in internal) {
-                        this._safeDestroyInternal(internal[iCache]);
-                    }
-                    delete this[DRAWER_INTERNAL_CACHE];
-                }
+                // main data changed: rebuild each drawer's internal (derived) cache from the new
+                // data. Double-buffered so preload/async drawers keep showing the old texture
+                // until the replacement is ready (no blink); the old one is freed after the swap.
+                this._refreshInternalCaches();
                 this._triggerNeedsDraw();
                 return this._promise;
             }

--- a/test/modules/tilecache-failure-regressions.js
+++ b/test/modules/tilecache-failure-regressions.js
@@ -293,4 +293,75 @@
         v.open([{ isFailTestSource: "1" }, { isFailTestSource: "2" }]);
     });
 
+    QUnit.test('throwing/null internal cache free does not crash or corrupt cache bookkeeping', function (assert) {
+        const throwingFree = () => { throw new TypeError("deleteTexture: parameter 1 is not of type 'WebGLTexture'"); };
+        const rec = new OpenSeadragon.InternalCacheRecord({ texture: {} }, "drawer-unit", throwingFree);
+        let escaped = false;
+        try {
+            rec.destroy();
+        } catch (e) {
+            escaped = true;
+        }
+        assert.notOk(escaped, "InternalCacheRecord.destroy() contains a throwing drawer destructor");
+        assert.notOk(rec.loaded, "record marked unloaded after destroy");
+        assert.equal(rec.data, null, "record data cleared after destroy");
+
+        // null-resolved data never reaches the drawer destructor
+        let freeCalled = false;
+        const nullRec = new OpenSeadragon.InternalCacheRecord(
+            OpenSeadragon.Promise.resolve(null), "drawer-unit", () => { freeCalled = true; });
+
+        return nullRec.await().then(() => {
+            assert.ok(nullRec.loaded, "null-backed record is 'loaded' once its promise resolves");
+            nullRec.destroy();
+            assert.notOk(freeCalled, "destructor not invoked when internal cache data is null");
+
+            const fakeDrawer = {
+                _dataNeedsRefresh: 0,
+                options: { usePrivateCache: true, preloadCache: false },
+                getId() { return "drawer-unit"; },
+                getSupportedDataFormats() { return [T_A]; },
+                internalCacheCreate() { return { texture: {} }; },
+                internalCacheFree() { throw new TypeError("deleteTexture: parameter 1 is not of type 'WebGLTexture'"); }
+            };
+
+            const fakeTile = { cacheKey: "unit-key" };
+            const cache = new OpenSeadragon.CacheRecord();
+            cache.addTile(fakeTile, 0, T_A);          // loaded, main data present
+            cache.withTileReference(fakeTile);         // _tRef for internalCacheCreate
+            cache.prepareInternalCacheSync(fakeDrawer); // installs internal cache with throwing free
+
+            const tc = new OpenSeadragon.TileCache({ maxImageCacheCount: 200 });
+            const key = "unit-key";
+            cache.cacheKey = key;
+            cache._ownerTileCache = tc;
+            tc._cachesLoaded[key] = cache;
+            tc._cachesLoadedCount++;
+
+            const originalError = OpenSeadragon.console.error;
+            let sawDoesNotBelong = false;
+            OpenSeadragon.console.error = function (msg) {
+                if (typeof msg === "string" && msg.indexOf("does not belong to") !== -1) {
+                    sawDoesNotBelong = true;
+                }
+                // swallow (expected contained-destructor error is logged here too)
+            };
+
+            let unloadThrew = false;
+            try {
+                tc.unloadCacheForTile(fakeTile, key, true, false);
+            } catch (e) {
+                unloadThrew = true;
+            } finally {
+                OpenSeadragon.console.error = originalError;
+            }
+
+            assert.notOk(unloadThrew, "unloadCacheForTile does not rethrow the drawer destructor error");
+            assert.notOk(sawDoesNotBelong, "no 'does not belong to' cascade emitted");
+            assert.equal(tc._cachesLoaded[key], undefined, "cache record removed from _cachesLoaded");
+            assert.equal(tc._cachesLoadedCount, 0, "cache count decremented consistently");
+            assert.notOk(cache.loaded, "cache record fully destroyed");
+        });
+    });
+
 })();

--- a/test/modules/tilecache-failure-regressions.js
+++ b/test/modules/tilecache-failure-regressions.js
@@ -364,4 +364,72 @@
         });
     });
 
+    // Regression: in-place main-data overwrite (setDataAs) must rebuild each drawer's internal
+    // (derived) cache from the new data. Double-buffered so preload/async drawers keep drawing the
+    // old texture until the replacement is loaded (no blink), then free the old one. Previously the
+    // code called a nonexistent InternalCacheRecord.setDataAs and threw.
+    QUnit.test('in-place data overwrite rebuilds internal cache (double-buffered, no blink)', function (assert) {
+        const stubTile = () => ({ cacheKey: "k", tiledImage: { viewer: { forceRedraw() {} } } });
+
+        const syncFreed = [];
+        const syncDrawer = {
+            _dataNeedsRefresh: 0,
+            options: { usePrivateCache: true, preloadCache: false },
+            getId() { return "sync-drawer"; },
+            getSupportedDataFormats() { return [T_A]; },
+            internalCacheCreate(cache) { return { tex: cache.data }; }, // derive from current main data
+            internalCacheFree(data) { syncFreed.push(data); }
+        };
+
+        const syncTile = stubTile();
+        const syncCache = new OpenSeadragon.CacheRecord();
+        syncCache.addTile(syncTile, 10, T_A);
+        syncCache.withTileReference(syncTile);
+        const syncIc1 = syncCache.prepareInternalCacheSync(syncDrawer);
+        assert.deepEqual(syncIc1.data, { tex: 10 }, "internal cache built from initial data");
+
+        syncCache.setDataAs(20, T_A); // in-place overwrite -> _refreshInternalCaches (sync path)
+        const syncIc2 = syncCache._getInternalCacheRef(syncDrawer);
+        assert.notEqual(syncIc2, syncIc1, "new internal record swapped in for sync drawer");
+        assert.deepEqual(syncIc2.data, { tex: 20 }, "internal cache rebuilt from new data");
+        assert.ok(syncFreed.some(d => d && d.tex === 10), "old internal data freed after sync swap");
+
+        const asyncFreed = [];
+        const asyncDrawer = {
+            _dataNeedsRefresh: 0,
+            options: { usePrivateCache: true, preloadCache: true },
+            getId() { return "async-drawer"; },
+            getSupportedDataFormats() { return [T_A]; },
+            internalCacheCreate(cache) {
+                const val = cache.data;
+                return OpenSeadragon.Promise.resolve().then(() => ({ tex: val }));
+            },
+            internalCacheFree(data) { asyncFreed.push(data); }
+        };
+
+        const asyncTile = stubTile();
+        const asyncCache = new OpenSeadragon.CacheRecord();
+        asyncCache.addTile(asyncTile, 1, T_A);
+        asyncCache.withTileReference(asyncTile);
+
+        return asyncCache.prepareInternalCacheAsync(asyncDrawer).then(() => {
+            const ic1 = asyncCache._getInternalCacheRef(asyncDrawer);
+            assert.deepEqual(ic1.data, { tex: 1 }, "async internal cache built from initial data");
+
+            asyncCache.setDataAs(2, T_A); // in-place overwrite -> async rebuild
+
+            const during = asyncCache._getInternalCacheRef(asyncDrawer);
+            assert.equal(during, ic1, "old internal cache kept in slot during async rebuild (no blink)");
+            assert.ok(during.loaded, "old internal cache still loaded during rebuild");
+            assert.deepEqual(during.data, { tex: 1 }, "old data still available during rebuild");
+
+            return sleep(30).then(() => {
+                const after = asyncCache._getInternalCacheRef(asyncDrawer);
+                assert.notEqual(after, ic1, "new internal cache swapped in once loaded");
+                assert.deepEqual(after.data, { tex: 2 }, "new internal cache holds new data");
+                assert.ok(asyncFreed.some(d => d && d.tex === 1), "old async internal data freed after swap");
+            });
+        });
+    });
+
 })();


### PR DESCRIPTION
I encountered issues where my data source provider stored null/undefined for tile, and the renderer was choing on it with a data destructor (webgl deleteTextures). This tries to safely check invalid data, and adds more async checks.

Moreover, we did `internal[iCache].setDataAs(data, type);` call, which was invalid for webgl (internal cache might belong to different contexts). The question is whether we could at least detect if a drawer can actually inherit an internal cache, and if not, only then destroy to force load.