### PR TITLE
test: add positiveModulo unit tests to basic.js

### DIFF
--- a/test/modules/basic.js
+++ b/test/modules/basic.js
@@ -463,4 +463,11 @@
             assert.ok(OpenSeadragon.version.revision >= 0, "revision should be a positive number");
         });
     }
+    // Ensures positiveModulo returns a positive result for negative inputs
+    QUnit.test('positiveModulo', function(assert) {
+        assert.equal(OpenSeadragon.positiveModulo(-1, 5), 4, 'positiveModulo(-1, 5) should be 4');
+        assert.equal(OpenSeadragon.positiveModulo(-8, 7), 6, 'positiveModulo(-8, 7) should be 6');
+    });
+
+
 })();


### PR DESCRIPTION
Addresses #306.

Adds a QUnit test for OpenSeadragon.positiveModulo() directly into
test/modules/basic.js, verifying it returns a positive remainder
for negative inputs (e.g. positiveModulo(-1, 5) === 4).

This follows up on an earlier attempt that used a standalone test
file outside the main test harness — this version integrates into
the existing Basic module so it runs as part of the standard test suite.
