### PR TITLE
fix: `IIIFTileSource` throws on an empty sizes array

### DIFF
--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -165,7 +165,7 @@ $.IIIFTileSource = function( options ){
     }
 
     // Create an array with precise resolution sizes if these have been supplied through the 'sizes' object
-    if( this.sizes ) {
+    if( this.sizes && this.sizes.length > 0 ) {
         let sizeLength = this.sizes.length;
 
         // Create a copy of the sizes list and sort in ascending order

--- a/test/modules/iiif.js
+++ b/test/modules/iiif.js
@@ -96,6 +96,14 @@
             "height": 1000,
             "profile": ["http://iiif.io/api/image/2/level1.json"]
         },
+        infoJson2level1EmptySizes = {
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "@id": id,
+            "width": 2000,
+            "height": 1000,
+            "sizes": [],
+            "profile": ["http://iiif.io/api/image/2/level1.json"]
+        },
         infoJson3level0 = {
             "@context": "http://iiif.io/api/image/3/context.json",
             "id": id,
@@ -286,6 +294,19 @@
         assert.equal(source3DescendingSizeOrder.getTileUrl(0, 0, 0), "http://example.com/identifier/full/500,250/0/default.jpg");
         assert.equal(source3DescendingSizeOrder.getTileUrl(1, 1, 0), "http://example.com/identifier/1024,0,976,1000/488,500/0/default.jpg");
         assert.equal(source3DescendingSizeOrder.getTileUrl(2, 0, 0), "http://example.com/identifier/0,0,512,512/512,512/0/default.jpg");
+    });
+
+    QUnit.test('IIIFTileSource ignores an empty sizes array', function( assert ) {
+        const source = getSource(infoJson2level1EmptySizes);
+        const reference = getSource(infoJson2level1);
+
+        assert.equal(source.levelSizes, undefined, 'No resolution levels are derived from an empty sizes array');
+        assert.notOk(source.emulateLegacyImagePyramid, 'An empty sizes array does not trigger a legacy pyramid');
+        assert.equal(source.maxLevel, reference.maxLevel, 'Max level matches a source with no sizes array');
+        assert.equal(source.getTileWidth(source.maxLevel), reference.getTileWidth(reference.maxLevel),
+            'Tile width matches a source with no sizes array');
+        assert.equal(source.getTileUrl(8, 0, 0), reference.getTileUrl(8, 0, 0),
+            'Tile URLs match a source with no sizes array');
     });
 
     QUnit.test('IIIFTileSource.getTileUrl honours tileQuality option', function( assert ) {


### PR DESCRIPTION
Resolves #2962.

---

An info.json with `"sizes": []` crashes the `IIIFTileSource` constructor, so the image never opens even when `width`, `height` and the profile are enough to tile it normally.

The branch that builds the legacy pyramid already tests the length:

```js
} else if (this.sizes && this.sizes.length > 0) {
```

but the block that derives `levelSizes` only tests the property, then indexes straight into the sorted copy:

```js
if( this.sizes ) {
    let sizeLength = this.sizes.length;
    const sortedSizes = this.sizes.slice().sort(( size1, size2 ) => size1.width - size2.width);
    if( sortedSizes[sizeLength - 1].width < this.width && ...
```

With an empty array `sizeLength` is 0, `sortedSizes[-1]` is `undefined`, and reading `.width` throws `TypeError: Cannot read properties of undefined (reading 'width')`. This applies the same length test to that block.

### Where it came up

A level 2 IIIF v2 service that reports its dimensions and then an empty sizes array:

https://iiif-server.lib.uchicago.edu/ark:61001/b2bv0rp5j298/00000001/info.json

Both Clover IIIF and Universal Viewer fail to open it, since both hand the info.json straight to `IIIFTileSource`.

### Affected versions

Checked each release build against the same info.json:

| Version | Result |
| --- | --- |
| 5.0.1 | tiles fine |
| 6.0.0 | throws |
| 6.0.2 | throws |
| 6.1.0 | throws |
| this branch | tiles fine, matches 5.0.1 |

5.0.1 was safe because the block compared `sizes.length` against `maxLevel` before indexing, so an empty array fell through. The indexing form arrived in ae500afb ("Refactored code related to the use of the 'sizes' array", part of #2710), first released in 6.0.0.

### Test

Added `IIIFTileSource ignores an empty sizes array` to `test/modules/iiif.js`, with an `infoJson2level1EmptySizes` fixture alongside the existing v2 ones.