### PR TITLE
Hardening cache pipeline & fixing drawers

### DIFF
--- a/src/canvasdrawer.js
+++ b/src/canvasdrawer.js
@@ -78,7 +78,8 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
 
         // Image smoothing for canvas rendering (only if canvas is used).
         // Canvas default is "true", so this will only be changed if user specifies "false" in the options or via setImageSmoothinEnabled.
-        this._imageSmoothingEnabled = true;
+        this._imageSmoothingEnabled = this.options.imageSmoothingEnabled !== undefined ?
+            !!this.options.imageSmoothingEnabled : true;
 
         // Since the tile-drawn and tile-drawing events are fired by this drawer, make sure handlers can be added for them
         this.viewer.allowEventHandler("tile-drawn");
@@ -169,7 +170,7 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
      */
     setImageSmoothingEnabled(imageSmoothingEnabled){
         this._imageSmoothingEnabled = !!imageSmoothingEnabled;
-        this._updateImageSmoothingEnabled(this.context);
+        this._applyImageSmoothingEnabled();
         this.viewer.forceRedraw();
     }
 
@@ -241,13 +242,12 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
             this.canvas.height !== viewportSize.y ) {
             this.canvas.width = viewportSize.x;
             this.canvas.height = viewportSize.y;
-            this._updateImageSmoothingEnabled(this.context);
             if ( this.sketchCanvas !== null ) {
                 const sketchCanvasSize = this._calculateSketchCanvasSize();
                 this.sketchCanvas.width = sketchCanvasSize.x;
                 this.sketchCanvas.height = sketchCanvasSize.y;
-                this._updateImageSmoothingEnabled(this.sketchContext);
             }
+            this._applyImageSmoothingEnabled();
         }
         this._clear();
     }
@@ -650,6 +650,8 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
                         const sketchCanvasSize = self._calculateSketchCanvasSize();
                         self.sketchCanvas.width = sketchCanvasSize.x;
                         self.sketchCanvas.height = sketchCanvasSize.y;
+                        // resizing a canvas resets its 2d context state, smoothing included
+                        self._updateImageSmoothingEnabled(self.sketchContext);
                     });
                 }
                 this._updateImageSmoothingEnabled(this.sketchContext);
@@ -880,6 +882,17 @@ class CanvasDrawer extends OpenSeadragon.DrawerBase{
     _updateImageSmoothingEnabled(context){
         context.msImageSmoothingEnabled = this._imageSmoothingEnabled;
         context.imageSmoothingEnabled = this._imageSmoothingEnabled;
+    }
+
+    // private
+    // imageSmoothingEnabled is per-context state, and this drawer renders through two contexts:
+    // tiles that go through the sketch canvas - tiled image opacity below 1, non source-over
+    // compositing, transparency, tile edge smoothing - are scaled there, not on the main canvas.
+    _applyImageSmoothingEnabled(){
+        this._updateImageSmoothingEnabled(this.context);
+        if (this.sketchContext) {
+            this._updateImageSmoothingEnabled(this.sketchContext);
+        }
     }
 
     /**

--- a/src/datatypeconverter.js
+++ b/src/datatypeconverter.js
@@ -247,26 +247,36 @@ function postWorker(op, payload, { timeoutMs = 15000 } = {}) {
         }
         _pendingConversions.set(id, entry);
 
-        if (op === 'decodeFromBytes') {
-            if (__hasSAB) {
-                const u8 = payload.u8;
-                // eslint-disable-next-line no-undef
-                const sab = new SharedArrayBuffer(u8.byteLength);
-                new Uint8Array(sab).set(u8);
-                worker.postMessage({ id, op, bytes: sab, mime: payload.mime });
-            } else {
-                if (!__warnedNoSAB) {
-                    __warnedNoSAB = true;
-                    console.warn('[Converter] SharedArrayBuffer unavailable; falling back to ArrayBuffer.');
+        // postMessage() throws synchronously on a payload it cannot clone. Without this the entry would
+        // sit in the pending map until the timeout above fires, stalling the tile for the full timeout.
+        try {
+            if (op === 'decodeFromBytes') {
+                if (__hasSAB) {
+                    const u8 = payload.u8;
+                    // eslint-disable-next-line no-undef
+                    const sab = new SharedArrayBuffer(u8.byteLength);
+                    new Uint8Array(sab).set(u8);
+                    worker.postMessage({ id, op, bytes: sab, mime: payload.mime });
+                } else {
+                    if (!__warnedNoSAB) {
+                        __warnedNoSAB = true;
+                        console.warn('[Converter] SharedArrayBuffer unavailable; falling back to ArrayBuffer.');
+                    }
+                    const u8 = payload.u8;
+                    const tight = (u8.byteOffset === 0 && u8.byteLength === u8.buffer.byteLength) ? u8 : u8.slice();
+                    worker.postMessage({ id, op, bytes: tight.buffer, mime: payload.mime }, [tight.buffer]);
                 }
-                const u8 = payload.u8;
-                const tight = (u8.byteOffset === 0 && u8.byteLength === u8.buffer.byteLength) ? u8 : u8.slice();
-                worker.postMessage({ id, op, bytes: tight.buffer, mime: payload.mime }, [tight.buffer]);
+            } else {
+                worker.postMessage(payload);
             }
-            return;
+        } catch (e) {
+            if (entry.timer) {
+                clearTimeout(entry.timer);
+                entry.timer = null;
+            }
+            _pendingConversions.delete(id);
+            reject(e);
         }
-
-        worker.postMessage(payload);
     });
 }
 
@@ -340,19 +350,6 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
         this.copyings = {};
 
         // Teaching OpenSeadragon built-in conversions:
-        const imageCreator = (tile, url) => new $.Promise((resolve, reject) => {
-            if (!$.supportsAsync) {
-                return reject("Not supported in sync mode!");
-            }
-            const img = new Image();
-            img.onerror = img.onabort = e => reject(`Failed to load image: ${url}`);
-            img.onload = () => resolve(img);
-            if (tile.tiledImage && tile.tiledImage.crossOriginPolicy) {
-                img.crossOrigin = tile.tiledImage.crossOriginPolicy;
-            }
-            img.src = url;
-            return undefined;
-        });
         const canvasContextCreator = (tile, imageData) => {
             const canvas = document.createElement('canvas');
             canvas.width = imageData.width;
@@ -362,33 +359,43 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
             return context;
         };
 
+        // An Image can only be built from a URL, so a Blob has to go through a temporary object URL:
+        // a data: URL would base64 encode the whole tile, and createImageBitmap() - which needs no URL -
+        // produces an imageBitmap instead, which is the cheaper edge registered below anyway.
+        // The URL is not released once the image has decoded: consumers may clone the element, and a
+        // clone loads from its src again. It is released by the image destructor instead.
         this.learn("rasterBlob", "image", (tile, blob) => new $.Promise((resolve, reject) => {
-            // eslint-disable-next-line compat/compat
-            const url = (window.URL || window.webkitURL).createObjectURL(blob);
             if (!$.supportsAsync) {
                 return reject("Not supported in sync mode!");
             }
+            // eslint-disable-next-line compat/compat
+            const urlApi = window.URL || window.webkitURL;
+            const url = urlApi.createObjectURL(blob);
             const img = new Image();
             img.onerror = img.onabort = e => {
-                // eslint-disable-next-line compat/compat
-                (window.URL || window.webkitURL).revokeObjectURL(blob);
+                // Nothing will ever own this image, so the destructor cannot run for it: release here.
+                urlApi.revokeObjectURL(url);
                 reject(e);
             };
-            img.onload = () => {
-                // eslint-disable-next-line compat/compat
-                (window.URL || window.webkitURL).revokeObjectURL(blob);
-                resolve(img);
-            };
+            img.onload = () => resolve(img);
             img.decoding = 'async';
             img.src = url;
             return undefined;
-        }), 1, 2);
+        }), 1, 3);
 
         this.learn("context2d", "rasterBlob", (tile, ctx) => new $.Promise((resolve, reject) => {
             if (!$.supportsAsync) {
                 return reject("Not supported in sync mode!");
             }
-            ctx.canvas.toBlob(resolve);
+            // toBlob() reports failure by passing null, which would otherwise be resolved as if it were
+            // valid data and only fail further down the conversion path.
+            ctx.canvas.toBlob(blob => {
+                if (blob) {
+                    resolve(blob);
+                } else {
+                    reject(new Error("Canvas toBlob() failed to encode the canvas!"));
+                }
+            });
             return undefined;
         }), 1, 2);
 
@@ -421,35 +428,24 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
         this.learn("image", "context2d", canvasContextCreator, 1, 2);
 
         //Copies
-        this.learn("image", "image", (tile, image) => imageCreator(tile, image.src), 1, 1);
+        //there is no API to write pixels into an Image, nothing to protect by copying
+        this.learn("image", "image", (tile, image) => image, 0, 1);
         this.learn("context2d", "context2d", (tile, ctx) => canvasContextCreator(tile, ctx.canvas));
         this.learn("rasterBlob", "rasterBlob", (tile, blob) => blob, 0, 1); //blobs are immutable, no need to copy
-        this.learn("imageBitmap", "imageBitmap", (tile, bmp) => new $.Promise((resolve, reject) => {
-            try {
-                if (!$.supportsAsync) {
-                    return reject("Not supported in sync mode!");
-                }
-                if (!bmp) {
-                    return reject(new Error("No ImageBitmap to copy"));
-                }
-
-                if (typeof OffscreenCanvas !== 'undefined' && bmp.width && bmp.height) {
-                    const oc = new OffscreenCanvas(bmp.width, bmp.height);
-                    const ctx = oc.getContext('2d', { willReadFrequently: false });
-                    ctx.drawImage(bmp, 0, 0);
-
-                    if (typeof oc.transferToImageBitmap === 'function') {
-                        const copy = oc.transferToImageBitmap();
-                        return resolve(copy);
-                    }
-                    return createImageBitmap(oc, { colorSpaceConversion: 'none' }).then(resolve);
-                }
-                // Fallback
-                return createImageBitmap(bmp, { colorSpaceConversion: 'none' }).then(resolve);
-            } catch (e) {
-                return reject(e);
+        // createImageBitmap() on an ImageBitmap already yields an independent handle: closing the source
+        // does not close the copy, which is the only property the cache ownership model needs. Rasterizing
+        // through an OffscreenCanvas to achieve the same thing costs a GPU->CPU->GPU round trip per copy.
+        this.learn("imageBitmap", "imageBitmap", (tile, bmp) => {
+            if (!$.supportsAsync) {
+                return $.Promise.reject("Not supported in sync mode!");
             }
-        }), 1, 1);
+            // A closed ImageBitmap reports zero dimensions, and createImageBitmap() rejects on a zero-sized
+            // source: check here so the failure names the actual cause.
+            if (!bmp || !bmp.width || !bmp.height) {
+                return $.Promise.reject(new Error("Cannot copy a closed or empty ImageBitmap!"));
+            }
+            return createImageBitmap(bmp, { colorSpaceConversion: 'none' });
+        }, 1, 1);
         /**
          * Free up canvas memory
          * (iOS 12 or higher on 2GB RAM device has only 224MB canvas memory,
@@ -458,6 +454,28 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
         this.learnDestroy("context2d", ctx => {
             ctx.canvas.width = 0;
             ctx.canvas.height = 0;
+        });
+        /**
+         * Release the decoded pixels immediately instead of waiting for the collector. An ImageBitmap can
+         * hold several MB, and the cache evicts far more often than the collector runs. Copying the type
+         * produces an independent handle, so closing one can never affect another.
+         */
+        this.learnDestroy("imageBitmap", bmp => {
+            if (bmp && typeof bmp.close === 'function') {
+                bmp.close();
+            }
+        });
+        /**
+         * Release the object URL an image was decoded from, if any. It cannot be released earlier: an
+         * image element may be cloned by a consumer (the HTML drawer does), and the clone loads from
+         * the very same src. Copying the image type hands back the same element rather than a second
+         * one, so exactly one destructor call exists per object URL.
+         */
+        this.learnDestroy("image", image => {
+            if (image && typeof image.src === "string" && image.src.indexOf("blob:") === 0) {
+                // eslint-disable-next-line compat/compat
+                (window.URL || window.webkitURL).revokeObjectURL(image.src);
+            }
         });
     }
 
