### PR TITLE
Fix ImageBitmap worker script Object URL leak (fixes #2969)

### DIFF
--- a/src/datatypeconverter.js
+++ b/src/datatypeconverter.js
@@ -196,6 +196,8 @@ self.onmessage = async (e) => {
     // eslint-disable-next-line compat/compat
     const url = URL.createObjectURL(new Blob([code], { type: 'text/javascript' }));
     _imageConversionWorker = new Worker(url);
+    // eslint-disable-next-line compat/compat
+    URL.revokeObjectURL(url);
 
     _imageConversionWorker.onmessage = (e) => {
         const { id, ok, bmp, err } = e.data || {};


### PR DESCRIPTION
Fixes #2969

`getIBWorker()`'s singleton worker was constructed from an object URL that
was never revoked. Since `new Worker(url)` reads the script synchronously at
construction, the URL is safe to revoke immediately after.

One-time leak per page session (the worker is a strict singleton via the
early-return guard), not per-tile — low severity, but a real leak.

No regression test added: once constructed, a Worker exposes no way to
introspect or assert against its originating object URL, so there's no
observable hook to test against post-construction.

Full suite: 390/390 passing. Bundle size delta negligible (+30 bytes
unminified, no measurable change after minification/gzip).