### PR TITLE
Expose HTTP status in open-failed events

### DIFF
--- a/src/iiptilesource.js
+++ b/src/iiptilesource.js
@@ -190,7 +190,11 @@
         error: function ( xhr, exc ) {
           const msg = "IIPTileSource: Unable to get IIP metadata from " + url;
           $.console.error( msg );
-          _this.raiseEvent( 'open-failed', { message: msg, source: url });
+          _this.raiseEvent( 'open-failed', {
+            message: msg,
+            source: url,
+            status: xhr.status
+          });
         }
       });
     },

--- a/src/iristilesource.js
+++ b/src/iristilesource.js
@@ -157,7 +157,11 @@
         error: function(xhr, exc) {
           const msg = "IrisTileSource: Unable to get metadata from " + url;
           $.console.error(msg);
-          _this.raiseEvent('open-failed', { message: msg, source: url });
+          _this.raiseEvent('open-failed', {
+            message: msg,
+            source: url,
+            status: xhr.status
+          });
         }
       });
     },

--- a/src/tilesource.js
+++ b/src/tilesource.js
@@ -539,6 +539,7 @@ $.TileSource.prototype = {
                 },
                 error: function ( xhr, exc ) {
                     let msg;
+                    let status;
 
                     /*
                         IE < 10 will block XHR requests to different origins. Any property access on the request
@@ -546,7 +547,8 @@ $.TileSource.prototype = {
                         exception rather than the second one raised when we try to access xhr.status
                      */
                     try {
-                        msg = "HTTP " + xhr.status + " attempting to load TileSource: " + url;
+                        status = xhr.status;
+                        msg = "HTTP " + status + " attempting to load TileSource: " + url;
                     } catch ( e ) {
                         let formattedExc;
                         if ( typeof ( exc ) === "undefined" || !exc.toString ) {
@@ -571,12 +573,14 @@ $.TileSource.prototype = {
                      * @property {String} source
                      * @property {String} postData - HTTP POST data (usually but not necessarily in k=v&k2=v2... form,
                      *      see TileSource::getTilePostData) or null
+                     * @property {?Number} status - HTTP status code, if available.
                      * @property {?Object} userData - Arbitrary subscriber-defined object.
                      */
                     _this.raiseEvent( 'open-failed', {
                         message: msg,
                         source: url,
-                        postData: postData
+                        postData: postData,
+                        status: status
                     });
                 }
             });

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2134,7 +2134,8 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                     tileSource.addHandler('open-failed', function (event) {
                         reject({
                             message: event.message,
-                            source: originalTileSource
+                            source: originalTileSource,
+                            status: event.status,
                         });
                     });
                 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -868,6 +868,7 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
                      * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
                      * @property {String} message - Information about what failed.
                      * @property {String} source - The tile source that failed.
+                     * @property {?Number} status - HTTP status code, if available.
                      * @property {?Object} userData - Arbitrary subscriber-defined object.
                      */
                     _this.raiseEvent( 'open-failed', failEvent );

--- a/test/modules/basic.js
+++ b/test/modules/basic.js
@@ -56,6 +56,8 @@
         viewer.addHandler('open-failed', function(event) {
             assert.ok(true, "The open-failed event should be fired when the source 404s");
 
+            assert.equal(event.status, 404, "The open-failed event should expose the HTTP status");
+
             assert.equal($(".openseadragon-message").length, 1, "Open failures should display a message");
 
             assert.ok(testLog.error.contains('["HTTP 404 attempting to load TileSource: /test/data/not-a-real-file"]'),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2256,6 +2256,7 @@ declare namespace OpenSeadragon {
         message: string;
         source: string;
         postData?: string;
+        status?: number;
     }
 
     interface ReadyTileSourceEvent extends TileSourceEvent {
@@ -2477,6 +2478,7 @@ declare namespace OpenSeadragon {
 
     interface OpenFailedEvent extends OpenEvent {
         message: string;
+        status?: number;
     }
 
     interface PageEvent extends ViewerEvent {


### PR DESCRIPTION
## Summary

Expose the HTTP status code in `open-failed` events when it is available.

## Changes

- Add the HTTP status to TileSource `open-failed` events.
- Propagate the status to Viewer `open-failed` events.
- Add a test verifying that a 404 response exposes `event.status`.
- Update the TypeScript definitions for both events.

## Testing

- `npx grunt test --module=basic`
- Full test suite: 390 tests passed
- TypeScript definition checks passed

Fixes #2541