### PR TITLE
Fix Object URL leak in rasterBlob to image conversion (fixes #2964)

### DIFF
--- a/src/datatypeconverter.js
+++ b/src/datatypeconverter.js
@@ -371,12 +371,11 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
             const img = new Image();
             img.onerror = img.onabort = e => {
                 // eslint-disable-next-line compat/compat
-                (window.URL || window.webkitURL).revokeObjectURL(blob);
+                (window.URL || window.webkitURL).revokeObjectURL(url);
                 reject(e);
             };
             img.onload = () => {
-                // eslint-disable-next-line compat/compat
-                (window.URL || window.webkitURL).revokeObjectURL(blob);
+                img.__osdObjectUrl = url;
                 resolve(img);
             };
             img.decoding = 'async';
@@ -458,6 +457,16 @@ OpenSeadragon.DataTypeConverter = class DataTypeConverter {
         this.learnDestroy("context2d", ctx => {
             ctx.canvas.width = 0;
             ctx.canvas.height = 0;
+        });
+        /**
+         * Free up image object URL if this image was created from a Blob URL.
+         */
+        this.learnDestroy("image", img => {
+            if (img && img.__osdObjectUrl) {
+                // eslint-disable-next-line compat/compat
+                (window.URL || window.webkitURL).revokeObjectURL(img.__osdObjectUrl);
+                delete img.__osdObjectUrl;
+            }
         });
     }
 

--- a/test/modules/type-conversion.js
+++ b/test/modules/type-conversion.js
@@ -440,4 +440,50 @@
 
         return { passed, diffPct, rmse, width: w, height: h };
     }
+
+    QUnit.test('rasterBlob -> image lifecycle: copy then destroy original revokes object URL', async function (test) {
+        const done = test.async();
+
+        const base64Png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+        const byteCharacters = atob(base64Png);
+        const byteNumbers = new Array(byteCharacters.length);
+        for (let i = 0; i < byteCharacters.length; i++) {
+            byteNumbers[i] = byteCharacters.charCodeAt(i);
+        }
+        const byteArray = new Uint8Array(byteNumbers);
+        const blob = new Blob([byteArray], { type: "image/png" });
+
+        // 1. Convert rasterBlob -> image
+        const img = await OpenSeadragon.converter.convert({}, blob, "rasterBlob", "image");
+        test.ok(img instanceof HTMLImageElement, "Converted to HTMLImageElement.");
+        test.ok(img.__osdObjectUrl, "Object URL stashed on image as __osdObjectUrl.");
+        const stashedUrl = img.__osdObjectUrl;
+        test.ok(stashedUrl.startsWith("blob:"), "Stashed URL is a blob URL.");
+
+        // Verify the object URL is fetchable before destroy
+        const fetchBefore = await fetch(stashedUrl);
+        test.ok(fetchBefore.ok, "Object URL is live and fetchable prior to destroy.");
+
+        // 2. Copy the image ("image" -> "image")
+        const imgCopy = await OpenSeadragon.converter.copy({}, img, "image");
+        test.ok(imgCopy instanceof HTMLImageElement, "Image copy succeeded.");
+        test.equal(imgCopy.src, img.src, "Image copy shares the same src URL.");
+
+        // 3. Destroy the original image
+        await OpenSeadragon.converter.destroy(img, "image");
+        test.equal(img.__osdObjectUrl, undefined, "__osdObjectUrl cleared after destroy.");
+
+        // 4. Verify the copy is still functional and has dimensions
+        test.ok(imgCopy.naturalWidth > 0, "Copied image retains valid dimensions.");
+
+        // 5. Verify the object URL was actually revoked by checking that fetching it now fails
+        try {
+            await fetch(stashedUrl);
+            test.ok(false, "Fetch of revoked object URL should have failed.");
+        } catch (err) {
+            test.ok(true, "Fetch of revoked object URL threw network error as expected.");
+        }
+
+        done();
+    });
 })();


### PR DESCRIPTION
## Fixes #2964

`revokeObjectURL` was being called with the `Blob` object instead of the object URL
string it returned, in the `rasterBlob -> image` converter
(`src/datatypeconverter.js`). This made every revoke call a silent no-op, leaking
one object URL per AJAX-loaded tile whenever `loadTilesWithAjax: true` is used.

### Why not just swap `blob` for `url`?

A same-line fix (revoking on `img.onload`) breaks two things that still rely on
`img.src` being a valid, live blob URL after load:
- the `"image" -> "image"` copy conversion, which re-derives a new `Image` from
  `image.src`
- `HTMLDrawer`'s tile preparation, which clones the image node via `cloneNode()`

### The fix

Defers the revoke to when the `"image"` data is actually destroyed (cache
eviction), instead of revoking eagerly on load — matching the existing destructor
pattern already used for `context2d` cleanup in this file:

- `onload` now stashes the created object URL on the image
  (`img.__osdObjectUrl = url`) instead of revoking it immediately.
- A new `this.learnDestroy("image", ...)` revokes that URL when
  `converter.destroy()` is called on the image data, which `TileCache` already
  does on tile eviction / cache clear (traced: `CacheRecord.destroy` ->
  `_destroySelfUnsafe` -> `converter.destroy(data, "image")`).
- `onerror`/`onabort` still revokes immediately and correctly (`revokeObjectURL(url)`,
  not `blob`) — a failed load never produces an image anything downstream will
  reference, so there's no need to defer there.
- The destructor is a no-op for images that never had a blob URL (e.g. plain
  network-loaded images), since it checks for `__osdObjectUrl` before revoking.

### Testing

Added a unit test in `test/modules/type-conversion.js` covering the actual
lifecycle this fix is meant to preserve, not just "does it run without throwing":
1. Convert a `rasterBlob` to `image`, confirm the object URL is live and fetchable.
2. Copy the image (`"image" -> "image"`), confirm the copy still works.
3. Destroy the original image, confirm `__osdObjectUrl` is cleared.
4. Confirm the copy is still valid after the original is destroyed.
5. Confirm the object URL is genuinely unfetchable after destroy (not just that no
   error was thrown).

Verified this test is meaningful via mutation testing — it fails if the stash
(`img.__osdObjectUrl = url`) is removed, and separately fails if the
`learnDestroy` block is removed, so it actually exercises both halves of the fix.

Full suite: `391/391` passing locally. `npm run bundlesize` shows a negligible
delta (+0.03kB uncompressed / +0.01kB gzip), well within configured limits.

**Note:** the full suite occasionally shows transient failures in the `navigator`
module (5 tests) when run back-to-back in a single headless Chrome process. This
reproduces identically on unmodified `master` and is unrelated to this change —
looks like WebGL context accumulation under continuous test load, not something
introduced here.

### Known limitation (not a regression)

If application/plugin code copies an AJAX-backed `"image"` and *then* the original
tile is evicted, a later attempt to copy that copy again would fail, since the
copy's `.src` still points to the (by-then-revoked) blob URL. This isn't new
behavior — nothing today revokes the URL at all — and OpenSeadragon's own internal
conversion chains destroy intermediates synchronously mid-pipeline, before eviction
is a factor, so this shouldn't be reachable in normal use. Flagging it in case it
matters for a plugin pattern I'm not aware of.

### Out of scope

Two adjacent leaks I noticed while tracing this are left out of this PR since
they're unrelated call sites with different fixes:
- An unrevoked object URL for the singleton worker script blob in `getIBWorker()`
  (one-time per page session).
- No `ImageBitmap.close()` destructor registered for the `imageBitmap` type on
  eviction.

Happy to file separate issues for those, or fold them in here if you'd rather keep
it as one PR — let me know which you'd prefer.