### PR TITLE
Fixed test coverage failures

### DIFF
--- a/test/coverage-runner.js
+++ b/test/coverage-runner.js
@@ -48,9 +48,6 @@ async function runCoverage() {
         args: [
             '--no-sandbox',
             '--allow-file-access-from-files',
-            '--use-gl=swiftshader',
-            '--enable-webgl',
-            '--ignore-gpu-blacklist',
             '--disable-dev-shm-usage'
         ]
     });

--- a/test/modules/basic.js
+++ b/test/modules/basic.js
@@ -455,7 +455,7 @@
     });
 
     //Version numbers are injected by the build process, so skip version tests if we are only running code coverage
-    if(!window.isCoverageTest ){
+    if(!window.COVERAGE_RUN){
         QUnit.test('version object', function(assert) {
             assert.equal(typeof OpenSeadragon.version.versionStr, "string", "versionStr should be a string");
             assert.ok(OpenSeadragon.version.major >= 0, "major should be a positive number");


### PR DESCRIPTION
Following up on #2955. I asked Claude about why we're getting test failures in coverage but not in normal testing. Here's what it said:

> 1. test/coverage-runner.js — the Puppeteer launch flags --use-gl=swiftshader --enable-webgl --ignore-gpu-blacklist, meant to force WebGL on, actually disable it on the current Chrome version (verified directly: WebGL works with no flags, fails with them). That was cascading into 18 of the 23 failures via Error with creating the selected drawer(s) in beforeEach, and left webgldrawer.js at 2.6% coverage. Removed the stale flags — coverage now correctly exercises the WebGL drawer (75.9% coverage) and overall statement coverage jumped from 65.96% → 72%.
> 
> 2. test/coverage.html — sets window.COVERAGE_RUN, but test/modules/basic.js:458 checks window.isCoverageTest to skip the version object test (version numbers are only injected by the concat/build step, not present in raw instrumented sources). Naming mismatch meant the guard never fired. Added the correctly-named flag.

@Zaidzezo Can you give this branch a try and see if it's working for you? Here's what I'm getting: 

```
========================================================
  Test Results
========================================================
  343 tests completed in 34418 milliseconds, with 0 failed, 0 skipped, and 0 todo.4074 assertions of 4074 passed, 0 failed.

  Coverage data collected for 42 files.
  Coverage data written to: /Users/iangilman/projects/openseadragon/openseadragon/.nyc_output/coverage.json
========================================================


Running "shell:nyc_report" (shell) task
-------------------------|---------|----------|---------|---------|---------------------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s               
-------------------------|---------|----------|---------|---------|---------------------------------
All files                |      72 |    62.11 |   70.39 |   71.98 |                                 
 button.js               |   71.42 |    48.61 |   65.21 |   71.42 | ...-493,498-501,514-517,522-525 
 buttongroup.js          |   92.85 |    66.66 |    87.5 |   92.85 | 122-123                         
 canvasdrawer.js         |   62.42 |       50 |   76.74 |   62.09 | ...988,1013-1029,1043,1050-1056 
 control.js              |   55.81 |    43.33 |   66.66 |   55.81 | 81-84,117-130,136,152,177-186   
 controldock.js          |   78.88 |    74.07 |   66.66 |   80.23 | 54,102,131-140,184-203          
 datatypeconverter.js    |   60.84 |    43.87 |    67.3 |    60.2 | ...,695-715,737,741-753,757,763 
 displayrectangle.js     |      50 |      100 |      50 |      50 | 53-66                           
 drawerbase.js           |   70.58 |    51.85 |      60 |   70.58 | ...,358,361,364,398-399,426,454 
 dzitilesource.js        |      60 |    56.57 |   88.88 |   59.81 | ...,284-290,303,309-321,356-358 
 eventsource.js          |   92.63 |    84.72 |     100 |   92.47 | 168,181,211,251,258,279-280     
 fullscreen.js           |    25.8 |       10 |      20 |    25.8 | 53-54,75-76,81-136,142-143      
 htmldrawer.js           |   94.02 |    70.37 |     100 |   93.75 | 256-260,268,284                 
 iiiftilesource.js       |   82.22 |    78.94 |      95 |   82.69 | ...,541,543,545,559,686,700-705 
 iiptilesource.js        |   59.59 |    61.36 |   54.54 |   59.18 | ...,268,271,274,277,280,287,291 
 imageloader.js          |   71.09 |     55.2 |   75.86 |   70.83 | ...-557,577-578,587-589,593-598 
 imagetilesource.js      |   57.81 |       52 |   70.58 |   57.81 | ...-177,189-191,201-207,229-254 
 iristilesource.js       |   61.81 |       40 |   57.14 |   60.37 | 61,72-73,138-175,201-211        
 legacytilesource.js     |   58.57 |       52 |   91.66 |    58.2 | ...,135,169,197,201,232,249-291 
 matrix3.js              |   56.25 |       50 |   63.63 |   51.56 | 94,110,211-269                  
 mousetracker.js         |   63.96 |    55.55 |   46.15 |   63.75 | ...590,3660-3662,3724-3798,3820 
 navigator.js            |   79.68 |    59.66 |   82.35 |    79.6 | ...,564,609,612,616,625,649-675 
 openseadragon.js        |   59.13 |    51.82 |   59.67 |   59.49 | ...114,3125-3126,3130,3133-3135 
 osmtilesource.js        |      20 |    14.28 |   33.33 |      20 | 74-101,132-150                  
 overlay.js              |   91.35 |    83.01 |     100 |   91.35 | ...,306-308,342,408,411,416,484 
 placement.js            |     100 |      100 |     100 |     100 |                                 
 point.js                |     100 |      100 |     100 |     100 |                                 
 priorityqueue.js        |   60.82 |    45.45 |   42.85 |   64.83 | ...-154,183,260-294,310-317,349 
 rectangle.js            |    99.4 |    98.75 |     100 |   99.39 | 130                             
 referencestrip.js       |   45.17 |    19.13 |   42.85 |   45.17 | ...-271,297-407,423,436,499-607 
 spring.js               |   83.87 |    57.44 |   88.88 |   83.87 | 56,186-203                      
 strings.js              |     100 |     62.5 |     100 |     100 | 86,97-115                       
 tile.js                 |   47.39 |    37.79 |   47.05 |   47.61 | ...,690-692,696-702,720-783,793 
 tilecache.js            |   64.63 |    62.81 |   70.52 |   64.79 | ...508-1517,1549-1551,1566-1567 
 tiledimage.js           |   86.79 |    78.65 |   82.25 |   86.82 | ...468,2490,2520,2562,2609-2613 
 tilesource.js           |   77.48 |    78.78 |   68.62 |   77.97 | ...034-1038,1047,1053,1083-1085 
 tilesourcecollection.js |     100 |      100 |     100 |     100 |                                 
 tmstilesource.js        |   19.04 |       25 |   33.33 |   19.04 | 63-91,119-140                   
 viewer.js               |   74.88 |    64.31 |   72.02 |   74.68 | ...614,4625,4639-4643,4667,4681 
 viewport.js             |   82.41 |    67.98 |   90.36 |   82.41 | ...732,1744-1748,1778,1783,1823 
 webgldrawer.js          |   75.88 |    62.71 |   75.29 |   75.66 | ...924-1958,1978-1982,2001-2006 
 world.js                |   87.24 |    70.09 |   95.12 |   86.89 | ...,651,657-660,666,786-787,794 
 zoomifytilesource.js    |   94.73 |       60 |    87.5 |   94.59 | 48,152                          
-------------------------|---------|----------|---------|---------|---------------------------------

=============================== Coverage summary ===============================
Statements   : 72% ( 6946/9646 )
Branches     : 62.11% ( 3432/5525 )
Functions    : 70.39% ( 1046/1486 )
Lines        : 71.98% ( 6826/9482 )
================================================================================
```