### PR TITLE
Add setVisible method to Navigator

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -464,19 +464,25 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
      * @return {OpenSeadragon.Navigator} Chainable.
      */
     setVisible: function (visible) {
-        if (this.element) {
-            this.element.style.display = visible ? "block" : "none";
+    if (this.element) {
+        if (visible) {
+            this.element.style.display = this._previousDisplayStyle || '';
+            this._previousDisplayStyle = undefined;
 
-            if (visible && this.viewport) {
+            if (this.viewport) {
                 this.updateSize();
                 this.update(this.viewer.viewport);
             }
         } else {
-            $.console.warn("[OpenSeadragon.Navigator.setVisible] Navigator element is not defined.");
+            this._previousDisplayStyle = this.element.style.display;
+            this.element.style.display = 'none';
         }
+    } else {
+        $.console.warn("[OpenSeadragon.Navigator.setVisible] Navigator element is not defined.");
+    }
 
-        return $.Viewer.prototype.setVisible.apply(this, [visible]);
-    },
+    return $.Viewer.prototype.setVisible.apply(this, [visible]);
+},
 
     // private
     _getMatchingItem: function(theirItem) {

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -457,6 +457,27 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
         return $.Viewer.prototype.destroy.apply(this);
     },
 
+    /**
+     * Controls the visibility of the navigator element.
+     * @function
+     * @param {Boolean} visible - True to show the navigator, false to hide it.
+     * @return {OpenSeadragon.Navigator} Chainable.
+     */
+    setVisible: function (visible) {
+        if (this.element) {
+            this.element.style.display = visible ? "block" : "none";
+
+            if (visible && this.viewport) {
+                this.updateSize();
+                this.update(this.viewer.viewport);
+            }
+        } else {
+            console.warn("[OpenSeadragon.Navigator.setVisible] Navigator element is not defined.");
+        }
+
+        return $.Viewer.prototype.setVisible.apply(this, [visible]);
+    },
+
     // private
     _getMatchingItem: function(theirItem) {
         const count = this.world.getItemCount();

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -472,7 +472,7 @@ $.extend( $.Navigator.prototype, $.EventSource.prototype, $.Viewer.prototype, /*
                 this.update(this.viewer.viewport);
             }
         } else {
-            console.warn("[OpenSeadragon.Navigator.setVisible] Navigator element is not defined.");
+            $.console.warn("[OpenSeadragon.Navigator.setVisible] Navigator element is not defined.");
         }
 
         return $.Viewer.prototype.setVisible.apply(this, [visible]);


### PR DESCRIPTION
Picks up the work from #2650 (marked "up for grabs") and addresses the
review feedback left there.

Adds a `setVisible` method to `OpenSeadragon.Navigator`, allowing the
navigator element to be shown or hidden programmatically.

- Toggles the navigator element's `display` style
- When shown, calls `updateSize()` and `update()` to refresh the viewport
  and display region, reusing existing logic instead of duplicating
  viewport/world refresh calls (per review comment on #2650 asking
  whether all 4 original calls were needed)
- Calls the superclass `Viewer.prototype.setVisible` so the `visible`
  event is still raised (per review comment on #2650)
- Logs a warning if the navigator element is not defined
- Doc comment indentation matches existing style in the file

Closes #2634

Tested manually via test/demo/navigator-resize.html — toggling
visibility on/off correctly shows/hides the navigator and keeps the
display region in sync. Verified the warning logs correctly when
`element` is not defined.