### PR TITLE
Fix: Add missing types

### DIFF
--- a/test-dts/index.test-d.ts
+++ b/test-dts/index.test-d.ts
@@ -9,6 +9,8 @@ expectError(OpenSeadragon({ id: 123 }));
 expectType<boolean>(viewer.isOpen());
 expectType<boolean>(viewer.isFullPage());
 expectType<OpenSeadragon.Viewer>(viewer.close());
+expectType<OpenSeadragon.Viewer>(OpenSeadragon({ id: "viewer", cooperativeGestures: true }));
+expectType<OpenSeadragon.Viewer>(viewer.setCooperativeGestures(true));
 viewer.destroy();
 
 // Viewport
@@ -113,6 +115,11 @@ viewer.addHandler("tile-loaded", (ev) => {
     expectType<OpenSeadragon.Tile>(ev.tile);
     expectType<OpenSeadragon.TiledImage>(ev.tiledImage);
 });
+viewer.addHandler("canvas-cooperative-gesture", (ev) => {
+    expectType<"drag" | "scroll">(ev.gesture);
+    expectType<string>(ev.message);
+    expectType<boolean>(ev.preventDefaultAction);
+});
 expectError(viewer.addHandler("invalid", () => {}));
 
 // Point
@@ -198,9 +205,12 @@ button.destroy();
 // MouseTracker
 const tracker = new OpenSeadragon.MouseTracker({
     element: document.createElement("div"),
+    cooperativeGestureHandling: true,
     clickHandler: (ev) => expectType<OpenSeadragon.MouseTracker>(ev.eventSource)
 });
 expectType<number>(tracker.getActivePointerCount());
+expectType<boolean>(tracker.cooperativeGestureHandling);
+expectType<OpenSeadragon.MouseTracker>(tracker.setCooperativeGestureHandling(false));
 tracker.setTracking(true);
 tracker.destroy();
 
@@ -271,5 +281,6 @@ expectType<any>(cacheRecord.getRenderedContext());
 expectType<Element>(OpenSeadragon.getElement("id"));
 expectType<OpenSeadragon.Point>(OpenSeadragon.getElementOffset(document.createElement("div")));
 expectType<OpenSeadragon.Point>(OpenSeadragon.getWindowSize());
+expectType<void>(OpenSeadragon.setElementTouchAction("id", "pan-x pan-y"));
 expectType<string>(OpenSeadragon.version.versionStr);
 expectType<boolean>(OpenSeadragon.supportsCanvas);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -218,6 +218,11 @@ declare namespace OpenSeadragon {
 
     function setElementPointerEventsNone(element: Element | string): void;
 
+    function setElementTouchAction(
+        element: Element | string,
+        value: string,
+    ): void;
+
     function setElementTouchActionNone(element: Element | string): void;
 
     function setImageFormatsSupported(formats: {
@@ -393,6 +398,7 @@ declare namespace OpenSeadragon {
         springStiffness?: number;
         animationTime?: number;
         loadDestinationTilesOnAnimation?: boolean;
+        cooperativeGestures?: boolean;
         gestureSettingsMouse?: GestureSettings;
         gestureSettingsTouch?: GestureSettings;
         gestureSettingsPen?: GestureSettings;
@@ -1119,6 +1125,7 @@ declare namespace OpenSeadragon {
         dblClickDistThreshold?: number;
         stopDelay?: number;
         userData?: unknown;
+        cooperativeGestureHandling?: boolean;
 
         preProcessEventHandler?: EventHandler<PreProcessMouseTrackerEvent>;
         keyDownHandler?: EventHandler<KeyMouseTrackerEvent>;
@@ -1155,10 +1162,12 @@ declare namespace OpenSeadragon {
         dblClickDistThreshold: number;
         stopDelay: number;
         userData: unknown;
+        cooperativeGestureHandling: boolean;
 
         destroy(): void;
         /** @deprecated use `this.tracking` */
         isTracking(): boolean;
+        setCooperativeGestureHandling(enabled: boolean): MouseTracker;
         setTracking(track: boolean): MouseTracker;
         getActivePointersListByType(type: string): GesturePointList;
         getActivePointerCount(): number;
@@ -1867,6 +1876,7 @@ declare namespace OpenSeadragon {
         ): object | boolean;
         requestInvalidate(restoreTiles?: boolean): Promise<any>;
         setAjaxHeaders(ajaxHeaders: object, propagate?: boolean): void;
+        setCooperativeGestures(enabled: boolean): Viewer;
         setDebugMode(debug: boolean): Viewer;
         setFullPage(fullScreen: boolean): Viewer;
         setFullScreen(fullScreen: boolean): Viewer;
@@ -2151,6 +2161,7 @@ declare namespace OpenSeadragon {
         "canvas-blur": CanvasTrackerEvent;
         "canvas-click": CanvasClickEvent;
         "canvas-contextmenu": CanvasContextMenuEvent;
+        "canvas-cooperative-gesture": CanvasCooperativeGestureEvent;
         "canvas-double-click": CanvasDoubleClickEvent;
         "canvas-drag": CanvasDragEvent;
         "canvas-drag-end": Omit<CanvasDragEvent, "delta">;
@@ -2306,6 +2317,13 @@ declare namespace OpenSeadragon {
 
     interface CanvasContextMenuEvent extends CanvasEvent {
         preventDefault: boolean;
+    }
+
+    interface CanvasCooperativeGestureEvent extends CanvasEvent {
+        pointerType: PointerType;
+        gesture: "drag" | "scroll";
+        message: string;
+        preventDefaultAction: boolean;
     }
 
     interface CanvasDoubleClickEvent extends CanvasEvent {


### PR DESCRIPTION
Slight oversight on my part, and something that only becomes apparent when trying to access this new option on a Typescript project, where it will throw a type error if not patched locally!

Here I've added the missing type definitions for `cooperativeGestures` option on `Openseadragon`, the canvas events, and the setters, as well as the extra utility I added for `setElementTouchAction`.

I think that covers the public facing API additions.