@@ -571,6 +589,9 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
     convert(tile, data, from, ...to) {
         const conversionPath = this.getConversionPath(from, to);
         if (!conversionPath) {
+            // A missing path is a static property of the graph, so rejecting here would report it once per
+            // tile and, through the cache error handling, take every one of those tiles down permanently.
+            // Report it and let the caller keep whatever data it already had, as CacheRecord._convert does.
             $.console.error(`[OpenSeadragon.converter.convert] Conversion ${from} ---> ${to} cannot be done!`);
             return $.Promise.resolve();
         }
@@ -618,7 +639,14 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
     copy(tile, data, type) {
         const copyTransform = this.copyings[type];
         if (copyTransform) {
-            const y = copyTransform(tile, data);
+            let y;
+            try {
+                y = copyTransform(tile, data);
+            } catch (e) {
+                // Callers treat this as a promise-returning function: a synchronous throw would otherwise
+                // escape past them, e.g. out of CacheRecord.getDataAs() itself.
+                return $.Promise.reject(e);
+            }
             return $.type(y) === "promise" ? y : $.Promise.resolve(y);
         }
         $.console.warn(`[OpenSeadragon.converter.copy] is not supported with type %s`, type);

--- a/src/datatypeconverter.js
+++ b/src/datatypeconverter.js
@@ -362,8 +362,11 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
         // An Image can only be built from a URL, so a Blob has to go through a temporary object URL:
         // a data: URL would base64 encode the whole tile, and createImageBitmap() - which needs no URL -
         // produces an imageBitmap instead, which is the cheaper edge registered below anyway.
-        // The URL is not released once the image has decoded: consumers may clone the element, and a
-        // clone loads from its src again. It is released by the image destructor instead.
+        // The URL is released as soon as the image has decoded: no conversion out of the image type needs
+        // the src (drawImage and createImageBitmap both work off the decoded element), copying an image
+        // hands back the same element, and the HTML drawer places that very element in the DOM rather
+        // than a clone. Deferring the release to a destructor would both keep every blob alive for the
+        // lifetime of the cache and force it to guess, from the src alone, which images it owns.
         this.learn("rasterBlob", "image", (tile, blob) => new $.Promise((resolve, reject) => {
             if (!$.supportsAsync) {
                 return reject("Not supported in sync mode!");
@@ -373,11 +376,13 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
             const url = urlApi.createObjectURL(blob);
             const img = new Image();
             img.onerror = img.onabort = e => {
-                // Nothing will ever own this image, so the destructor cannot run for it: release here.
                 urlApi.revokeObjectURL(url);
                 reject(e);
             };
-            img.onload = () => resolve(img);
+            img.onload = () => {
+                urlApi.revokeObjectURL(url);
+                resolve(img);
+            };
             img.decoding = 'async';
             img.src = url;
             return undefined;
@@ -463,18 +468,6 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
         this.learnDestroy("imageBitmap", bmp => {
             if (bmp && typeof bmp.close === 'function') {
                 bmp.close();
-            }
-        });
-        /**
-         * Release the object URL an image was decoded from, if any. It cannot be released earlier: an
-         * image element may be cloned by a consumer (the HTML drawer does), and the clone loads from
-         * the very same src. Copying the image type hands back the same element rather than a second
-         * one, so exactly one destructor call exists per object URL.
-         */
-        this.learnDestroy("image", image => {
-            if (image && typeof image.src === "string" && image.src.indexOf("blob:") === 0) {
-                // eslint-disable-next-line compat/compat
-                (window.URL || window.webkitURL).revokeObjectURL(image.src);
             }
         });
     }

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -134,7 +134,15 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
             }
         }
 
-        $.converter.learnDestroy(HTMLDrawer.canvasCacheType, _freeTile);
+        // The canvas is a copy this cache owns exclusively - the way back out copies again - so its
+        // bitmap can be released here. Detaching the node only makes it collectable eventually, and
+        // Safari holds canvas memory until width and height are set to zero.
+        $.converter.learnDestroy(HTMLDrawer.canvasCacheType, data => {
+            _freeTile(data);
+            data.data.width = 0;
+            data.data.height = 0;
+        });
+        // The image type holds an element owned by the 'image' cache it came from, so it is only detached.
         $.converter.learnDestroy(HTMLDrawer.imageCacheType, _freeTile);
     }
 

--- a/src/htmldrawer.js
+++ b/src/htmldrawer.js
@@ -69,10 +69,10 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
         // Since the tile-drawn event is fired by this drawer, make sure handlers can be added for it
         this.viewer.allowEventHandler("tile-drawn");
 
-        // works with canvas & image objects
-        function _prepareTile(tile, data) {
+        // Wrap the node to be placed in the DOM: the positioning happens at draw time, but the elements
+        // themselves are built here, when the cache is created.
+        function _wrapTile(imgElement, data) {
             const element = $.makeNeutralElement( "div" );
-            const imgElement = data.cloneNode();
             imgElement.style.msInterpolationMode = "nearest-neighbor";
             imgElement.style.width = "100%";
             imgElement.style.height = "100%";
@@ -85,15 +85,44 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
             };
         }
 
-        // In theory, HTML drawer should cope well with canvas node type too,
-        // but tests fail - if this conversion is used, it outputs uninitialized zeroed data
-        // (data manipulation test module).
+        // The image is placed in the DOM as-is rather than cloned. cloneNode() only carries over the
+        // src, so the clone has to load all over again - and by the time it does, the conversion has
+        // already destroyed the source, which releases the object URL a Blob-decoded image loads from.
+        // The element is already decoded, so reusing it needs no URL and no second decode.
+        function _prepareImageTile(tile, data) {
+            return _wrapTile(data, data);
+        }
 
-        // The actual placing logics will not happen at draw event, but when the cache is created:
-        // $.converter.learn("context2d", HTMLDrawer.canvasCacheType, (t, d) => _prepareTile(t, d.canvas), 1, 1);
-        $.converter.learn("image", HTMLDrawer.imageCacheType, _prepareTile, 1, 1);
+        function _copyCanvas(source) {
+            const canvas = document.createElement( "canvas" );
+            canvas.width = source.width;
+            canvas.height = source.height;
+            canvas.getContext('2d').drawImage(source, 0, 0);
+            return canvas;
+        }
+
+        // A canvas cannot be handled the same way as an image: cloneNode() on a canvas copies attributes
+        // only and never the bitmap, and the source context2d is destroyed - its canvas resized to zero -
+        // as soon as this conversion step returns. So the pixels have to be copied out right here, and
+        // that copy is then both the node placed in the DOM and the data this cache holds.
+        function _prepareCanvasTile(tile, context) {
+            const canvas = _copyCanvas(context.canvas);
+            return _wrapTile(canvas, canvas);
+        }
+
+        // Going back has to copy as well, rather than handing out a context on the canvas that is live in
+        // the DOM: the receiver owns what it gets, and the context2d destructor resizes its canvas to zero,
+        // which would blank the tile this drawer is currently displaying.
+        function _canvasTileToContext(tile, data) {
+            return _copyCanvas(data.data).getContext('2d');
+        }
+
+        // Accepting context2d directly matters for performance: reaching the image type from a canvas
+        // means encoding the tile (toBlob) and decoding it again, whereas this is a single drawImage.
+        $.converter.learn("context2d", HTMLDrawer.canvasCacheType, _prepareCanvasTile, 1, 1);
+        $.converter.learn("image", HTMLDrawer.imageCacheType, _prepareImageTile, 1, 1);
         // Also learn how to move back, since these elements can be just used as-is
-        // $.converter.learn(HTMLDrawer.canvasCacheType, "context2d", (t, d) => d.data.getContext('2d'), 1, 3);
+        $.converter.learn(HTMLDrawer.canvasCacheType, "context2d", _canvasTileToContext, 1, 3);
         $.converter.learn(HTMLDrawer.imageCacheType, "image", (t, d) => d.data, 1, 3);
 
         function _freeTile(data) {
@@ -105,7 +134,7 @@ class HTMLDrawer extends OpenSeadragon.DrawerBase{
             }
         }
 
-        // $.converter.learnDestroy(HTMLDrawer.canvasCacheType, _freeTile);
+        $.converter.learnDestroy(HTMLDrawer.canvasCacheType, _freeTile);
         $.converter.learnDestroy(HTMLDrawer.imageCacheType, _freeTile);
     }
 

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -3053,35 +3053,35 @@ function OpenSeadragon( options ){
             this.__value = undefined;
 
             try {
-                // Make sure to unwrap all nested promises!
                 handler(
-                    (value) => {
-                        while (value instanceof $.Promise) {
-                            value = value._value;
-                        }
-                        this._value = value;
-                    },
-                    (error) => {
-                        while (error instanceof $.Promise) {
-                            error = error._value;
-                        }
-                        this._value = error;
-                        this._error = true;
-                    }
+                    (value) => this._adopt(value, false),
+                    (error) => this._adopt(error, true)
                 );
             } catch (e) {
-                this._value = e;
-                this._error = true;
+                this._adopt(e, true);
             }
+        }
+
+        /**
+         * Unwrap all nested promises and take over both the value and the rejected state: a handler
+         * returning a rejected promise has to reject the chain, as it does natively.
+         * @private
+         */
+        _adopt(value, isError) {
+            while (value instanceof $.Promise) {
+                isError = isError || value._error;
+                value = value.__value;
+            }
+            this.__value = value;
+            this._error = !!isError;
         }
 
         then(handler) {
             if (!this._error) {
                 try {
-                    this._value = handler(this._value);
+                    this._adopt(handler(this._value), false);
                 } catch (e) {
-                    this._value = e;
-                    this._error = true;
+                    this._adopt(e, true);
                 }
             }
             return this;
@@ -3090,24 +3090,25 @@ function OpenSeadragon( options ){
         catch(handler) {
             if (this._error) {
                 try {
-                    this._value = handler(this._value);
-                    this._error = false;
+                    this._adopt(handler(this._value), false);
                 } catch (e) {
-                    this._value = e;
-                    this._error = true;
+                    this._adopt(e, true);
                 }
             }
             return this;
         }
 
         finally(handler) {
-            // Runs whichever way the chain went, and passes the outcome through untouched: only a
-            // throw from the handler itself replaces it, as with the native implementation.
+            // Runs whichever way the chain went, and passes the outcome through untouched: only a throw
+            // from the handler, or a rejected promise it returns, replaces it - as natively. A fulfilled
+            // result is discarded.
             try {
-                handler();
+                const result = handler();
+                if (result instanceof $.Promise && result._error) {
+                    this._adopt(result, true);
+                }
             } catch (e) {
-                this._value = e;
-                this._error = true;
+                this._adopt(e, true);
             }
             return this;
         }
@@ -3116,10 +3117,7 @@ function OpenSeadragon( options ){
             return this.__value;
         }
         set _value(val) {
-            if (val && val.constructor === this.constructor) {
-                val = val._value; //unwrap
-            }
-            this.__value = val;
+            this._adopt(val, this._error);
         }
 
         static resolve(value) {

--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -572,7 +572,27 @@
   *     sharper data as they navigate, since during zoom we have already one level
   *     up loaded. If you experience high network traffic/latency, you might want
   *     to set this value to 1.0 (~fetch at most identical pixel size) or higher
-  *     to force upsampling.
+  *     to force upsampling.<br><br>
+  *     This option is what sets the range of scale factors tiles are drawn at.
+  *     A level is rejected once it falls below minPixelRatio, and on a pyramid
+  *     halving each level the next finer one sits at half the ratio, so the
+  *     sharpest level being drawn always lands in
+  *     <code>[minPixelRatio, 2 * minPixelRatio)</code>:
+  *     <ul>
+  *       <li><code>0.5</code> (default) gives <code>[0.5, 1.0)</code>: always
+  *         minified, never drawn pixel for pixel, favouring one level of
+  *         preloading over sharpness.</li>
+  *       <li><code>1 / Math.SQRT2</code> (~0.707) gives
+  *         <code>[0.707, 1.414)</code>, centred on 1.0 - the least total
+  *         resampling, and the least aliasing on detailed images.</li>
+  *       <li><code>1.0</code> gives <code>[1.0, 2.0)</code>: never minified,
+  *         always magnified, at the lowest bandwidth of the three.</li>
+  *     </ul>
+  *     The ratio is measured in <b>device</b> pixels, not CSS pixels:
+  *     $.pixelDensityRatio is part of it, so the same setting fetches a finer
+  *     level on a high density display than on a standard one. The two levels
+  *     bypassing this gate are the minimum level and the cut-off level, which
+  *     are always drawn so that something covers the viewport.
   *
   * @property {Number} [discardLevelsBelowDownsampleRatio=1]
   *     You can force the viewer to skip levels that have smaller pixel ratio
@@ -3076,6 +3096,18 @@ function OpenSeadragon( options ){
                     this._value = e;
                     this._error = true;
                 }
+            }
+            return this;
+        }
+
+        finally(handler) {
+            // Runs whichever way the chain went, and passes the outcome through untouched: only a
+            // throw from the handler itself replaces it, as with the native implementation.
+            try {
+                handler();
+            } catch (e) {
+                this._value = e;
+                this._error = true;
             }
             return this;
         }

--- a/src/tilecache.js
+++ b/src/tilecache.js
@@ -772,8 +772,15 @@
         }
 
         _triggerNeedsDraw() {
-            if (this._tiles.length > 0) {
-                this._tiles[0].tiledImage.viewer.forceRedraw();
+            // A tile unloaded while an asynchronous plugin was still working keeps referencing this
+            // record, but its tiledImage is gone by then - so look for one that can still draw rather
+            // than assuming the first one can.
+            for (const tile of this._tiles || []) {
+                const tiledImage = tile.tiledImage;
+                if (tiledImage && tiledImage.viewer) {
+                    tiledImage.viewer.forceRedraw();
+                    return;
+                }
             }
         }
 
@@ -887,6 +894,19 @@
          */
         _handleConversionError(e) {
             $.console.error("[CacheRecord] Conversion/preparation error:", e);
+
+            // Release what the record still holds before losing the reference to it: destroy() is a no-op
+            // once _destroyed is set, so this is the last chance to run the destructors. Read paths such
+            // as getDataAs() do not consume their input, so the data here is often still the live one.
+            if (this._data !== null && this._data !== undefined) {
+                try {
+                    $.converter.destroy(this._data, this._type);
+                } catch (destroyError) {
+                    $.console.error("[CacheRecord] data destroy threw while handling a conversion error:",
+                        destroyError);
+                }
+            }
+            this.destroyInternalCache();
 
             this._destroyed = true;
             this.loaded = false;
@@ -1152,6 +1172,8 @@
                     oldKey, newKey);
                 return null; // do not remove, we perform additional fixes on caches later on when swap occurred
             } else {
+                // As in injectCache: a zombie under the target key is superseded by this record.
+                this._discardZombie(newKey);
                 this._cachesLoaded[newKey] = originalCache;
                 delete this._cachesLoaded[oldKey];
             }
@@ -1209,6 +1231,8 @@
          * @param {Boolean} options.tileAllowNotLoaded - if true, tile that is not loaded is also processed,
          *   this is internal parameter used in tile-loaded completion routine, as we need to prepare tile but
          *   it is not yet loaded and cannot be marked as so (otherwise the system would think it is ready)
+         * @return {Boolean} true if the cache was installed, false if it was refused - the caller keeps
+         *   ownership of a refused cache and is responsible for destroying it
          * @private
          */
         injectCache(options) {
@@ -1216,7 +1240,7 @@
                 tile = options.tile;
             if (!options.tileAllowNotLoaded && !tile.loaded && !tile.loading) {
                 $.console.warn("Attempt to inject cache on tile in invalid state: this is probably a bug!");
-                return;
+                return false;
             }
             const consumer = this._cachesLoaded[targetKey];
             if (consumer) {
@@ -1231,6 +1255,14 @@
             }
 
             const cache = options.cache;
+            // A zombie may still hold the previous data under this key; it is superseded by what we
+            // are about to install, and keeping it would leave two records competing for one key.
+            this._discardZombie(targetKey);
+            // The unload above already decremented for the consumer it removed, so the replacement has
+            // to be counted here. Guarded, so that the error path above cannot count the same key twice.
+            if (!this._cachesLoaded[targetKey]) {
+                this._cachesLoadedCount++;
+            }
             this._cachesLoaded[targetKey] = cache;
             cache._ownerTileCache = this;
             cache.cacheKey = targetKey;
@@ -1239,6 +1271,7 @@
             for (const t of tile.getCache(tile.originalCacheKey)._tiles) {  // grab all cache-equal tiles
                 t.setCache(targetKey, cache, options.setAsMainCache, false);
             }
+            return true;
         }
 
         /**
@@ -1448,8 +1481,15 @@
             for (const zombie in this._zombiesLoaded) {
                 this._zombiesLoaded[zombie].destroy();
             }
-            for (const tile in this._tilesLoaded) {
+            // _tilesLoaded is a real array: for..in would hand out index strings instead of tiles, and
+            // every tile would be skipped without unloading a single cache.
+            for (const tile of this._tilesLoaded) {
                 this._unloadTile(tile, true);
+            }
+            // Records holding no tiles are not reachable through the loop above, and dropping the map
+            // without destroying them would strand their data - canvases, bitmaps, GPU textures.
+            for (const key in this._cachesLoaded) {
+                this._cachesLoaded[key].destroy();
             }
             this._tilesLoaded = [];
             this._zombiesLoaded = [];
@@ -1464,12 +1504,14 @@
          */
         clearDrawerInternalCache(drawer) {
             const drawerId = drawer.getId();
-            for (const zombie of this._zombiesLoaded) {
+            for (const key in this._zombiesLoaded) {
+                const zombie = this._zombiesLoaded[key];
                 if (zombie) {
                     zombie.destroyInternalCache(drawerId);
                 }
             }
-            for (const cache of this._cachesLoaded) {
+            for (const key in this._cachesLoaded) {
+                const cache = this._cachesLoaded[key];
                 if (cache) {
                     cache.destroyInternalCache(drawerId);
                 }
@@ -1500,6 +1542,21 @@
         }
 
         /**
+         * Release a zombie parked under a key that a live record is about to take over. Leaving it
+         * behind leaks the record, and makes two entries compete for a single key.
+         * @param {string} key
+         * @private
+         */
+        _discardZombie(key) {
+            const zombie = this._zombiesLoaded[key];
+            if (zombie) {
+                delete this._zombiesLoaded[key];
+                this._zombiesLoadedCount--;
+                zombie.destroy();
+            }
+        }
+
+        /**
          * Delete cache safely from the system if it is not needed
          * @param {OpenSeadragon.CacheRecord} cache
          */
@@ -1509,6 +1566,7 @@
                     const c = this._zombiesLoaded[i];
                     if (c === cache) {
                         delete this._zombiesLoaded[i];
+                        this._zombiesLoadedCount--;
                         c.destroy();
                         return;
                     }
@@ -1537,8 +1595,17 @@
                             cacheRecord.destroy();
                         } else {
                             // #2 Tile is a zombie. Do not delete record, reuse.
-                            this._zombiesLoaded[key] = cacheRecord;
-                            this._zombiesLoadedCount++;
+                            // Count only a genuinely new entry, and never silently drop a zombie
+                            // already parked here - that would leak it and inflate the counter.
+                            const previous = this._zombiesLoaded[key];
+                            if (previous !== cacheRecord) {
+                                if (previous) {
+                                    previous.destroy();
+                                } else {
+                                    this._zombiesLoadedCount++;
+                                }
+                                this._zombiesLoaded[key] = cacheRecord;
+                            }
                         }
                         // Either way clear cache
                         delete this._cachesLoaded[key];

--- a/src/tiledimage.js
+++ b/src/tiledimage.js
@@ -1523,7 +1523,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                 false
             ).x * this._scaleSpring.current.value;
 
-            const levelOpacity = Math.min(1, (currentRenderPixelRatio - 0.5) / 0.5);
+            const levelOpacity = this._getLevelOpacity(currentRenderPixelRatio);
             const levelVisibility = optimalRatio / Math.abs(
                 optimalRatio - targetRenderPixelRatio
             );
@@ -1578,7 +1578,7 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                 ).x * this._scaleSpring.current.value;
 
             const optimalRatio = this.immediateRender ? 1 : targetZeroRatio;
-            const levelOpacity = Math.min(1, (currentRenderPixelRatio - 0.5) / 0.5);
+            const levelOpacity = this._getLevelOpacity(currentRenderPixelRatio);
             const levelVisibility = optimalRatio / Math.abs(
                 optimalRatio - targetRenderPixelRatio
             );
@@ -1667,6 +1667,23 @@ $.extend($.TiledImage.prototype, $.EventSource.prototype, /** @lends OpenSeadrag
                 }
             }
         }
+    },
+
+    /**
+     * Opacity ramp applied to a level when alwaysBlend is set: a level fades in across the scale range it
+     * is actually drawn at. Level selection keeps that range at [minPixelRatio, 2 * minPixelRatio), so the
+     * ramp is derived from minPixelRatio rather than assuming its default value. Levels drawn outside that
+     * range - the minimum level and the cut-off level, which bypass the selection gate - are clamped.
+     * @param {Number} currentRenderPixelRatio device pixels per source pixel at the level being drawn
+     * @returns {Number} opacity in [0, 1]
+     * @private
+     */
+    _getLevelOpacity: function( currentRenderPixelRatio ) {
+        const minRatio = this.minPixelRatio;
+        if ( minRatio <= 0 ) {
+            return 1;
+        }
+        return Math.max( 0, Math.min( 1, ( currentRenderPixelRatio - minRatio ) / minRatio ) );
     },
 
     /**

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -190,18 +190,21 @@
         }
 
         /**
-         * Apply anisotropic filtering to the currently bound texture if available
+         * Apply anisotropic filtering to the currently bound texture if available. Always writes the
+         * parameter, never skips: the render target is created once and updated in place, so leaving a
+         * previous value behind would keep averaging samples under minification with smoothing off,
+         * which is exactly what NEAREST is asked to avoid.
          * @private
          */
         _applyAnisotropy() {
-            if (!this._imageSmoothingEnabled || !this._extTextureFilterAnisotropic || this._maxAnisotropy <= 0) {
+            if (!this._extTextureFilterAnisotropic || !(this._maxAnisotropy > 0)) {
                 return;
             }
             const gl = this._gl;
             gl.texParameterf(
                 gl.TEXTURE_2D,
                 this._extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT,
-                Math.min(4, this._maxAnisotropy)
+                this._imageSmoothingEnabled ? Math.min(4, this._maxAnisotropy) : 1
             );
         }
 

--- a/src/webgldrawer.js
+++ b/src/webgldrawer.js
@@ -206,6 +206,34 @@
         }
 
         /**
+         * Apply the current filter to the texture the caller has already bound, magnification included.
+         * Tile textures and the render-to-texture target must agree, since the second rendering pass
+         * samples the target rather than the tiles.
+         * @private
+         */
+        _applyTextureFilter() {
+            const gl = this._gl;
+            const filter = this.getTextureFilter();
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
+            this._applyAnisotropy();
+        }
+
+        /**
+         * Same, for the paths that do not already have the render target bound.
+         * @private
+         */
+        _applyRenderTargetFilter() {
+            const gl = this._gl;
+            if (!gl || !this._renderToTexture) {
+                return;
+            }
+            gl.activeTexture(gl.TEXTURE0);
+            gl.bindTexture(gl.TEXTURE_2D, this._renderToTexture);
+            this._applyTextureFilter();
+        }
+
+        /**
          * Set up the renderer: create shaders, textures, and framebuffers
          * @param {Number} width - Canvas width
          * @param {Number} height - Canvas height
@@ -228,8 +256,7 @@
             gl.activeTexture(gl.TEXTURE0);
             gl.bindTexture(gl.TEXTURE_2D, this._renderToTexture);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.getTextureFilter());
-            this._applyAnisotropy();
+            this._applyTextureFilter();
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
@@ -267,8 +294,7 @@
             gl.activeTexture(gl.TEXTURE0);
             gl.bindTexture(gl.TEXTURE_2D, this._renderToTexture);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.getTextureFilter());
-            this._applyAnisotropy();
+            this._applyTextureFilter();
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
@@ -295,9 +321,9 @@
             gl.bindTexture(gl.TEXTURE_2D, texture);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.getTextureFilter());
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.getTextureFilter());
-            this._applyAnisotropy();
+            // The texture is bound right above, so this is the params-only variant - and it runs for
+            // every tile, which is why the filter is read once rather than twice.
+            this._applyTextureFilter();
 
             try {
                 const unpackPremultipliedAlpha = options.unpackWithPremultipliedAlpha !== undefined ?
@@ -327,7 +353,16 @@
          * @param {Boolean} enabled - Whether image smoothing is enabled
          */
         setImageSmoothingEnabled(enabled) {
-            this._imageSmoothingEnabled = !!enabled;
+            enabled = !!enabled;
+            if (this._imageSmoothingEnabled === enabled) {
+                // Nothing to do, and the render target already carries this filter: never touch GL state
+                // for a setting that did not change, however often this is called.
+                return;
+            }
+            this._imageSmoothingEnabled = enabled;
+            // Tile textures are rebuilt by the caller, but the render target is created once at setup time,
+            // before the viewer gets to pass the option in, so its filter has to be updated in place.
+            this._applyRenderTargetFilter();
         }
 
         /**
@@ -913,6 +948,8 @@
         _getBackupCanvasDrawer(){
             if(!this._backupCanvasDrawer){
                 this._backupCanvasDrawer = this.viewer.requestDrawer('canvas', {mainDrawer: false});
+                // Only the main drawer is handed the viewer option, so pass it on to the fallback as well.
+                this._backupCanvasDrawer.setImageSmoothingEnabled(this._imageSmoothingEnabled);
                 this._backupCanvasDrawer.canvas.style.setProperty('visibility', 'hidden');
                 this._backupCanvasDrawer.getSupportedDataFormats = () => this._supportedFormats;
                 this._backupCanvasDrawer.getDataToDraw = this.getDataToDraw.bind(this);
@@ -1218,16 +1255,38 @@
         // Public API required by all Drawer implementations
         /**
         * Sets whether image smoothing is enabled or disabled
-        * @param {Boolean} enabled If true, uses gl.LINEAR as the TEXTURE_MIN_FILTER and TEXTURE_MAX_FILTER, otherwise gl.NEAREST.
+        * @param {Boolean} enabled If true, uses gl.LINEAR as the TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER,
+        *   otherwise gl.NEAREST. Applies to the tile textures, to the render-to-texture target sampled by
+        *   the second rendering pass, to the 2d contexts used for compositing, and to the fallback drawer.
         */
         setImageSmoothingEnabled(enabled){
+            enabled = !!enabled;
             if( this._imageSmoothingEnabled !== enabled ){
                 this._imageSmoothingEnabled = enabled;
                 if (this._glContext) {
                     this._glContext.setImageSmoothingEnabled(enabled);
                 }
+                this._applyOutputSmoothing();
+                if (this._backupCanvasDrawer) {
+                    this._backupCanvasDrawer.setImageSmoothingEnabled(enabled);
+                }
                 this.setInternalCacheNeedsRefresh();
                 this.viewer.forceRedraw();
+            }
+        }
+
+        /**
+         * Mirror the smoothing setting onto the 2d contexts this drawer composites through, so that they
+         * behave like the CanvasDrawer contexts do.
+         * @private
+         */
+        _applyOutputSmoothing(){
+            const contexts = [this._outputContext, this._clippingContext];
+            for (const context of contexts) {
+                if (context) {
+                    context.msImageSmoothingEnabled = this._imageSmoothingEnabled;
+                    context.imageSmoothingEnabled = this._imageSmoothingEnabled;
+                }
             }
         }
 
@@ -1378,6 +1437,7 @@
             this._clippingContext = this._clippingCanvas.getContext('2d');
             this._renderingCanvas.width = this._clippingCanvas.width = this._outputCanvas.width;
             this._renderingCanvas.height = this._clippingCanvas.height = this._outputCanvas.height;
+            this._applyOutputSmoothing();
 
             // Create WebGL context manager
             this._glContext = new WebglContextManager({
@@ -1405,6 +1465,8 @@
                 _this._renderingCanvas.style.height = _this._outputCanvas.clientHeight + 'px';
                 _this._renderingCanvas.width = _this._clippingCanvas.width = _this._outputCanvas.width;
                 _this._renderingCanvas.height = _this._clippingCanvas.height = _this._outputCanvas.height;
+                // resizing a canvas resets its 2d context state, smoothing included
+                _this._applyOutputSmoothing();
 
                 // important - update the size of the rendering viewport!
                 _this._resizeRenderer();

--- a/src/world.js
+++ b/src/world.js
@@ -334,19 +334,22 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
                 return Promise.resolve();
             }
 
+            const originalCache = tile.getCache(tile.originalCacheKey);
+            // A tile unloaded before it finished loading keeps 'processing' set - it passes the check
+            // above - but it has dropped its tiledImage and its cache references, and records that are
+            // still reachable can be destroyed afterwards. All of this has to be settled before the
+            // tiledImage below is dereferenced.
+            if (!tile.tiledImage || !originalCache || originalCache._destroyed || !originalCache._tiles ||
+                    (originalCache.__invStamp && originalCache.__invStamp >= tStamp)) {
+                return Promise.resolve();
+            }
+
             const tiledImage = tile.tiledImage;
             const drawer = tiledImage.getDrawer();
             // We call the event on the parent viewer window no matter what, nested viewers have parent viewer ref.
             //  we use the knowledge that drawerBase keeps track of parent viewer to register into, we use this ref.
             //  We could turn this into API...
             const eventTarget = drawer._parentViewer || this.viewer;
-            const originalCache = tile.getCache(tile.originalCacheKey);
-            // A tile unloaded before it finished loading keeps its cache references, and those records
-            // can be destroyed afterwards - so the record may still be reachable while being dead.
-            if (!originalCache || originalCache._destroyed || !originalCache._tiles ||
-                    (originalCache.__invStamp && originalCache.__invStamp >= tStamp)) {
-                return Promise.resolve();
-            }
 
 
             let wasOutdatedRun = false;
@@ -630,7 +633,11 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
                     workingCache.destroy();
                     workingCache = null;
                 }
-                originalCache.__finishProcessing();
+                // A throw after the run already finished normally would find the finisher cleared: calling
+                // it then replaces the real error with 'not a function'.
+                if (originalCache.__finishProcessing) {
+                    originalCache.__finishProcessing();
+                }
             }).finally(() => {
                 // Several exits above return before reaching a disposal site - a run that was declared
                 // outdated by a newer one is the common case. Whatever the route, a working cache still

--- a/src/world.js
+++ b/src/world.js
@@ -423,13 +423,19 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
             const atomicCacheSwap = () => {
                 if (workingCache) {
                     const newCacheKey = tile.buildDistinctMainCacheKey();
-                    tiledImage._tileCache.injectCache({
+                    const injected = tiledImage._tileCache.injectCache({
                         tile: tile,
                         cache: workingCache,
                         targetKey: newCacheKey,
                         setAsMainCache: true,
                         tileAllowNotLoaded: tile.loading
                     });
+                    if (injected) {
+                        // The cache belongs to the tile cache now: release our claim so that the cleanup
+                        // below cannot destroy a record that has just been installed. A refused cache
+                        // stays ours, and the cleanup is what frees it.
+                        workingCache = null;
+                    }
                 } else if (restoreTiles) {
                     // If we requested restore, perform now
                     tiledImage._tileCache.restoreTilesThatShareOriginalCache(tile, tile.getCache(tile.originalCacheKey), true);
@@ -624,6 +630,14 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
                     workingCache = null;
                 }
                 originalCache.__finishProcessing();
+            }).finally(() => {
+                // Several exits above return before reaching a disposal site - a run that was declared
+                // outdated by a newer one is the common case. Whatever the route, a working cache still
+                // held here was never installed, and it owns data nobody else will release.
+                if (workingCache) {
+                    workingCache.destroy();
+                    workingCache = null;
+                }
             });
         });
 

--- a/src/world.js
+++ b/src/world.js
@@ -341,9 +341,10 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
             //  We could turn this into API...
             const eventTarget = drawer._parentViewer || this.viewer;
             const originalCache = tile.getCache(tile.originalCacheKey);
-            const tileCache = tile.getCache(tile.originalCacheKey);
-            if (tileCache.__invStamp && tileCache.__invStamp >= tStamp) {
-                // OpenSeadragon.trace(`Ignoring tile - old,  ${tile ? tile.toString() : 'null'} tstamp ${tStamp}`);
+            // A tile unloaded before it finished loading keeps its cache references, and those records
+            // can be destroyed afterwards - so the record may still be reachable while being dead.
+            if (!originalCache || originalCache._destroyed || !originalCache._tiles
+                    || (originalCache.__invStamp && originalCache.__invStamp >= tStamp)) {
                 return Promise.resolve();
             }
 

--- a/src/world.js
+++ b/src/world.js
@@ -343,8 +343,8 @@ $.extend( $.World.prototype, $.EventSource.prototype, /** @lends OpenSeadragon.W
             const originalCache = tile.getCache(tile.originalCacheKey);
             // A tile unloaded before it finished loading keeps its cache references, and those records
             // can be destroyed afterwards - so the record may still be reachable while being dead.
-            if (!originalCache || originalCache._destroyed || !originalCache._tiles
-                    || (originalCache.__invStamp && originalCache.__invStamp >= tStamp)) {
+            if (!originalCache || originalCache._destroyed || !originalCache._tiles ||
+                    (originalCache.__invStamp && originalCache.__invStamp >= tStamp)) {
                 return Promise.resolve();
             }
 

--- a/test/demo/tilecache-pipeline-audit.html
+++ b/test/demo/tilecache-pipeline-audit.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OpenSeadragon TileCache Pipeline Audit Demo</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <style type="text/css">
+
+      .openseadragon1 {
+          width: 800px;
+          height: 600px;
+          border: 1px solid #ccc;
+      }
+
+      fieldset {
+          display: inline-block;
+          vertical-align: top;
+          margin: 0 6px 6px 0;
+      }
+
+      #report {
+          font-family: monospace;
+          font-size: 12px;
+          white-space: pre;
+          margin-top: 8px;
+      }
+
+      .bad {
+          color: #b00;
+          font-weight: bold;
+      }
+
+    </style>
+</head>
+<body>
+    <div>
+        Demo page that keeps the v6 cache/conversion pipeline busy and continuously checks TileCache
+        invariants. Unlike the failure stress demo, nothing here is deliberately broken: every operation is
+        legal, so any invariant violation reported below is a real bug.
+        <br>
+        The pressure comes from a small cache limit (constant eviction), tile data being round-tripped
+        through a different data type every round, and optional drawer switching, which changes the data
+        format every cache has to be converted into.
+        <br>
+        Besides the invariants, it also measures data leaks - a record dropped without its destructor
+        running, which leaves a canvas unreleased, an ImageBitmap unclosed or an object URL unrevoked.
+        Those records are unreachable by then, so they are counted rather than inspected: watch that
+        <code>records live</code> tracks <code>registered</code>, and that <code>data held</code>
+        plateaus instead of climbing.
+    </div>
+
+    <fieldset>
+        <legend>Pressure</legend>
+        <label>cache limit <input type="number" id="cacheLimit" min="1" max="500" step="1" value="12"></label><br>
+        <label><input type="checkbox" id="pluginOn" checked> round-trip data through a type each round</label><br>
+        <label><input type="checkbox" id="cycleDrawers"> cycle drawers (webgl/canvas/html)</label><br>
+        <label>restore original every <input type="number" id="restoreEvery" min="0" max="50" step="1" value="7"> rounds
+            (0 = never)</label>
+    </fieldset>
+
+    <fieldset>
+        <legend>Run</legend>
+        <button onclick="startStress()">Start</button>
+        <button onclick="stopStress()">Stop</button>
+        <button onclick="invalidateOnce()">Invalidate once</button>
+        <button onclick="resetItem()">Reset item</button>
+        <button onclick="resetCounters()">Reset counters</button>
+    </fieldset>
+
+    <div id="contentDiv" class="openseadragon1"></div>
+    <pre id="report">not started</pre>
+
+    <script type="text/javascript">
+
+        // A custom data type, so that the demo also covers third-party types: it takes part in the
+        // conversion graph, it can be copied, and it owns memory that has to be released. Counting how
+        // many are created against how many are destroyed turns a cache leak into a visible number.
+        const PROBE = "__demo__probe";
+        let probesCreated = 0, probesDestroyed = 0;
+
+        function copyCanvas(source) {
+            const canvas = document.createElement("canvas");
+            canvas.width = source.width;
+            canvas.height = source.height;
+            canvas.getContext("2d").drawImage(source, 0, 0);
+            return canvas;
+        }
+
+        OpenSeadragon.converter.learn("context2d", PROBE, (tile, ctx) => {
+            probesCreated++;
+            return { canvas: copyCanvas(ctx.canvas) };
+        }, 1, 1);
+        OpenSeadragon.converter.learn(PROBE, "context2d", (tile, probe) => {
+            return copyCanvas(probe.canvas).getContext("2d");
+        }, 1, 1);
+        // Registering a same-type conversion teaches the system how to copy the type. Without it, the
+        // invalidation routine cannot take a working copy of a cache that holds this type.
+        OpenSeadragon.converter.learn(PROBE, PROBE, (tile, probe) => {
+            probesCreated++;
+            return { canvas: copyCanvas(probe.canvas) };
+        }, 1, 1);
+        OpenSeadragon.converter.learnDestroy(PROBE, (probe) => {
+            probesDestroyed++;
+            probe.canvas.width = 0;
+            probe.canvas.height = 0;
+        });
+
+        // Data leaks are invisible to the invariant checks further down: a record that was dropped
+        // without its destructor running is, by definition, no longer reachable to be inspected. So it
+        // has to be counted instead. Cache records are built as new OpenSeadragon.CacheRecord(), looked
+        // up on the namespace at call time, which makes them interceptable from here.
+        let recordsCreated = 0, recordsDestroyed = 0, recordsFailed = 0;
+
+        const BaseCacheRecord = OpenSeadragon.CacheRecord;
+        OpenSeadragon.CacheRecord = class extends BaseCacheRecord {
+            constructor(...args) {
+                super(...args);
+                recordsCreated++;
+            }
+
+            destroy() {
+                if (!this._destroyed) {
+                    recordsDestroyed++;
+                }
+                return super.destroy();
+            }
+
+            _handleConversionError(e) {
+                // This ends the record's life without going through destroy(), so it counts here too.
+                if (!this._destroyed) {
+                    recordsDestroyed++;
+                }
+                // Data still present at this point used to be dropped without being released.
+                if (this._data !== null && this._data !== undefined) {
+                    recordsFailed++;
+                }
+                return super._handleConversionError(e);
+            }
+        };
+
+        // Rough size of what a record holds, so unbounded growth is visible as a number. Only the types
+        // this demo puts into the cache are covered; anything else counts as zero rather than guessing.
+        function estimateBytes(record) {
+            const data = record && record.loaded ? record._data : null;
+            if (!data) {
+                return 0;
+            }
+            switch (record._type) {
+                case "context2d":
+                    return data.canvas.width * data.canvas.height * 4;
+                case "image":
+                    return (data.naturalWidth || 0) * (data.naturalHeight || 0) * 4;
+                case "imageBitmap":
+                    return (data.width || 0) * (data.height || 0) * 4;
+                case "rasterBlob":
+                    return data.size || 0;
+                case PROBE:
+                    return data.canvas.width * data.canvas.height * 4;
+                default:
+                    // The html drawer wraps its node in {element, imgElement, data}
+                    if (data.data) {
+                        return (data.data.width || 0) * (data.data.height || 0) * 4;
+                    }
+                    return 0;
+            }
+        }
+
+        // Types the tile data is pushed through, one per round. Each of them reaches the drawer over a
+        // different path, and each has its own destructor behaviour.
+        const TYPE_CYCLE = ["context2d", "imageBitmap", "rasterBlob", "image", PROBE];
+        const DRAWER_CYCLE = ["webgl", "canvas", "html"];
+
+        const stress = {
+            timer: null,
+            round: 0,
+            pluginOn: true,
+            cycleDrawers: false,
+            restoreEvery: 7,
+            pluginErrors: 0,
+            restores: 0
+        };
+
+        const viewer = window.viewer = OpenSeadragon({
+            id: "contentDiv",
+            prefixUrl: "../../build/openseadragon/images/",
+            tileSources: "../data/testpattern.dzi",
+            // Deliberately tiny, so records are evicted (or turned into zombies) while conversions of the
+            // very same records are still in flight.
+            maxImageCacheCount: 12,
+            showNavigator: true
+        });
+
+        viewer.addHandler('tile-invalidated', async (e) => {
+            if (!stress.pluginOn) {
+                return;
+            }
+            try {
+                if (stress.restoreEvery > 0 && stress.round % stress.restoreEvery === 0) {
+                    // Drops the working data and puts the tile back to its original cache.
+                    stress.restores++;
+                    e.resetData();
+                    return;
+                }
+
+                const ctx = await e.getData('context2d');
+                if (!ctx) {
+                    return;
+                }
+                ctx.fillStyle = "rgba(0, 128, 255, 0.12)";
+                ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+                await e.setData(ctx, 'context2d');
+
+                // Round-trip through the type of this round, so the main cache ends up holding it and the
+                // drawer has to convert it back into something it can render.
+                const target = TYPE_CYCLE[stress.round % TYPE_CYCLE.length];
+                if (target !== 'context2d') {
+                    const converted = await e.getData(target);
+                    if (converted !== undefined && converted !== null) {
+                        await e.setData(converted, target);
+                    }
+                }
+            } catch (error) {
+                stress.pluginErrors++;
+                OpenSeadragon.console.error("demo plugin failed:", error);
+            }
+        });
+
+        function readSettings() {
+            stress.pluginOn = document.getElementById('pluginOn').checked;
+            stress.cycleDrawers = document.getElementById('cycleDrawers').checked;
+            stress.restoreEvery = Number(document.getElementById('restoreEvery').value) || 0;
+            const limit = Number(document.getElementById('cacheLimit').value) || 12;
+            viewer.tileCache._maxCacheItemCount = limit;
+        }
+
+        function startStress() {
+            if (stress.timer) {
+                return;
+            }
+            readSettings();
+            stress.timer = setInterval(() => {
+                stress.round++;
+                readSettings();
+
+                // Keep tiles entering and leaving the viewport, so the cache keeps evicting.
+                const viewport = viewer.viewport;
+                if (viewport) {
+                    const zoom = viewport.getZoom(true);
+                    const factor = 1 + (Math.random() - 0.5) * 0.25;
+                    viewport.zoomTo(Math.max(0.5, Math.min(12, zoom * factor)), null, true);
+                    viewport.panBy(new OpenSeadragon.Point(
+                        (Math.random() - 0.5) * 0.05,
+                        (Math.random() - 0.5) * 0.05
+                    ), true);
+                }
+
+                if (stress.cycleDrawers && stress.round % 10 === 0) {
+                    // Note: browsers cap the number of live WebGL contexts, so repeated switching may drop
+                    // the oldest one. That is a browser limit, not a cache problem.
+                    const next = DRAWER_CYCLE[(stress.round / 10) % DRAWER_CYCLE.length];
+                    viewer.requestDrawer(next, { mainDrawer: true });
+                }
+
+                viewer.requestInvalidate();
+            }, 300);
+            report();
+        }
+
+        function stopStress() {
+            if (stress.timer) {
+                clearInterval(stress.timer);
+                stress.timer = null;
+            }
+            report();
+        }
+
+        function invalidateOnce() {
+            readSettings();
+            stress.round++;
+            viewer.requestInvalidate();
+        }
+
+        function resetItem() {
+            const item = viewer.world.getItemAt(0);
+            if (item) {
+                item.reset();
+            }
+        }
+
+        function resetCounters() {
+            probesCreated = 0;
+            probesDestroyed = 0;
+            recordsCreated = 0;
+            recordsDestroyed = 0;
+            recordsFailed = 0;
+            stress.pluginErrors = 0;
+            stress.restores = 0;
+            violations.length = 0;
+            report();
+        }
+
+        const violations = [];
+
+        function describeTile(tile) {
+            return tile ? `${tile.level}/${tile.x}-${tile.y}` : "<no tile>";
+        }
+
+        // The navigator runs the Viewer constructor, so it owns a second, completely separate TileCache.
+        // Auditing only the main one would leave its records looking like they had leaked, since the
+        // record counters above cover every cache in the page.
+        function tileCaches() {
+            const caches = [];
+            if (viewer.tileCache) {
+                caches.push({ name: "viewer", cache: viewer.tileCache });
+            }
+            if (viewer.navigator && viewer.navigator.tileCache) {
+                caches.push({ name: "navigator", cache: viewer.navigator.tileCache });
+            }
+            return caches;
+        }
+
+        // Every check below is an invariant a cache is supposed to hold at all times, no matter what the
+        // pipeline is doing. They are checked between frames, when the system is expected to be consistent.
+        function auditOne(name, cache, totals) {
+            const problems = [];
+
+            const liveKeys = Object.keys(cache._cachesLoaded);
+            const zombieKeys = Object.keys(cache._zombiesLoaded);
+
+            if (liveKeys.length !== cache._cachesLoadedCount) {
+                problems.push(`live cache counter says ${cache._cachesLoadedCount}, found ${liveKeys.length} records`);
+            }
+            if (zombieKeys.length !== cache._zombiesLoadedCount) {
+                problems.push(`zombie counter says ${cache._zombiesLoadedCount}, found ${zombieKeys.length} records`);
+            }
+
+            const checkRecord = (key, record, kind) => {
+                if (!record) {
+                    problems.push(`${kind} '${key}' is registered but empty`);
+                    return;
+                }
+                if (record._destroyed) {
+                    problems.push(`${kind} '${key}' is destroyed but still registered`);
+                }
+                for (const tile of record._tiles || []) {
+                    if (!tile._caches || tile._caches[key] !== record) {
+                        problems.push(`${kind} '${key}' claims tile ${describeTile(tile)}, which does not point back`);
+                    }
+                }
+            };
+            liveKeys.forEach(key => checkRecord(key, cache._cachesLoaded[key], "cache"));
+            zombieKeys.forEach(key => checkRecord(key, cache._zombiesLoaded[key], "zombie"));
+
+            // A record is only turned into a zombie once its last tile is gone, so a zombie that still
+            // references tiles means a tile was dropped without being detached.
+            zombieKeys.forEach(key => {
+                const record = cache._zombiesLoaded[key];
+                const count = record && record._tiles ? record._tiles.length : 0;
+                if (count) {
+                    problems.push(`zombie '${key}' still references ${count} tile(s)`);
+                }
+            });
+
+            for (const tile of cache._tilesLoaded) {
+                if (!tile.exists) {
+                    totals.unrecoverable++;
+                }
+                const main = tile.getCache ? tile.getCache() : null;
+                if (tile.loaded && !main) {
+                    problems.push(`tile ${describeTile(tile)} is loaded but has no main cache`);
+                } else if (main && main._destroyed) {
+                    problems.push(`tile ${describeTile(tile)} points at a destroyed cache`);
+                }
+            }
+
+            for (const problem of problems) {
+                // Name the cache, so a violation says which one it came from.
+                const message = `[${name}] ${problem}`;
+                if (violations.indexOf(message) === -1) {
+                    violations.push(message);
+                }
+            }
+
+            const collect = (record) => {
+                totals.bytes += estimateBytes(record);
+                for (const tile of (record && record._tiles) || []) {
+                    totals.tilesWithCaches.add(tile);
+                }
+            };
+            liveKeys.forEach(key => collect(cache._cachesLoaded[key]));
+            zombieKeys.forEach(key => collect(cache._zombiesLoaded[key]));
+
+            totals.registered += liveKeys.length + zombieKeys.length;
+            totals.tiles += cache._tilesLoaded.length;
+
+            return {
+                name: name,
+                live: liveKeys.length,
+                zombies: zombieKeys.length,
+                limit: cache._maxCacheItemCount
+            };
+        }
+
+        function audit() {
+            const totals = {
+                registered: 0,
+                tiles: 0,
+                bytes: 0,
+                unrecoverable: 0,
+                tilesWithCaches: new Set()
+            };
+            const perCache = tileCaches().map(entry => auditOne(entry.name, entry.cache, totals));
+
+            return {
+                perCache: perCache,
+                tiles: totals.tiles,
+                unrecoverable: totals.unrecoverable,
+                registered: totals.registered,
+                bytes: totals.bytes,
+                tilesWithCaches: totals.tilesWithCaches.size
+            };
+        }
+
+        function report() {
+            const state = audit();
+            const lines = [];
+            lines.push(`running        ${stress.timer ? "yes" : "no"}   round ${stress.round}`);
+            lines.push(`drawer         ${viewer.drawer ? viewer.drawer.getType() : "?"}`);
+            lines.push(`next type      ${TYPE_CYCLE[stress.round % TYPE_CYCLE.length]}`);
+            lines.push("");
+            // One line per cache: the navigator owns a separate one, and the limit applies to each.
+            for (const entry of state.perCache) {
+                lines.push(`caches ${entry.name.padEnd(8)}${entry.live} live, ${entry.zombies} zombie (limit ${entry.limit})`);
+            }
+            // A tile holding caches but missing from the tracked list cannot be picked for eviction,
+            // so the two numbers drifting apart explains a cache that grows past its limit.
+            lines.push(`tiles          ${state.tilesWithCaches} holding caches, ${state.tiles} tracked for eviction`);
+            lines.push(`restores       ${stress.restores}`);
+            lines.push(`plugin errors  ${stress.pluginErrors}`);
+            lines.push("");
+            // Records dropped without destroy() are unreachable, so they can only be counted, never
+            // inspected. 'live' should track 'registered'; a gap that keeps growing means records are
+            // being lost. A small, fluctuating gap is normal - working caches are real records that are
+            // deliberately never registered with the TileCache.
+            lines.push(`records        ${recordsCreated} created, ${recordsDestroyed} destroyed, ${recordsCreated - recordsDestroyed} live`);
+            lines.push(`               ${state.registered} registered across ${state.perCache.length} cache(s)`);
+            // Records alive but in neither map. Working caches are legitimately unregistered, so this
+            // fluctuates while invalidation runs; with the demo stopped it should settle at zero.
+            lines.push(`unaccounted    ${recordsCreated - recordsDestroyed - state.registered}${stress.timer ? " (running - working caches inflate this)" : ""}`);
+            // Not a leak by itself, and not a violation: it counts records whose conversion failed while
+            // they still held data. Those used to be dropped without releasing it.
+            lines.push(`failed mid-conv ${recordsFailed}`);
+            // The figure that shows unbounded growth directly. It should plateau, not climb.
+            lines.push(`data held      ~${(state.bytes / (1024 * 1024)).toFixed(1)} MB across ${state.registered} records`);
+            lines.push("");
+            // Should stay bounded. A number that only ever grows means destructors are not running, i.e.
+            // the cache is holding on to data it already replaced.
+            lines.push(`probes         ${probesCreated} created, ${probesDestroyed} destroyed, ${probesCreated - probesDestroyed} live`);
+            // Tiles the cache gave up on. Marking a tile as non-existent is permanent, so this should stay
+            // at zero unless something genuinely failed to load.
+            lines.push(`tiles dropped  ${state.unrecoverable}`);
+            lines.push("");
+
+            if (violations.length) {
+                lines.push(`INVARIANT VIOLATIONS (${violations.length}):`);
+                for (const violation of violations.slice(0, 20)) {
+                    lines.push(`  ${violation}`);
+                }
+            } else {
+                lines.push("no invariant violations so far");
+            }
+
+            const element = document.getElementById('report');
+            element.textContent = lines.join("\n");
+            element.className = violations.length ? "bad" : "";
+        }
+
+        setInterval(report, 500);
+
+    </script>
+</body>
+</html>

--- a/test/demo/tilecache-pipeline-audit.html
+++ b/test/demo/tilecache-pipeline-audit.html
@@ -29,6 +29,12 @@
           font-weight: bold;
       }
 
+      .note {
+          max-width: 46em;
+          margin-top: 6px;
+          color: #555;
+      }
+
     </style>
 </head>
 <body>
@@ -55,6 +61,14 @@
         <label><input type="checkbox" id="cycleDrawers"> cycle drawers (webgl/canvas/html)</label><br>
         <label>restore original every <input type="number" id="restoreEvery" min="0" max="50" step="1" value="7"> rounds
             (0 = never)</label>
+        <div class="note">
+            Leave drawer cycling off when hunting real defects. Switching drawers logs
+            <code>unsupported type ... for the target drawer</code> per tile, by design: a cache is
+            converted for the drawer that was active when it was built, and nothing re-prepares
+            existing caches on a switch - the viewer converts and recovers on the next frame.
+            Browsers also cap the number of live WebGL contexts, so repeated switching may drop the
+            oldest one. Neither is a cache fault.
+        </div>
     </fieldset>
 
     <fieldset>
@@ -287,9 +301,12 @@
         }
 
         function resetCounters() {
-            probesCreated = 0;
+            // Records and probes that are alive right now will still report their destruction, so keep
+            // them as the new created baseline - zeroing both totals would drive the live counts,
+            // reported as created - destroyed, negative as soon as the viewer releases anything.
+            probesCreated -= probesDestroyed;
             probesDestroyed = 0;
-            recordsCreated = 0;
+            recordsCreated -= recordsDestroyed;
             recordsDestroyed = 0;
             recordsFailed = 0;
             stress.pluginErrors = 0;

--- a/test/modules/drawer.js
+++ b/test/modules/drawer.js
@@ -175,6 +175,66 @@
         });
 
         // ----------
+        QUnit.test('imageSmoothingEnabled applies to the sketch canvas', function(assert) {
+            const done = assert.async();
+
+            createViewer({
+                tileSources: '/test/data/testpattern.dzi',
+            });
+            const drawer = viewer.drawer;
+
+            // this test only makes sense for canvas drawer, which is the only one with a sketch canvas
+            if(drawer.getType() !== 'canvas'){
+                assert.expect(0);
+                done();
+                return;
+            }
+
+            let tiledImage;
+            viewer.addHandler('open', function openHandler() {
+                viewer.removeHandler('open', openHandler);
+                // a decimal opacity forces the drawer to render through the sketch canvas
+                viewer.addTiledImage({
+                    tileSource: '/test/data/testpattern.dzi',
+                    opacity: 0.5,
+                    success: function(event) {
+                        tiledImage = event.item;
+                    }
+                });
+            });
+
+            viewer.addHandler('tile-drawn', function drawnHandler(event) {
+                if (tiledImage !== event.tiledImage) {
+                    return;
+                }
+                viewer.removeHandler('tile-drawn', drawnHandler);
+
+                assert.notEqual(drawer.sketchContext, null,
+                    'The sketch context exists once a decimal opacity has been used.');
+
+                drawer.setImageSmoothingEnabled(false);
+                assert.equal(drawer.context.imageSmoothingEnabled, false,
+                    'Disabling smoothing applies to the main context.');
+                assert.equal(drawer.sketchContext.imageSmoothingEnabled, false,
+                    'Disabling smoothing applies to the sketch context as well.');
+
+                // resizing a canvas resets its 2d context state, so the rotation-triggered
+                // resize of the sketch canvas must re-apply the setting
+                viewer.viewport.setRotation(30, true);
+                assert.equal(drawer.sketchContext.imageSmoothingEnabled, false,
+                    'Resizing the sketch canvas on rotation preserves the smoothing setting.');
+
+                drawer.setImageSmoothingEnabled(true);
+                assert.equal(drawer.context.imageSmoothingEnabled, true,
+                    'Enabling smoothing applies to the main context.');
+                assert.equal(drawer.sketchContext.imageSmoothingEnabled, true,
+                    'Enabling smoothing applies to the sketch context as well.');
+
+                done();
+            });
+        });
+
+        // ----------
         QUnit.test('deprecations', function(assert) {
             const done = assert.async();
 

--- a/test/modules/tilecache.js
+++ b/test/modules/tilecache.js
@@ -315,6 +315,79 @@
     });
 
     // ----------
+    QUnit.test('clear', function (assert) {
+        const done = assert.async();
+        const fakeViewer = MockSeadragon.getViewer(
+            MockSeadragon.getDrawer({
+                getSupportedDataFormats() {
+                    return [T_A, T_B, T_C, T_D, T_E];
+                }
+            })
+        );
+        const fakeTiledImage = MockSeadragon.getTiledImage(fakeViewer);
+
+        const tileA = MockSeadragon.getTile('a.jpg', fakeTiledImage);
+        const tileB = MockSeadragon.getTile('b.jpg', fakeTiledImage);
+        const zombieTile = MockSeadragon.getTile('zombie.jpg', fakeTiledImage);
+        const orphanTile = MockSeadragon.getTile('orphan.jpg', fakeTiledImage);
+
+        const cache = new OpenSeadragon.TileCache();
+
+        // cache size must be increased only after caching: the tile is registered in _tilesLoaded
+        // only while it still reports no caches
+        const cacheFor = (tile, data, dataType) => {
+            tile._caches[tile.cacheKey] = cache.cacheTile({
+                tile: tile,
+                tiledImage: fakeTiledImage,
+                data: data,
+                dataType: dataType
+            });
+            tile._cacheSize++;
+        };
+
+        // two ordinary records, each reachable through its tile
+        cacheFor(tileA, 1, T_A);
+        cacheFor(tileB, 2, T_B);
+
+        // a zombie: its only tile released it without destroying the record
+        cacheFor(zombieTile, 3, T_C);
+        cache.unloadCacheForTile(zombieTile, zombieTile.cacheKey, false, false);
+        delete zombieTile._caches[zombieTile.cacheKey];
+
+        // an orphan: a record still listed in _cachesLoaded that no tile points at anymore, so the
+        // tile loop cannot reach it and only the _cachesLoaded sweep can free its data
+        cacheFor(orphanTile, 4, T_D);
+        const orphanRecord = orphanTile._caches[orphanTile.cacheKey];
+        orphanRecord.removeTile(orphanTile);
+        delete orphanTile._caches[orphanTile.cacheKey];
+
+        assert.equal(cache.numTilesLoaded(), 4, 'four tiles registered');
+        assert.equal(cache.numCachesLoaded(), 4, 'three records plus one zombie');
+
+        let unloadedTiles = 0;
+        fakeViewer.addHandler('tile-unloaded', () => unloadedTiles++);
+
+        cache.clear();
+
+        // A for..in over _tilesLoaded hands out index strings instead of tiles, so no tile is touched:
+        // the records get freed by the _cachesLoaded sweep, but the tiles keep their data references.
+        assert.equal(unloadedTiles, 4, 'every registered tile was unloaded');
+        assert.equal(tileA.loaded, false, 'tile was marked as unloaded');
+        assert.equal(tileA.tiledImage, null, 'tile released its tiled image');
+        assert.equal(Object.keys(tileA._caches).length, 0, 'tile released its cache references');
+
+        assert.equal(destroyA, 1, 'ordinary record destroyed exactly once');
+        assert.equal(destroyB, 1, 'second ordinary record destroyed exactly once');
+        assert.equal(destroyC, 1, 'zombie record destroyed exactly once');
+        assert.equal(destroyD, 1, 'orphan record destroyed exactly once');
+
+        assert.equal(cache.numTilesLoaded(), 0, 'no tiles left');
+        assert.equal(cache.numCachesLoaded(), 0, 'no records left');
+
+        done();
+    });
+
+    // ----------
     QUnit.test('maxImageCacheCount', function (assert) {
         const done = assert.async();
         const fakeViewer = MockSeadragon.getViewer(

--- a/test/modules/tiledimage.js
+++ b/test/modules/tiledimage.js
@@ -347,6 +347,34 @@
     });
 
     // ----------
+    QUnit.test('level opacity ramp', function(assert) {
+        // Pure function of minPixelRatio: call it directly rather than driving a viewer to a scale.
+        const opacityAt = (minPixelRatio, renderPixelRatio) =>
+            OpenSeadragon.TiledImage.prototype._getLevelOpacity.call(
+                { minPixelRatio: minPixelRatio }, renderPixelRatio);
+
+        // Default ratio: the ramp spans [minPixelRatio, 2 * minPixelRatio), which is the range level
+        // selection actually draws a level at.
+        assert.strictEqual(opacityAt(0.5, 0.5), 0, 'default: transparent at minPixelRatio');
+        assert.strictEqual(opacityAt(0.5, 0.75), 0.5, 'default: half way up the ramp');
+        assert.strictEqual(opacityAt(0.5, 1), 1, 'default: opaque at twice minPixelRatio');
+        assert.strictEqual(opacityAt(0.5, 2), 1, 'default: clamped above the ramp');
+        assert.strictEqual(opacityAt(0.5, 0.25), 0,
+            'default: clamped below the ramp, where the minimum level bypasses the selection gate');
+
+        // A non-default minPixelRatio must move the ramp with it: a hard-coded 0.5 would report 0.41
+        // instead of 0 at minRatio here, and reach full opacity before the level is done fading in.
+        const minRatio = 1 / Math.SQRT2;
+        assert.strictEqual(opacityAt(minRatio, minRatio), 0, 'custom: transparent at minPixelRatio');
+        assert.strictEqual(opacityAt(minRatio, 1.5 * minRatio), 0.5, 'custom: half way up the ramp');
+        assert.strictEqual(opacityAt(minRatio, 2 * minRatio), 1, 'custom: opaque at twice minPixelRatio');
+
+        // No ramp without a positive ratio - the division would be meaningless.
+        assert.strictEqual(opacityAt(0, 0), 1, 'zero minPixelRatio disables the ramp');
+        assert.strictEqual(opacityAt(-1, 0.5), 1, 'negative minPixelRatio disables the ramp');
+    });
+
+    // ----------
     QUnit.test('rotation', function(assert) {
         const done = assert.async();
         function testDefaultRotation() {

--- a/test/modules/type-conversion.js
+++ b/test/modules/type-conversion.js
@@ -151,10 +151,9 @@
             test.equal(typeof context, typeof context2, "Type of copies equals.");
             test.equal(context.canvas.toDataURL(), context2.canvas.toDataURL(), "Data is equal.");
 
-            //copy image
+            //copy image: an Image has no API to write pixels into it, so the copy is the original
             const image2 = await Converter.copy({}, image, "image");
-            test.notEqual(image, image2, "Copy is not the same as original image.");
-            test.equal(typeof image, typeof image2, "Type of copies equals.");
+            test.equal(image, image2, "Copy of an image is the original, images are immutable.");
             test.equal(image.src, image2.src, "Data is equal.");
 
             done();
@@ -399,6 +398,82 @@
 
         const test2 = await compareImages(image1, image3);
         test.ok(test2.passed, "Images 1-3 are equal.");
+        done();
+    });
+
+    QUnit.test('Conversion failures reject instead of resolving or hanging', async function (test) {
+        const done = test.async();
+
+        // A conversion that cannot be routed must NOT reject: a missing path is a static property of the
+        // conversion graph, so rejecting would report it per tile and take each of those tiles down for
+        // good. It reports the problem and resolves with nothing, leaving the caller its existing data.
+        let noPathRejected = false;
+        let noPathResult = "not resolved";
+        try {
+            noPathResult = await Converter.convert({}, "whatever", "__TEST__url", "context2d");
+        } catch (e) {
+            noPathRejected = true;
+        }
+        test.notOk(noPathRejected, "Conversion without a known path does not reject.");
+        test.equal(noPathResult, undefined, "Conversion without a known path resolves with nothing.");
+
+        // Copying a closed ImageBitmap used to leave the promise pending forever: the copy went through
+        // createImageBitmap() without a rejection handler, and a closed bitmap reports zero dimensions.
+        const imageUrl = "data/A.png";
+        const bitmap = await Converter.convert({}, imageUrl, "__private__imageUrl", "imageBitmap");
+        const bitmapCopy = await Converter.copy({}, bitmap, "imageBitmap");
+        test.notEqual(bitmap, bitmapCopy, "Copy of an ImageBitmap is a new object.");
+        test.equal(bitmapCopy.width, bitmap.width, "Copy of an ImageBitmap keeps its width.");
+        test.equal(bitmapCopy.height, bitmap.height, "Copy of an ImageBitmap keeps its height.");
+
+        // The copy must be independent of the original: closing one must not close the other.
+        bitmap.close();
+        test.equal(bitmapCopy.width > 0, true, "Copy survives closing the original.");
+
+        let closedRejected = false;
+        await Promise.race([
+            Converter.copy({}, bitmap, "imageBitmap").catch(() => {
+                closedRejected = true;
+            }),
+            new Promise(resolve => setTimeout(resolve, 2000))
+        ]);
+        test.ok(closedRejected, "Copy of a closed ImageBitmap rejects rather than never settling.");
+        bitmapCopy.close();
+
+        // toBlob() reports failure by passing null, which used to be resolved as if it were valid data.
+        const canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 1;
+        const context = canvas.getContext('2d');
+        const originalToBlob = canvas.toBlob;
+        canvas.toBlob = function (callback) {
+            callback(null);
+        };
+        let toBlobRejected = false;
+        try {
+            await Converter.convert({}, context, "context2d", "rasterBlob");
+        } catch (e) {
+            toBlobRejected = true;
+        }
+        canvas.toBlob = originalToBlob;
+        test.ok(toBlobRejected, "Failing canvas.toBlob() rejects rather than resolving with null.");
+
+        done();
+    });
+
+    QUnit.test('Copy of an image never re-decodes or re-downloads', async function (test) {
+        const done = test.async();
+
+        const response = await fetch("data/A.png");
+        const blob = await response.blob();
+        const image = await Converter.convert({}, blob, "rasterBlob", "image");
+        test.ok(image.naturalWidth > 0, "Blob decoded into a usable image.");
+
+        // The object URL is revoked once the image has decoded, so a copy going through image.src would
+        // have nothing to load from. It does not need to: copying an image hands back the same element.
+        const copy = await Converter.copy({}, image, "image");
+        test.equal(copy, image, "Copy of a blob-backed image is the original element.");
+        test.ok(copy.naturalWidth > 0, "Copy is still usable after the object URL was revoked.");
+
         done();
     });
 


### PR DESCRIPTION
Fixes:
 - canvas drawer did not properly update image smoothing
 - data type converter - missing destructors, fix copy convertors (image is immutable), robustness
 - tile cache - clear properly track zombies + loaded caches, typo fixes 
 - tiled image - levelOpacity driven by `minPixelRatio`
 - webgl drawer - proper updates of texture samplings
 - html drawer now accepts canvas (problem was that cloneNode does not carry over pixels)