### PR TITLE
test: add regression coverage for ImageBitmap destroy-on-eviction (fixes #2970)

### DIFF
--- a/test/modules/type-conversion.js
+++ b/test/modules/type-conversion.js
@@ -515,4 +515,52 @@
 
         return { passed, diffPct, rmse, width: w, height: h };
     }
+
+    QUnit.test('imageBitmap lifecycle: destroy closes bitmap and zero-dimensions it, copies are independent', async function (test) {
+        const done = test.async();
+
+        if (typeof createImageBitmap === 'undefined') {
+            test.expect(0);
+            done();
+            return;
+        }
+
+        const base64Png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+        const byteCharacters = atob(base64Png);
+        const byteNumbers = new Array(byteCharacters.length);
+        for (let i = 0; i < byteCharacters.length; i++) {
+            byteNumbers[i] = byteCharacters.charCodeAt(i);
+        }
+        const byteArray = new Uint8Array(byteNumbers);
+        const blob = new Blob([byteArray], { type: "image/png" });
+
+        // 1. Convert rasterBlob -> imageBitmap
+        const bmp = await OpenSeadragon.converter.convert({}, blob, "rasterBlob", "imageBitmap");
+        test.ok(bmp instanceof ImageBitmap, "Got ImageBitmap instance from conversion.");
+        test.equal(bmp.width, 1, "ImageBitmap width is positive before destroy.");
+        test.equal(bmp.height, 1, "ImageBitmap height is positive before destroy.");
+
+        // 2. Copy the ImageBitmap
+        const bmpCopy = await OpenSeadragon.converter.copy({}, bmp, "imageBitmap");
+        test.ok(bmpCopy instanceof ImageBitmap, "Copy returned an ImageBitmap instance.");
+        test.notEqual(bmp, bmpCopy, "Copy is an independent instance.");
+        test.equal(bmpCopy.width, 1, "Copied ImageBitmap width is valid.");
+        test.equal(bmpCopy.height, 1, "Copied ImageBitmap height is valid.");
+
+        // 3. Destroy original ImageBitmap
+        await OpenSeadragon.converter.destroy(bmp, "imageBitmap");
+        test.equal(bmp.width, 0, "Original ImageBitmap width is 0 after destroy (bmp.close() called).");
+        test.equal(bmp.height, 0, "Original ImageBitmap height is 0 after destroy (bmp.close() called).");
+
+        // 4. Verify the copy remains open and independent
+        test.equal(bmpCopy.width, 1, "Copied ImageBitmap width remains 1 after original was destroyed.");
+        test.equal(bmpCopy.height, 1, "Copied ImageBitmap height remains 1 after original was destroyed.");
+
+        // 5. Destroy the copy
+        await OpenSeadragon.converter.destroy(bmpCopy, "imageBitmap");
+        test.equal(bmpCopy.width, 0, "Copied ImageBitmap width is 0 after destroy (bmp.close() called).");
+        test.equal(bmpCopy.height, 0, "Copied ImageBitmap height is 0 after destroy (bmp.close() called).");
+
+        done();
+    });
 })();


### PR DESCRIPTION
## Fixes #2970

`ImageBitmap` objects created by the converter graph (`src/datatypeconverter.js`) were removed from the tile cache on eviction via `$.converter.destroy(data, type)`, but no destructor was registered for the `"imageBitmap"` type, so native/GPU memory relied on GC timing instead of being released deterministically.

The `learnDestroy("imageBitmap", ...)` fix has already landed on `master` (closing a bitmap on destroy, guarded by a `typeof bmp.close === 'function'` check, mirroring the existing `learnDestroy("context2d", ...)` pattern). This PR adds the regression test coverage for it that wasn't included with that fix.

### What the test verifies

Added `imageBitmap lifecycle: destroy closes bitmap and zero-dimensions it, copies are independent` to `test/modules/type-conversion.js`:

1. Converts a `rasterBlob` to `imageBitmap`, confirms it's live (non-zero
   dimensions).
2. Copies the bitmap (`"imageBitmap" -> "imageBitmap"`), confirms the copy is
   a distinct, independently valid instance.
3. Destroys the original via `converter.destroy(bmp, "imageBitmap")`, asserts
   `width`/`height` become `0` — the spec-guaranteed signature of a closed
   `ImageBitmap`, and a directly observable proof that `.close()` actually ran
   (not just that no error was thrown).
4. Confirms the copy remains valid and independently usable after the
   original is destroyed — this is the check that would catch a
   shared-reference bug, if the copy path ever stopped producing an
   independent handle.
5. Destroys the copy, confirms it also closes correctly.

### Verification

Mutation-tested: temporarily removed the `learnDestroy("imageBitmap", ...)` block and confirmed this test fails (`width` stays `1` instead of dropping to `0`). Restored and confirmed it passes.

Full suite passing locally. No `src/` changes in this PR — test-only, since the fix itself is already on `master`.